### PR TITLE
Add long_description, to indicate detailed description of the package.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,14 @@
 from setuptools import setup, find_packages
 
 
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
 setup(
     name="smarts",
     description="Scalable Multi-Agent RL Training School",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     version="0.4.1",
     packages=find_packages(exclude="tests"),
     include_package_data=True,


### PR DESCRIPTION
According to the [package user guide](https://packaging.python.org/tutorials/packaging-projects/#creating-setup-py), need to specify `long_description` in setup.py. The detailed description will be shown on the package detail.