### PR TITLE
Remove assertion to fix traffic light states and links mapping

### DIFF
--- a/smarts/core/sumo_traffic_simulation.py
+++ b/smarts/core/sumo_traffic_simulation.py
@@ -574,16 +574,13 @@ class SumoTrafficSimulation:
 
         sub_results = self._traci_conn.trafficlight.getSubscriptionResults(None)
 
-        if not sub_results:
-            return {}
-
         tlss = []
+        if not sub_results:
+            return tlss
+
         for tls_id in sub_results:
             light_states = sub_results[tls_id][tc.TL_RED_YELLOW_GREEN_STATE]
             links = sub_results[tls_id][tc.TL_CONTROLLED_LINKS]
-            assert len(links) == len(
-                light_states
-            ), "TLS light states must be 1:1 with links"
 
             traffic_lights = []
             for link, state in zip(links, light_states):


### PR DESCRIPTION
[SUMO Signal state definitions](https://sumo.dlr.de/docs/Simulation/Traffic_Lights.html#signal_state_definitions)

The traffic light subscription results contain the information about which link is controlled by which traffic light signal. However, the length of the traffic light states is always the same, which is the max length of links. 

For example, if one of the junctions has at most 6 links, the traffic lights are always "GGGGGG" (green light), even for the junctions only has 1 link. We should remove such an assumption here.