### PR TITLE
Fix data replay: re-order params to pass the correct timestep to client

### DIFF
--- a/cli/envision.py
+++ b/cli/envision.py
@@ -17,10 +17,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-import socketserver
-from functools import partial
-from http.server import SimpleHTTPRequestHandler
-
 import click
 
 from envision.server import run

--- a/envision/client.py
+++ b/envision/client.py
@@ -120,9 +120,9 @@ class Client:
     def read_and_send(
         path: str,
         endpoint: str = "ws://localhost:8081",
+        timestep_sec: float = 0.1,
         num_retries: int = 5,
         wait_between_retries: float = 0.5,
-        timestep_sec: float = 0.1,
     ):
         client = Client(
             endpoint=endpoint,


### PR DESCRIPTION
cli/studio.py
```
with multiprocessing.pool.ThreadPool(len(jsonl_paths)) as pool:
    pool.starmap(
        Envision.read_and_send,
        [(jsonl, endpoint, timestep) for jsonl in jsonl_paths],
    )
```
In the past, a tuple - (path, endpoint, timestep) - of arguments are being sent to `read_and_send`, after introducing `num_retries` and `wait_between_retries`, which were placed before `timestep`, resulted in `num_retries` being set to `0.1`.

A more intuitive approach is to specify the names of arguments(`read_and_send(path, endpoint, timestep=timestep`), however, the second argument of `starmap` is expected to be iterables that are unpacked as arguments. So I didn't follow this approach.

close #21 