### PR TITLE
Fix leak case where scenario cycle iterator caches scenario

### DIFF
--- a/smarts/core/scenario.py
+++ b/smarts/core/scenario.py
@@ -208,10 +208,8 @@ class Scenario:
                 scenario_roots.extend(Scenario.discover_scenarios(root))
         np.random.shuffle(scenario_roots)
 
-        return cycle(
-            Scenario.variations_for_all_scenario_roots(
-                scenario_roots, agents_to_be_briefed
-            )
+        return Scenario.variations_for_all_scenario_roots(
+            cycle(scenario_roots), agents_to_be_briefed
         )
 
     @staticmethod


### PR DESCRIPTION
Python docs describes how the cycle iterator caches iterations to be reused once the base iterations have exausted: https://docs.python.org/3.7/library/itertools.html#itertools.cycle

For us, this meant that the scenario objects were being cached and that is a problem when given an unbounded number of scenarios.