### PR TITLE
Issue 68: ogm/drivable area are blank in the first few steps of agents

### DIFF
--- a/smarts/core/sensors.py
+++ b/smarts/core/sensors.py
@@ -497,7 +497,9 @@ class CameraSensor(Sensor):
         fb_props = FrameBufferProperties()
         fb_props.setRgbColor(True)
         fb_props.setRgbaBits(8, 8, 8, 1)
-        fb_props.setDepthBits(0)
+        # XXX: Though we don't need the depth buffer returned, setting this to 0
+        #      causes undefined behaviour where the ordering of meshes is random.
+        fb_props.setDepthBits(8)
 
         buffer = self._showbase.win.engine.makeOutput(
             self._showbase.pipe,

--- a/smarts/core/smarts.py
+++ b/smarts/core/smarts.py
@@ -226,6 +226,12 @@ class SMARTS(ShowBase):
         # Agents
         self._agent_manager.step_agent_sensors(self)
 
+        # Panda3D
+        # runs through the render pipeline
+        # MUST perform this after step_agent_sensors() above, and before observe() below,
+        # so that all updates are ready before rendering happens per frame
+        self.taskMgr.mgr.poll()
+
         observations, rewards, scores, dones = self._agent_manager.observe(self)
 
         response_for_ego = self._agent_manager.filter_response_for_ego(
@@ -600,9 +606,6 @@ class SMARTS(ShowBase):
 
     def _step_providers(self, actions, dt) -> List[VehicleState]:
         accumulated_provider_state = ProviderState()
-
-        # Panda3D
-        self.taskMgr.mgr.poll()  # runs through the render pipeline
 
         def agent_controls_vehicles(agent_id):
             vehicles = self._vehicle_index.vehicles_by_actor_id(agent_id)


### PR DESCRIPTION
- Make sure the render pipeline gets run through after all updates are ready, and before grid maps are returned
Before vs. After (grey squares indicate vehicle positions from observations):
![observations](https://user-images.githubusercontent.com/57057376/97609810-73c0f800-19ea-11eb-9d54-9ba8ec2eac98.png)

- Set depth bits from 0 to 8 to avoid z-fighting in RGB grid map
Before (ego vehicle is occluded) vs. After (ego vehicle is rendered correctly after the road):
![depthbits](https://user-images.githubusercontent.com/57057376/97609986-b1258580-19ea-11eb-9972-9ec839f60449.png)