### PR TITLE
Restart sumo process only when map file hash changes

### DIFF
--- a/smarts/core/scenario.py
+++ b/smarts/core/scenario.py
@@ -41,7 +41,7 @@ from .sumo_road_network import SumoRoadNetwork
 from .waypoints import Waypoints
 from .coordinates import Heading
 from .utils.math import vec_to_radians
-from .utils.file import path2hash
+from .utils.file import path2hash, file_md5_hash
 from .utils.id import SocialAgentId
 from .route import ShortestRoute
 from smarts.sstudio import types as sstudio_types
@@ -177,6 +177,7 @@ class Scenario:
 
         self._validate_assets_exist()
         self._road_network = SumoRoadNetwork.from_file(self.net_filepath)
+        self._net_file_hash = file_md5_hash(self.net_filepath)
         self._waypoints = Waypoints(self._road_network, spacing=1.0)
         self._scenario_hash = path2hash(str(Path(self.root_filepath).resolve()))
 
@@ -634,6 +635,10 @@ class Scenario:
     @property
     def net_filepath(self):
         return os.path.join(self._root, "map.net.xml")
+
+    @property
+    def net_file_hash(self):
+        return self._net_file_hash
 
     @property
     def plane_filepath(self):

--- a/smarts/core/sumo_traffic_simulation.py
+++ b/smarts/core/sumo_traffic_simulation.py
@@ -39,6 +39,7 @@ from .provider import ProviderState, ProviderTLS, ProviderTrafficLight
 from .vehicle import VEHICLE_CONFIGS, VehicleState
 
 # We need to import .utils.sumo before we can use traci
+from .utils.file import have_same_hash
 from .utils.sumo import SUMO_PATH, sumolib, traci
 from .utils import networking
 
@@ -220,7 +221,9 @@ class SumoTrafficSimulation:
         )
 
         # restart sumo process only when map file changes
-        if self._scenario and self._scenario.net_filepath == scenario.net_filepath:
+        if self._scenario and have_same_hash(
+            self._scenario.net_filepath, scenario.net_filepath
+        ):
             restart_sumo = False
         else:
             restart_sumo = True

--- a/smarts/core/sumo_traffic_simulation.py
+++ b/smarts/core/sumo_traffic_simulation.py
@@ -39,7 +39,6 @@ from .provider import ProviderState, ProviderTLS, ProviderTrafficLight
 from .vehicle import VEHICLE_CONFIGS, VehicleState
 
 # We need to import .utils.sumo before we can use traci
-from .utils.file import have_same_hash
 from .utils.sumo import SUMO_PATH, sumolib, traci
 from .utils import networking
 
@@ -221,9 +220,7 @@ class SumoTrafficSimulation:
         )
 
         # restart sumo process only when map file changes
-        if self._scenario and have_same_hash(
-            self._scenario.net_filepath, scenario.net_filepath
-        ):
+        if self._scenario and self._scenario.net_file_hash == scenario.net_file_hash:
             restart_sumo = False
         else:
             restart_sumo = True

--- a/smarts/core/utils/file.py
+++ b/smarts/core/utils/file.py
@@ -76,12 +76,9 @@ def path2hash(file_path: str):
     return m.hexdigest()
 
 
-def have_same_hash(file_a: str, file_b: str) -> bool:
-    hasher_a = hashlib.md5()
-    hasher_b = hashlib.md5()
-    with open(file_a) as f:
-        hasher_a.update(f.read().encode())
-    with open(file_b) as f:
-        hasher_b.update(f.read().encode())
+def file_md5_hash(file_path: str) -> str:
+    hasher = hashlib.md5()
+    with open(file_path) as f:
+        hasher.update(f.read().encode())
 
-    return str(hasher_a.hexdigest()) == str(hasher_b.hexdigest())
+    return str(hasher.hexdigest())

--- a/smarts/core/utils/file.py
+++ b/smarts/core/utils/file.py
@@ -74,3 +74,14 @@ def path2hash(file_path: str):
     m = hashlib.md5()
     m.update(bytes(file_path, "utf-8"))
     return m.hexdigest()
+
+
+def have_same_hash(file_a: str, file_b: str) -> bool:
+    hasher_a = hashlib.md5()
+    hasher_b = hashlib.md5()
+    with open(file_a) as f:
+        hasher_a.update(f.read().encode())
+    with open(file_b) as f:
+        hasher_b.update(f.read().encode())
+
+    return str(hasher_a.hexdigest()) == str(hasher_b.hexdigest())


### PR DESCRIPTION
A further PR for #73.

In #105, the approach is to compare the `net_filepath`, which is bound with the scenario path. However, different scenarios can have the same maps, in this case, SUMO doesn't have to restart either, so use file hash to compare is more robust.