### PR TITLE
Add timeout to Envision client theads while waiting termination

### DIFF
--- a/envision/client.py
+++ b/envision/client.py
@@ -214,9 +214,9 @@ class Client:
         self._state_queue.put(Client.QueueDone())
         self._logging_queue.put(Client.QueueDone())
         if self._thread:
-            self._thread.join()
+            self._thread.join(timeout=3)
             self._thread = None
 
         if self._logging_thread:
-            self._logging_thread.join()
+            self._logging_thread.join(timeout=3)
             self._logging_thread = None


### PR DESCRIPTION
close #128.

@charleschen6 reported the teardown of SMARTS instance was blocked by the hanging of Envision client thread. Add timeout to `thread.join()` to force terminating the thread.

@charleschen6 If you can find out what caused the hanging, would help to improve the WebSocket connection.