### PR TITLE
Add sumo-port as an argument in example's argument parser

### DIFF
--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -22,6 +22,9 @@ def default_argument_parser(program: str):
     )
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument(
+        "--sumo-port", help="Run SUMO with a specified port.", type=int, default=None
+    )
+    parser.add_argument(
         "--episodes",
         help="The number of episodes to run the simulation for.",
         type=int,


### PR DESCRIPTION
A small requirement from Dong's team. They are using the `default_argument_parser` in the examples and needed to pass `sumo-port` to the environment. They cloned the repo to use SMARTS instead of installing it as 3rd party library from the beginning.