### PR TITLE
History provider adopts the dimensions provided by the history data

### DIFF
--- a/smarts/core/traffic_history_provider.py
+++ b/smarts/core/traffic_history_provider.py
@@ -96,8 +96,22 @@ class TrafficHistoryProvider:
                         [*vehicle_state["position"][:2], 0,],
                         Heading(vehicle_state["heading"]),
                     ),
-                    # TODO: specify dimensions
-                    dimensions=VEHICLE_CONFIGS[vehicle_type].dimensions,
+                    dimensions=BoundingBox(
+                        length=vehicle_state.get(
+                            "vehicle_length",
+                            VEHICLE_CONFIGS[vehicle_type].dimensions.length,
+                        ),
+                        width=vehicle_state.get(
+                            "vehicle_width",
+                            VEHICLE_CONFIGS[vehicle_type].dimensions.width,
+                        ),
+                        # Note: Neither NGSIM nor INTERACTION provide
+                        #       the height of the vehicles.
+                        height=vehicle_state.get(
+                            "vehicle_height",
+                            VEHICLE_CONFIGS[vehicle_type].dimensions.height,
+                        ),
+                    ),
                     speed=vehicle_state["speed"],
                     source="HISTORY",
                 )


### PR DESCRIPTION
Close #135 

In the past, the history provider uses the passenger vehicle's dimensions as the default dimensions. I left a TODO in the previous MR, at that time I was thinking to have a way to map the vehicle type and dimensions of the history data to SMARTS internal vehicle type. Turns out I was overthinking the problem, I found that the other providers (like SUMO) and observation will honor the dimensions that the history provider provides in the `VehicleState`.