### PR TITLE
Merge agent and agent policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ SMARTS (Scalable Multi-Agent RL Training School) is a simulation platform for re
 import gym
 
 from smarts.core.agent_interface import AgentInterface, AgentType
-from smarts.core.agent import AgentSpec, AgentPolicy
+from smarts.core.agent import AgentSpec, Agent
 
-class Policy(AgentPolicy):
+class SimpleAgent(Agent):
     def act(self, obs):
         return "keep_lane"
 
 agent_spec = AgentSpec(
     interface=AgentInterface.from_type(AgentType.Laner, max_episode_steps=None),
-    policy_builder=Policy,
+    agent_builder=SimpleAgent,
 )
 
 agent_specs = {

--- a/benchmark/default_model.py
+++ b/benchmark/default_model.py
@@ -1,6 +1,6 @@
 """
 This file contain default network for rllib training,
-and can be used for policy evaluation
+and can be used for agent evaluation
 """
 import pickle
 import tensorflow as tf
@@ -21,7 +21,7 @@ tf1, tf, tfv = try_import_tf()
 BASE_DIR = Path(__file__).expanduser().absolute().parent.parent
 
 
-class RLLibTFCheckpointPolicy(Agent):
+class RLLibTFCheckpointAgent(Agent):
     def __init__(self, load_path, algorithm, policy_name, yaml_path):
         load_path = str(load_path)
         if algorithm == "ppo":
@@ -141,7 +141,7 @@ class RLLibTFCheckpointPolicy(Agent):
         return action
 
 
-class RLLibTFSavedModelPolicy(Agent):
+class RLLibTFSavedModelAgent(Agent):
     def __init__(self, load_path, algorithm, policy_name, observation_space):
         load_path = str(load_path)
         self._prep = ModelCatalog.get_preprocessor_for_space(observation_space)
@@ -192,7 +192,7 @@ class RLLibTFSavedModelPolicy(Agent):
         return action
 
 
-class BatchRLLibTFCheckpointPolicy(Agent):
+class BatchRLLibTFCheckpointAgent(Agent):
     def __init__(
         self, load_path, algorithm, policy_name, observation_space, action_space
     ):
@@ -266,7 +266,7 @@ class BatchRLLibTFCheckpointPolicy(Agent):
         return actions
 
 
-class BatchRLLibTFSavedModelPolicy(Agent):
+class BatchRLLibTFSavedModelAgent(Agent):
     def __init__(self, load_path, algorithm, policy_name, observation_space):
         load_path = str(load_path)
         self._prep = ModelCatalog.get_preprocessor_for_space(observation_space)

--- a/benchmark/default_model.py
+++ b/benchmark/default_model.py
@@ -11,7 +11,7 @@ from ray.rllib.models import ModelCatalog
 from ray.rllib.utils import try_import_tf
 from ray.rllib.agents.trainer import with_common_config
 
-from smarts.core.agent import AgentPolicy
+from smarts.core.agent import Agent
 
 from benchmark.agents import load_config
 
@@ -21,7 +21,7 @@ tf1, tf, tfv = try_import_tf()
 BASE_DIR = Path(__file__).expanduser().absolute().parent.parent
 
 
-class RLLibTFCheckpointPolicy(AgentPolicy):
+class RLLibTFCheckpointPolicy(Agent):
     def __init__(self, load_path, algorithm, policy_name, yaml_path):
         load_path = str(load_path)
         if algorithm == "ppo":
@@ -141,7 +141,7 @@ class RLLibTFCheckpointPolicy(AgentPolicy):
         return action
 
 
-class RLLibTFSavedModelPolicy(AgentPolicy):
+class RLLibTFSavedModelPolicy(Agent):
     def __init__(self, load_path, algorithm, policy_name, observation_space):
         load_path = str(load_path)
         self._prep = ModelCatalog.get_preprocessor_for_space(observation_space)
@@ -192,7 +192,7 @@ class RLLibTFSavedModelPolicy(AgentPolicy):
         return action
 
 
-class BatchRLLibTFCheckpointPolicy(AgentPolicy):
+class BatchRLLibTFCheckpointPolicy(Agent):
     def __init__(
         self, load_path, algorithm, policy_name, observation_space, action_space
     ):
@@ -266,7 +266,7 @@ class BatchRLLibTFCheckpointPolicy(AgentPolicy):
         return actions
 
 
-class BatchRLLibTFSavedModelPolicy(AgentPolicy):
+class BatchRLLibTFSavedModelPolicy(Agent):
     def __init__(self, load_path, algorithm, policy_name, observation_space):
         load_path = str(load_path)
         self._prep = ModelCatalog.get_preprocessor_for_space(observation_space)

--- a/docs/minimal.py
+++ b/docs/minimal.py
@@ -1,12 +1,12 @@
 import gym
 from smarts.core.agent_interface import AgentInterface, AgentType
-from smarts.core.agent import AgentSpec, AgentPolicy
+from smarts.core.agent import AgentSpec, Agent
 
 agent_id = "Agent-007"
 agent_spec = AgentSpec(
     interface=AgentInterface.from_type(AgentType.Laner),
-    policy_params={"policy_function": lambda _: "keep_lane"},
-    policy_builder=AgentPolicy.from_function,
+    agent_params={"agent_function": lambda _: "keep_lane"},
+    agent_builder=Agent.from_function,
 )
 
 env = gym.make(

--- a/docs/minimal_agent.py
+++ b/docs/minimal_agent.py
@@ -2,11 +2,11 @@ import numpy as np
 
 from smarts.zoo.registry import register
 from smarts.core.agent_interface import AgentInterface, AgentType
-from smarts.core.agent import AgentPolicy, AgentSpec
+from smarts.core.agent import Agent, AgentSpec
 from smarts.core.controllers import ActionSpaceType
 
 
-class BasicPolicy(AgentPolicy):
+class BasicAgent(Agent):
     def act(self, obs):
         return "keep_lane"
 
@@ -15,6 +15,6 @@ register(
     locator="minimal",
     entry_point=lambda **kwargs: AgentSpec(
         interface=AgentInterface(waypoints=True, action=ActionSpaceType.Lane),
-        policy_builder=BasicPolicy,
+        agent_builder=BasicAgent,
     ),
 )

--- a/docs/sim/agent.rst
+++ b/docs/sim/agent.rst
@@ -9,8 +9,8 @@ SMARTS provides users the ability to custom their agents. :class:`smarts.core.ag
 
     class AgentSpec:
         interface: AgentInterface
-        policy_builder: Callable[..., AgentPolicy] = None
-        policy_params: Optional[Any] = None
+        agent_builder: Callable[..., Agent] = None
+        agent_params: Optional[Any] = None
         observation_adapter: Callable = default_obs_adapter
         action_adapter: Callable = default_action_adapter
         reward_adapter: Callable = default_reward_adapter
@@ -22,8 +22,7 @@ An example of how to create an `Agent` instance is shown below.
 
     AgentSpec(
         interface=AgentInterface.from_type(AgentType.Standard, max_episode_steps=500),
-        policy_params={"policy_function": lambda _: "keep_lane"},
-        policy_builder=AgentPolicy.from_function,
+        agent_builder=lambda: Agent.from_function(lambda _: "keep_lane"),
         observation_adapter=observation_adapter,
         reward_adapter=reward_adapter,
         action_adapter=action_adapter,
@@ -121,27 +120,25 @@ IMPORTANT: The generation of DrivableAreaGridMap(`drivable_area_grid_map=True`),
 IMPORTANT: Depending on how your agent model is set up, `ActionSpaceType.ActuatorDynamic` might allow the agent to learn faster than `ActionSpaceType.Continuous` simply because learning to correct steering could be simpler than learning a mapping to all the absolute steering angle values. But, again, it also depends on the design of your agent model. 
 
 ======
-Policy
+Agent
 ======
 
-A policy is a provider that takes in the observations of an agent and decides on an action.
+An agent maps an observation to an action.
 
 .. code-block:: python
 
-    # A simple policy that ignores observations
-    class IgnoreObservationsPolicy(AgentPolicy):
+    # A simple agent that ignores observations
+    class IgnoreObservationsAgent(Agent):
         def act(self, obs):
             return [throttle, brake, steering_rate]
 
-The observation passed in should be the observations that a given agent sees. In **contininuous action space** the policy is expected to pass out values for `throttle` [0->1], `brake` [0->1], and `steering_rate` [-1->1].
+The observation passed in should be the observations that a given agent sees. In **contininuous action space** the action is expected to produce values for `throttle` [0->1], `brake` [0->1], and `steering_rate` [-1->1].
 
-Otherwise, only while using **lane action space**, the policy is expected to return a laning related command: `"keep_lane"`, `"slow_down"`, `"change_lane_left"`, `"change_lane_right"`.
-
-The `Policy` is needed when we use `Agent` for evaluation. Otherwise it is not necessary for RL training.
+Otherwise, only while using **lane action space**, the agent is expected to return a lane related command: `"keep_lane"`, `"slow_down"`, `"change_lane_left"`, `"change_lane_right"`.
 
 Another example:
 
-.. literalinclude:: ../minimal_agent_policy.py
+.. literalinclude:: ../minimal_agent.py
    :language: python
 
 ===================
@@ -186,7 +183,7 @@ Likewise with the action adapter
 
 .. code-block:: python
 
-    # this comes in from the output of the Policy
+    # this comes in from the output of the Agent
     def action_adapter(model_action):
         throttle, brake, steering = model_action
         return np.array([throttle, brake, steering])

--- a/envision/tests/test_data_replay.py
+++ b/envision/tests/test_data_replay.py
@@ -85,7 +85,9 @@ def test_data_replay(agent_spec, scenarios_iterator, data_replay_path, monkeypat
 
             done = False
             while not done:
-                action = agent.act_with_adaptation(obs[AGENT_ID])
+                obs = agent_spec.observation_adapter(obs[AGENT_ID])
+                action = agent.act(obs)
+                action = agent_spec.action_adapter(action)
                 obs, _, dones, _ = smarts.step({AGENT_ID: action})
                 done = dones[AGENT_ID]
 

--- a/envision/tests/test_data_replay.py
+++ b/envision/tests/test_data_replay.py
@@ -9,7 +9,7 @@ from smarts.core.agent_interface import AgentInterface, AgentType
 from smarts.core.scenario import Scenario
 from smarts.core.smarts import SMARTS
 from smarts.core.sumo_traffic_simulation import SumoTrafficSimulation
-from smarts.core.agent import AgentSpec, AgentPolicy
+from smarts.core.agent import AgentSpec, Agent
 
 
 AGENT_ID = "Agent-007"
@@ -20,7 +20,7 @@ TIMESTEP_SEC = 0.1
 
 @pytest.fixture
 def agent_spec():
-    class Policy(AgentPolicy):
+    class KeepLaneAgent(Agent):
         def act(self, obs):
             return "keep_lane"
 
@@ -28,7 +28,7 @@ def agent_spec():
         interface=AgentInterface.from_type(
             AgentType.Laner, max_episode_steps=MAX_STEPS
         ),
-        policy_builder=Policy,
+        agent_builder=KeepLaneAgent,
     )
 
 

--- a/examples/history_vehicles_replacement_for_imitation_learning.py
+++ b/examples/history_vehicles_replacement_for_imitation_learning.py
@@ -2,7 +2,7 @@ import logging
 
 from smarts.core.smarts import SMARTS
 from smarts.core.agent_interface import AgentInterface, AgentType
-from smarts.core.agent import AgentSpec, AgentPolicy
+from smarts.core.agent import AgentSpec, Agent
 from smarts.core.sumo_traffic_simulation import SumoTrafficSimulation
 from smarts.core.scenario import Scenario
 from envision.client import Client as Envision
@@ -13,7 +13,7 @@ from examples import default_argument_parser
 logging.basicConfig(level=logging.INFO)
 
 
-class Policy(AgentPolicy):
+class KeepLaneAgent(Agent):
     def act(self, obs):
         return "keep_lane"
 
@@ -31,7 +31,7 @@ def main(scenarios, headless, seed):
                 interface=AgentInterface.from_type(
                     AgentType.Laner, max_episode_steps=None
                 ),
-                policy_builder=Policy,
+                agent_builder=KeepLaneAgent,
             )
 
             agent = agent_spec.build_agent()

--- a/examples/human_in_the_loop.py
+++ b/examples/human_in_the_loop.py
@@ -4,7 +4,7 @@ import argparse
 import gym
 
 from smarts.core.agent_interface import AgentInterface, AgentType
-from smarts.core.agent import AgentSpec, AgentPolicy
+from smarts.core.agent import AgentSpec, Agent
 from smarts.core.utils.episodes import episodes
 
 from pynput.keyboard import Key, Listener
@@ -16,13 +16,13 @@ logging.basicConfig(level=logging.INFO)
 AGENT_ID = "Agent-007"
 
 
-class HumanKeyboardPolicy(AgentPolicy):
+class HumanKeyboardAgent(Agent):
     def __init__(self):
         # initialize the keyboard listener
         self.listener = Listener(on_press=self.on_press)
         self.listener.start()
 
-        # Parameters for the human-keyboard policy
+        # Parameters for the human-keyboard agent
         # you need to change them to suit the scenario
         # These values work the best with zoo_intersection
 
@@ -86,7 +86,7 @@ def main(
         interface=AgentInterface.from_type(
             AgentType.StandardWithAbsoluteSteering, max_episode_steps=3000
         ),
-        policy_builder=HumanKeyboardPolicy,
+        agent_builder=HumanKeyboardAgent,
     )
 
     env = gym.make(

--- a/examples/multi_agent.py
+++ b/examples/multi_agent.py
@@ -1,7 +1,7 @@
 import gym
 
 from smarts.core.agent_interface import AgentInterface, AgentType
-from smarts.core.agent import AgentSpec, AgentPolicy
+from smarts.core.agent import AgentSpec, Agent
 from smarts.core.utils.episodes import episodes
 
 from examples import default_argument_parser
@@ -10,7 +10,7 @@ N_AGENTS = 4
 AGENT_IDS = ["Agent %i" % i for i in range(N_AGENTS)]
 
 
-class Policy(AgentPolicy):
+class KeepLaneAgent(Agent):
     def act(self, obs):
         return "keep_lane"
 
@@ -19,7 +19,7 @@ def main(scenarios, headless, num_episodes, seed):
     agent_specs = {
         agent_id: AgentSpec(
             interface=AgentInterface.from_type(AgentType.Laner, max_episode_steps=5000),
-            policy_builder=Policy,
+            agent_builder=KeepLaneAgent,
         )
         for agent_id in AGENT_IDS
     }

--- a/examples/multi_instance.py
+++ b/examples/multi_instance.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from smarts.core.agent_interface import AgentInterface, AgentType
 from smarts.core.utils.episodes import episodes
-from smarts.core.agent import AgentSpec, AgentPolicy
+from smarts.core.agent import AgentSpec, Agent
 
 from examples import default_argument_parser
 
@@ -18,7 +18,7 @@ logging.basicConfig(level=logging.INFO)
 AGENT_ID = "Agent-007"
 
 
-class PyTorchPolicy(AgentPolicy):
+class PyTorchAgent(Agent):
     def __init__(self, input_dims, hidden_dims, output_dims, model_path=None):
         self.model = torch.nn.Sequential(
             torch.nn.Linear(input_dims, hidden_dims),
@@ -67,11 +67,11 @@ def observation_adapter(env_obs):
 
 @ray.remote
 def train(training_scenarios, evaluation_scenarios, headless, num_episodes, seed):
-    policy_params = {"input_dims": 4, "hidden_dims": 7, "output_dims": 3}
+    agent_params = {"input_dims": 4, "hidden_dims": 7, "output_dims": 3}
     agent_spec = AgentSpec(
         interface=AgentInterface.from_type(AgentType.Standard, max_episode_steps=5000),
-        policy_params=policy_params,
-        policy_builder=PyTorchPolicy,
+        agent_params=agent_params,
+        agent_builder=PyTorchAgent,
         observation_adapter=observation_adapter,
     )
 
@@ -104,10 +104,10 @@ def train(training_scenarios, evaluation_scenarios, headless, num_episodes, seed
                 # We construct an evaluation agent based on the saved
                 # state of the agent in training.
                 model_path = tempfile.mktemp()
-                agent.policy.save(model_path)
+                agent.save(model_path)
 
                 eval_agent_spec = agent_spec.replace(
-                    policy_params=dict(policy_params, model_path=model_path)
+                    agent_params=dict(agent_params, model_path=model_path)
                 )
 
                 # Remove the call to ray.wait if you want evaluation to run

--- a/examples/observation_collection_for_imitation_learning.py
+++ b/examples/observation_collection_for_imitation_learning.py
@@ -16,7 +16,7 @@ logging.basicConfig(level=logging.INFO)
 def main(scenarios, headless, seed):
     agent_spec = AgentSpec(
         interface=AgentInterface.from_type(AgentType.Laner, max_episode_steps=None),
-        policy_builder=None,
+        agent_builder=None,
         observation_adapter=None,
     )
 

--- a/examples/rllib_agent.py
+++ b/examples/rllib_agent.py
@@ -52,7 +52,7 @@ class TrainingModel(FullyConnectedNetwork):
 ModelCatalog.register_custom_model(TrainingModel.NAME, TrainingModel)
 
 
-class RLLibTFSavedModelPolicy(Agent):
+class RLLibTFSavedModelAgent(Agent):
     def __init__(self, path_to_model, observation_space):
         path_to_model = str(path_to_model)  # might be a str or a Path, normalize to str
         self._prep = ModelCatalog.get_preprocessor_for_space(observation_space)
@@ -83,7 +83,7 @@ rllib_agent = {
             "path_to_model": Path(__file__).resolve().parent / "model",
             "observation_space": OBSERVATION_SPACE,
         },
-        agent_builder=RLLibTFSavedModelPolicy,
+        agent_builder=RLLibTFSavedModelAgent,
         observation_adapter=observation_adapter,
         reward_adapter=reward_adapter,
         action_adapter=action_adapter,

--- a/examples/rllib_agent.py
+++ b/examples/rllib_agent.py
@@ -8,7 +8,7 @@ from ray.rllib.models.tf.fcnet_v2 import FullyConnectedNetwork
 from ray.rllib.utils import try_import_tf
 
 from smarts.core.agent_interface import AgentInterface, AgentType
-from smarts.core.agent import AgentSpec, AgentPolicy
+from smarts.core.agent import AgentSpec, Agent
 from smarts.env.custom_observations import lane_ttc_observation_adapter
 
 tf = try_import_tf()
@@ -52,7 +52,7 @@ class TrainingModel(FullyConnectedNetwork):
 ModelCatalog.register_custom_model(TrainingModel.NAME, TrainingModel)
 
 
-class RLLibTFSavedModelPolicy(AgentPolicy):
+class RLLibTFSavedModelPolicy(Agent):
     def __init__(self, path_to_model, observation_space):
         path_to_model = str(path_to_model)  # might be a str or a Path, normalize to str
         self._prep = ModelCatalog.get_preprocessor_for_space(observation_space)
@@ -79,11 +79,11 @@ class RLLibTFSavedModelPolicy(AgentPolicy):
 rllib_agent = {
     "agent_spec": AgentSpec(
         interface=AgentInterface.from_type(AgentType.Standard, max_episode_steps=500),
-        policy_params={
+        agent_params={
             "path_to_model": Path(__file__).resolve().parent / "model",
             "observation_space": OBSERVATION_SPACE,
         },
-        policy_builder=RLLibTFSavedModelPolicy,
+        agent_builder=RLLibTFSavedModelPolicy,
         observation_adapter=observation_adapter,
         reward_adapter=reward_adapter,
         action_adapter=action_adapter,

--- a/examples/single_agent.py
+++ b/examples/single_agent.py
@@ -4,7 +4,7 @@ import gym
 
 from smarts.core.utils.episodes import episodes
 from smarts.core.agent_interface import AgentInterface, AgentType
-from smarts.core.agent import AgentSpec, AgentPolicy
+from smarts.core.agent import AgentSpec, Agent
 
 from examples import default_argument_parser
 
@@ -14,7 +14,7 @@ logging.basicConfig(level=logging.INFO)
 AGENT_ID = "Agent-007"
 
 
-class Policy(AgentPolicy):
+class KeepLaneAgent(Agent):
     def act(self, obs):
         return "keep_lane"
 
@@ -22,7 +22,7 @@ class Policy(AgentPolicy):
 def main(scenarios, headless, num_episodes, seed):
     agent_spec = AgentSpec(
         interface=AgentInterface.from_type(AgentType.Laner, max_episode_steps=None),
-        policy_builder=Policy,
+        agent_builder=KeepLaneAgent,
     )
 
     env = gym.make(

--- a/examples/trajectory_tracking_agent.py
+++ b/examples/trajectory_tracking_agent.py
@@ -4,7 +4,7 @@ import gym
 
 from smarts.core.utils.episodes import episodes
 from smarts.core.agent_interface import AgentInterface, AgentType
-from smarts.core.agent import AgentSpec, AgentPolicy
+from smarts.core.agent import AgentSpec, Agent
 
 from examples import default_argument_parser
 
@@ -14,7 +14,7 @@ logging.basicConfig(level=logging.INFO)
 AGENT_ID = "Agent-007"
 
 
-class Policy(AgentPolicy):
+class TrackingAgent(Agent):
     def act(self, obs):
         lane_index = 0
         num_trajectory_points = min([10, len(obs.waypoint_paths[lane_index])])
@@ -41,7 +41,7 @@ class Policy(AgentPolicy):
 def main(scenarios, headless, num_episodes, seed):
     agent_spec = AgentSpec(
         interface=AgentInterface.from_type(AgentType.Tracker, max_episode_steps=None),
-        policy_builder=Policy,
+        agent_builder=TrackingAgent,
     )
 
     env = gym.make(

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,6 +50,7 @@ kiwisolver==1.2.0
 lz4==3.1.0
 Markdown==3.3.1
 matplotlib==3.3.2
+more-itertools==8.2.0
 multidict==4.7.6
 networkx==2.5
 numpy==1.19.2
@@ -62,6 +63,7 @@ panda3d==1.10.7
 panda3d-gltf==0.10
 panda3d-simplepbr==0.7
 pandas==1.1.3
+pbr==5.5.1
 Pillow==8.0.0
 pluggy==0.13.1
 protobuf==3.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ constantly==15.1.0
 coverage==5.3
 cycler==0.10.0
 Cython==0.29.21
+debtcollector==2.2.0
 decorator==4.4.2
 dm-tree==0.1.5
 evdev==1.3.0

--- a/scenarios/intersections/2lane_circle/agent_prefabs.py
+++ b/scenarios/intersections/2lane_circle/agent_prefabs.py
@@ -1,15 +1,15 @@
 from smarts.zoo.registry import register
 from smarts.core.agent_interface import AgentInterface, DoneCriteria
-from smarts.core.agent import AgentPolicy, AgentSpec
+from smarts.core.agent import Agent, AgentSpec
 from smarts.core.controllers import ActionSpaceType
 
 
-class KeepLanePolicy(AgentPolicy):
+class KeepLaneAgent(Agent):
     def act(self, obs):
         return "keep_lane"
 
 
-class StoppedPolicy(AgentPolicy):
+class StoppedAgent(Agent):
     def act(self, obs):
         return (0, 0)
 
@@ -20,7 +20,7 @@ register(
         interface=AgentInterface(
             waypoints=True, action=ActionSpaceType.Lane, max_episode_steps=5000
         ),
-        policy_builder=KeepLanePolicy,
+        agent_builder=KeepLaneAgent,
     ),
 )
 
@@ -32,6 +32,6 @@ register(
             action=ActionSpaceType.LaneWithContinuousSpeed,
             done_criteria=DoneCriteria(not_moving=True),
         ),
-        policy_builder=StoppedPolicy,
+        agent_builder=StoppedAgent,
     ),
 )

--- a/scenarios/intersections/4lane_t/agent_prefabs.py
+++ b/scenarios/intersections/4lane_t/agent_prefabs.py
@@ -1,17 +1,17 @@
 import numpy as np
 
-from smarts.core.agent import AgentPolicy, AgentSpec
+from smarts.core.agent import Agent, AgentSpec
 from smarts.core.agent_interface import AgentInterface, AgentType
 from smarts.core.controllers import ActionSpaceType
 from smarts.zoo.registry import register
 
 
-class KeepLanePolicy(AgentPolicy):
+class KeepLaneAgent(Agent):
     def act(self, obs):
         return "keep_lane"
 
 
-class MotionPlannerPolicy(AgentPolicy):
+class MotionPlannerAgent(Agent):
     def act(self, obs):
         wp = obs.waypoint_paths[0][:5][-1]
         dist_to_wp = np.linalg.norm(wp.pos - obs.ego_vehicle_state.position[:2])
@@ -23,7 +23,7 @@ register(
     locator="zoo-agent-v0",
     entry_point=lambda **kwargs: AgentSpec(
         interface=AgentInterface.from_type(AgentType.Laner, max_episode_steps=20000),
-        policy_builder=KeepLanePolicy,
+        agent_builder=KeepLaneAgent,
     ),
 )
 
@@ -31,6 +31,6 @@ register(
     locator="motion-planner-agent-v0",
     entry_point=lambda **kwargs: AgentSpec(
         interface=AgentInterface(waypoints=True, action=ActionSpaceType.TargetPose),
-        policy_builder=MotionPlannerPolicy,
+        agent_builder=MotionPlannerAgent,
     ),
 )

--- a/scenarios/straight/agent_prefabs.py
+++ b/scenarios/straight/agent_prefabs.py
@@ -8,6 +8,7 @@ from smarts.core.controllers import ActionSpaceType
 from smarts.zoo.registry import register
 
 
+
 class PoseBoidAgent(Agent):
     def __init__(self):
         self._log = logging.getLogger(self.__class__.__name__)

--- a/scenarios/straight/agent_prefabs.py
+++ b/scenarios/straight/agent_prefabs.py
@@ -1,13 +1,14 @@
 import logging
 
 import numpy as np
-from smarts.core.agent import AgentPolicy, AgentSpec
+
+from smarts.core.agent import Agent, AgentSpec
 from smarts.core.agent_interface import AgentInterface
 from smarts.core.controllers import ActionSpaceType
 from smarts.zoo.registry import register
 
 
-class PoseBoidPolicy(AgentPolicy):
+class PoseBoidAgent(Agent):
     def __init__(self):
         self._log = logging.getLogger(self.__class__.__name__)
         self._log.info(f"{self.__class__.__name__} was created")
@@ -25,7 +26,7 @@ class PoseBoidPolicy(AgentPolicy):
         return np.array([*wp.pos, wp.heading, dist_to_wp / target_speed])
 
 
-class TrajectoryBoidPolicy(AgentPolicy):
+class TrajectoryBoidAgent(Agent):
     def __init__(self):
         self._log = logging.getLogger(self.__class__.__name__)
         self._log.info(f"{self.__class__.__name__} was created")
@@ -64,7 +65,7 @@ register(
         interface=AgentInterface(
             action=ActionSpaceType.MultiTargetPose, waypoints=True
         ),
-        policy_builder=PoseBoidPolicy,
+        agent_builder=PoseBoidAgent,
     ),
 )
 
@@ -72,6 +73,6 @@ register(
     locator="trajectory-boid-agent-v0",
     entry_point=lambda **kwargs: AgentSpec(
         interface=AgentInterface(action=ActionSpaceType.Trajectory, waypoints=True),
-        policy_builder=TrajectoryBoidPolicy,
+        agent_builder=TrajectoryBoidAgent,
     ),
 )

--- a/scenarios/straight/agent_prefabs.py
+++ b/scenarios/straight/agent_prefabs.py
@@ -8,7 +8,6 @@ from smarts.core.controllers import ActionSpaceType
 from smarts.zoo.registry import register
 
 
-
 class PoseBoidAgent(Agent):
     def __init__(self):
         self._log = logging.getLogger(self.__class__.__name__)

--- a/scenarios/zoo_intersection/agent_prefabs.py
+++ b/scenarios/zoo_intersection/agent_prefabs.py
@@ -1,9 +1,9 @@
 from smarts.zoo.registry import register
 from smarts.core.agent_interface import AgentInterface, AgentType
-from smarts.core.agent import AgentPolicy, AgentSpec
+from smarts.core.agent import Agent, AgentSpec
 
 
-class Policy(AgentPolicy):
+class SimpleAgent(Agent):
     def act(self, obs):
         return "keep_lane"
 
@@ -12,7 +12,7 @@ class Policy(AgentPolicy):
 def demo_agent_callable(target_prefix=None, interface=None):
     if interface is None:
         interface = AgentInterface.from_type(AgentType.Laner)
-    return AgentSpec(interface=interface, policy_builder=Policy)
+    return AgentSpec(interface=interface, agent_builder=SimpleAgent)
 
 
 register(

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         # The following are for /smarts/zoo
         "twisted",
         "PyYAML",
+        "debtcollector",
     ],
     extras_require={
         "train": ["tensorflow==2.2", "torch==1.3.0", "torchvision==0.4.1"],

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "pybullet",
         "sklearn",  # KDTree from sklearn is used by waypoints
         "tableprint",
-        "pynput",  # Used by HumanKeyboardPolicy
+        "pynput",  # Used by HumanKeyboardAgent
         "sh",
         "rich",
         "supervisor",

--- a/smarts/core/agent.py
+++ b/smarts/core/agent.py
@@ -141,8 +141,8 @@ class AgentSpec:
             assert self.agent_params is None, self.agent_params
             self.agent_params = self.policy_params
 
-        self.policy_params = agent_params
-        self.policy_builder = agent_builder
+        self.policy_params = self.agent_params
+        self.policy_builder = self.agent_builder
 
     def replace(self, **kwargs) -> "AgentSpec":
         """Return a copy of this AgentSpec with the given fields updated."""

--- a/smarts/core/agent.py
+++ b/smarts/core/agent.py
@@ -19,74 +19,54 @@
 # THE SOFTWARE.
 from typing import Optional, Any, Callable
 from dataclasses import dataclass, replace
+import warnings
 
+from debtcollector import removals
 import cloudpickle
 
 from .agent_interface import AgentInterface
 
+warnings.simplefilter('once')
 
-class AgentPolicy:
-    """The base class for agent policies."""
+
+class Agent:
+    """The base class for agents"""
+
+    @removals.removed_property(message="Simply use the agent instance as is, Agent and AgentPolicy have been merged")
+    @property
+    def policy(self):
+        """ Backwards compatibility with the old Agent class"""
+        return self
 
     @classmethod
-    def from_function(cls, policy_function: Callable):
-        """A utility function to create a policy from a lambda or other callable object.
+    def from_function(cls, agent_function: Callable):
+        """A utility function to create an agent from a lambda or other callable object.
 
         .. code-block:: python
 
-            keep_lane_policy = AgentPolicy.from_function(lambda obs: "keep_lane")
+            keep_lane_policy = Agent.from_function(lambda obs: "keep_lane")
         """
-        assert callable(policy_function)
+        assert callable(agent_function)
 
-        class FunctionPolicy(AgentPolicy):
+        class FunctionAgent(Agent):
             def act(self, obs):
-                return policy_function(obs)
+                return agent_function(obs)
 
-        return FunctionPolicy()
+        return FunctionAgent()
 
     def act(self, obs):
-        """The policy action. See documentation on observations, `Agent`, and `AgentInterface`.
+        """The agent action. See documentation on observations, `AgentSpec`, and `AgentInterface`.
 
         Expects an adapted observation and returns an unadapted action.
         """
 
         raise NotImplementedError
 
-
-@dataclass
-class Agent:
-    """The core agent class. This gathers the interface, policy, and adapters."""
-
-    interface: AgentInterface
-    """The adaptor used to wrap agent observation and action flow"""
-    policy: AgentPolicy
-    """The wrapper for the policy action"""
-    observation_adapter: Callable
-    """An adaptor that allows shaping of the observations"""
-    reward_adapter: Callable
-    """An adaptor that allows shaping of the reward"""
-    action_adapter: Callable
-    """An adaptor that allows shaping of the action"""
-    info_adapter: Callable
-    """An adaptor that allows shaping of info"""
-
-    def act(self, observation):
-        """Calls the policy action. Expects adapted observation and returns an unadapted action.
-
-        See documentation on observations and `AgentInterface`.
-        """
-
-        assert self.policy, "Unable to call Agent.act(...) without a policy"
-        action = self.policy.act(observation)
-        return action
-
-    # XXX: This method should only be used by social agents, not by ego agents.
-    def act_with_adaptation(self, env_observation):
-        observation = self.observation_adapter(env_observation)
-        policy_action = self.act(observation)
-        action = self.action_adapter(policy_action)
-        return action
-
+# Remain backwards compatible with existing Agent's
+class AgentPolicy(Agent):
+    # we cannot use debtcollector here to signal deprecation because the wrapper object is
+    # not pickleable, instead we simply print.
+    print("[DEPRECATED] AgentPolicy has been replaced with `smarts.core.agent.Agent`")
 
 @dataclass
 class AgentSpec:
@@ -116,13 +96,15 @@ class AgentSpec:
     interface: AgentInterface = None
     """the adaptor used to wrap agent observation and action flow (default None)"""
 
-    # If you are training a policy with RLLib, you don't necessarily
-    # want to set the policy as part of the AgentSpec, thus we leave
-    # it as an optional field.
-    policy_builder: Callable[..., AgentPolicy] = None
-    """An adaptor that interprets the policy_params into a policy  (default None)"""
+    agent_builder: Callable[..., Agent] = None
+    """A callable to build an `smarts.core.agent.Agent` given `AgentSpec.agent_params` (default None)"""
+    agent_params: Optional[Any] = None
+    """Parameters to be given to `AgentSpec.agent_builder` (default None)"""
+
+    policy_builder: Callable[..., Agent] = None
+    """[DEPRECATED] see `AgentSpec.agent_builder` (default None)"""
     policy_params: Optional[Any] = None
-    """Parameters to be fed into the policy builder (default None)"""
+    """[DEPRECATED] see `AgentSpec.agent_params` (default None)"""
     observation_adapter: Callable = lambda obs: obs
     """An adaptor that allows shaping of the observations (default lambda obs: obs)"""
     action_adapter: Callable = lambda act: act
@@ -131,33 +113,25 @@ class AgentSpec:
     """An adaptor that allows shaping of the reward (default lambda obs, reward: reward)"""
     info_adapter: Callable = lambda obs, reward, info: info
     """An adaptor that allows shaping of info (default lambda obs, reward, info: info)"""
-    perform_self_test: bool = True
+    perform_self_test: bool = False
+    """[DEPRECATED] this parameter is not used anymore"""
 
     def __post_init__(self):
         # make sure we can pickle ourselves
         cloudpickle.dumps(self)
-        # Perform a self-test
-        # TODO: move this to a remote agent, this is not safe to do in the smarts process
-        if self.policy_builder is None:
-            # skip this self-test if we have not set a `policy_builder`
-            return
 
         if self.perform_self_test:
-            policy = self._build_policy()
-            assert isinstance(
-                policy, AgentPolicy
-            ), f"Policy builder did not build an AgentPolicy: {policy}"
-            # TODO: The user has to hook up a few things correctly here
-            #       and without types to guide the user, we should help
-            #       them proactively.
-            #
-            #       perform a self-test here to ensure things are rigged
-            #       up properly. ie.  generate some fake obs based on the
-            #       interface, pass it through the obs adapter, run that
-            #       through the policy, pass the policy action through
-            #       the action_adapter and ensure the controller accepts
-            #       the produced action.
-            del policy
+            print(f"[DEPRECATED] `perform_self_test` has been deprecated: {self}")
+
+        if self.policy_builder:
+            print(f"[DEPRECATED] Please use AgentSpec(agent_builder=<...>) instead of AgentSpec(policy_builder=<..>):\n {self}")
+            assert self.agent_builder is None, self.agent_builder
+            self.agent_builder = self.policy_builder
+
+        if self.policy_params:
+            print(f"[DEPRECATED] Please use AgentSpec(agent_params=<...>) instead of AgentSpec(policy_params=<..>):\n {self}")
+            assert self.agent_params is None, self.agent_params
+            self.agent_params = self.policy_params
 
     def replace(self, **kwargs) -> "AgentSpec":
         """Return a copy of this AgentSpec with the given fields updated."""
@@ -166,47 +140,30 @@ class AgentSpec:
 
     def build_agent(self) -> Agent:
         """Construct an Agent from the AgentSpec configuration."""
+        if self.agent_builder is None:
+            raise ValueError("Can't build agent, no agent builder was supplied")
 
-        return Agent(
-            interface=self.interface,
-            observation_adapter=self.observation_adapter,
-            action_adapter=self.action_adapter,
-            reward_adapter=self.reward_adapter,
-            info_adapter=self.info_adapter,
-            policy=self._build_policy(),
-        )
-
-    def _build_policy(self):
-        if self.policy_builder is None:
-            raise ValueError("Can't build agent, no policy builder was supplied")
-
-        if not callable(self.policy_builder):
+        if not callable(self.agent_builder):
             raise ValueError(
-                f"""policy_builder: {self.policy_builder} is not callable
-Use a combination of policy_params and policy_builder to define how to build your policy, ie.
-AgentSpec(
-  policy_params={{"input_dimensions": 12}},
-  policy_builder=lambda: input_dimensions: MyPolicy(input_dimensions)
-)
-
-OR Better yet
+                f"""agent_builder: {self.agent_builder} is not callable
+Use a combination of agent_params and agent_builder to define how to build your agent, ie.
 
 AgentSpec(
-  policy_params={{"input_dimensions": 12}},
-  policy_builder=MyPolicy # we are not instantiating the policy, just passing the class reference
+  agent_params={{"input_dimensions": 12}},
+  agent_builder=MyAgent # we are not instantiating the agent, just passing the class reference
 )
 """
             )
 
-        if self.policy_params is None:
-            # no args to policy builder
-            return self.policy_builder()
-        elif isinstance(self.policy_params, (list, tuple)):
+        if self.agent_params is None:
+            # no args to agent builder
+            return self.agent_builder()
+        elif isinstance(self.agent_params, (list, tuple)):
             # a list or tuple is treated as positional arguments
-            return self.policy_builder(*self.policy_params)
-        elif isinstance(self.policy_params, dict):
+            return self.agent_builder(*self.agent_params)
+        elif isinstance(self.agent_params, dict):
             # dictionaries, as keyword arguments
-            return self.policy_builder(**self.policy_params)
+            return self.agent_builder(**self.agent_params)
         else:
-            # otherwise, the policy params are sent as is to the builder
-            return self.policy_builder(self.policy_params)
+            # otherwise, the agent params are sent as is to the builder
+            return self.agent_builder(self.agent_params)

--- a/smarts/core/agent.py
+++ b/smarts/core/agent.py
@@ -141,6 +141,9 @@ class AgentSpec:
             assert self.agent_params is None, self.agent_params
             self.agent_params = self.policy_params
 
+        self.policy_params = agent_params
+        self.policy_builder = agent_builder
+
     def replace(self, **kwargs) -> "AgentSpec":
         """Return a copy of this AgentSpec with the given fields updated."""
 

--- a/smarts/core/agent.py
+++ b/smarts/core/agent.py
@@ -26,13 +26,15 @@ import cloudpickle
 
 from .agent_interface import AgentInterface
 
-warnings.simplefilter('once')
+warnings.simplefilter("once")
 
 
 class Agent:
     """The base class for agents"""
 
-    @removals.removed_property(message="Simply use the agent instance as is, Agent and AgentPolicy have been merged")
+    @removals.removed_property(
+        message="Simply use the agent instance as is, Agent and AgentPolicy have been merged"
+    )
     @property
     def policy(self):
         """ Backwards compatibility with the old Agent class"""
@@ -62,11 +64,13 @@ class Agent:
 
         raise NotImplementedError
 
+
 # Remain backwards compatible with existing Agent's
 class AgentPolicy(Agent):
     # we cannot use debtcollector here to signal deprecation because the wrapper object is
     # not pickleable, instead we simply print.
     print("[DEPRECATED] AgentPolicy has been replaced with `smarts.core.agent.Agent`")
+
 
 @dataclass
 class AgentSpec:
@@ -124,12 +128,16 @@ class AgentSpec:
             print(f"[DEPRECATED] `perform_self_test` has been deprecated: {self}")
 
         if self.policy_builder:
-            print(f"[DEPRECATED] Please use AgentSpec(agent_builder=<...>) instead of AgentSpec(policy_builder=<..>):\n {self}")
+            print(
+                f"[DEPRECATED] Please use AgentSpec(agent_builder=<...>) instead of AgentSpec(policy_builder=<..>):\n {self}"
+            )
             assert self.agent_builder is None, self.agent_builder
             self.agent_builder = self.policy_builder
 
         if self.policy_params:
-            print(f"[DEPRECATED] Please use AgentSpec(agent_params=<...>) instead of AgentSpec(policy_params=<..>):\n {self}")
+            print(
+                f"[DEPRECATED] Please use AgentSpec(agent_params=<...>) instead of AgentSpec(policy_params=<..>):\n {self}"
+            )
             assert self.agent_params is None, self.agent_params
             self.agent_params = self.policy_params
 

--- a/smarts/core/agent.py
+++ b/smarts/core/agent.py
@@ -44,7 +44,7 @@ class Agent:
 
         .. code-block:: python
 
-            keep_lane_policy = Agent.from_function(lambda obs: "keep_lane")
+            keep_lane_agent = Agent.from_function(lambda obs: "keep_lane")
         """
         assert callable(agent_function)
 
@@ -76,8 +76,8 @@ class AgentSpec:
 
         agent_spec = AgentSpec(
             interface=AgentInterface.from_type(AgentType.Laner),
-            policy_params={"policy_function": lambda _: "keep_lane"},
-            policy_builder=AgentPolicy.from_function,
+            agent_params={"agent_function": lambda _: "keep_lane"},
+            agent_builder=AgentPolicy.from_function,
         )
 
         env = gym.make(

--- a/smarts/core/agent_manager.py
+++ b/smarts/core/agent_manager.py
@@ -408,17 +408,21 @@ class AgentManager:
             boid=boid,
         )
 
-        for provider in sim.providers:
-            if agent_interface.action_space in provider.action_spaces:
-                provider.create_vehicle(
-                    VehicleState(
-                        vehicle_id=vehicle.id,
-                        vehicle_type=vehicle.vehicle_type,
-                        pose=vehicle.pose,
-                        dimensions=vehicle.chassis.dimensions,
-                        source="NEW-AGENT",
-                    )
-                )
+        matching_providers = [
+            provider for provider in sim.providers
+            if agent_interface.action_space in provider.action_spaces
+        ]
+        assert len(matching_providers) == 1
+        provider = matching_providers[0]
+        provider.create_vehicle(
+            VehicleState(
+                vehicle_id=vehicle.id,
+                vehicle_type=vehicle.vehicle_type,
+                pose=vehicle.pose,
+                dimensions=vehicle.chassis.dimensions,
+                source="NEW-AGENT",
+            )
+        )
 
         self._agent_interfaces[agent_id] = agent_interface
         self._social_agent_data_models[agent_id] = agent_model

--- a/smarts/core/agent_manager.py
+++ b/smarts/core/agent_manager.py
@@ -409,11 +409,14 @@ class AgentManager:
         )
 
         matching_providers = [
-            provider for provider in sim.providers
+            provider
+            for provider in sim.providers
             if agent_interface.action_space in provider.action_spaces
         ]
         if matching_providers:
-            assert len(matching_providers) == 1, f"Found {matching_providers} for action space {agent_interface.action_space}"
+            assert (
+                len(matching_providers) == 1
+            ), f"Found {matching_providers} for action space {agent_interface.action_space}"
             provider = matching_providers[0]
             provider.create_vehicle(
                 VehicleState(

--- a/smarts/core/agent_manager.py
+++ b/smarts/core/agent_manager.py
@@ -412,17 +412,18 @@ class AgentManager:
             provider for provider in sim.providers
             if agent_interface.action_space in provider.action_spaces
         ]
-        assert len(matching_providers) == 1
-        provider = matching_providers[0]
-        provider.create_vehicle(
-            VehicleState(
-                vehicle_id=vehicle.id,
-                vehicle_type=vehicle.vehicle_type,
-                pose=vehicle.pose,
-                dimensions=vehicle.chassis.dimensions,
-                source="NEW-AGENT",
+        if matching_providers:
+            assert len(matching_providers) == 1, f"Found {matching_providers} for action space {agent_interface.action_space}"
+            provider = matching_providers[0]
+            provider.create_vehicle(
+                VehicleState(
+                    vehicle_id=vehicle.id,
+                    vehicle_type=vehicle.vehicle_type,
+                    pose=vehicle.pose,
+                    dimensions=vehicle.chassis.dimensions,
+                    source="NEW-AGENT",
+                )
             )
-        )
 
         self._agent_interfaces[agent_id] = agent_interface
         self._social_agent_data_models[agent_id] = agent_model

--- a/smarts/core/remote_agent.py
+++ b/smarts/core/remote_agent.py
@@ -37,7 +37,7 @@ class RemoteAgentException(Exception):
 
 
 class RemoteAgent:
-    def __init__(self, with_adaptation=True, connection_retries=100):
+    def __init__(self, connection_retries=100):
         atexit.register(self.terminate)
 
         self._log = logging.getLogger(self.__class__.__name__)
@@ -51,9 +51,6 @@ class RemoteAgent:
             ),
             sock_file,
         ]
-
-        if with_adaptation:
-            cmd.append("--with_adaptation")
 
         self._log.debug(f"Spawning remote agent proc: {cmd}")
 

--- a/smarts/core/tests/test_agent.py
+++ b/smarts/core/tests/test_agent.py
@@ -1,10 +1,10 @@
-from smarts.core.agent import AgentSpec, AgentPolicy
+from smarts.core.agent import AgentSpec, Agent
 
 
 def test_building_agent_with_list_or_tuple_params():
     agent_spec = AgentSpec(
-        policy_params=[32, 41],
-        policy_builder=lambda x, y: AgentPolicy.from_function(lambda _: (x, y)),
+        agent_params=[32, 41],
+        agent_builder=lambda x, y: Agent.from_function(lambda _: (x, y)),
     )
 
     agent = agent_spec.build_agent()
@@ -13,8 +13,8 @@ def test_building_agent_with_list_or_tuple_params():
 
 def test_building_agent_with_tuple_params():
     agent_spec = AgentSpec(
-        policy_params=(32, 41),
-        policy_builder=lambda x, y: AgentPolicy.from_function(lambda _: (x, y)),
+        agent_params=(32, 41),
+        agent_builder=lambda x, y: Agent.from_function(lambda _: (x, y)),
     )
 
     agent = agent_spec.build_agent()
@@ -23,8 +23,8 @@ def test_building_agent_with_tuple_params():
 
 def test_building_agent_with_dict_params():
     agent_spec = AgentSpec(
-        policy_params={"y": 2, "x": 1},
-        policy_builder=lambda x, y: AgentPolicy.from_function(lambda _: x / y),
+        agent_params={"y": 2, "x": 1},
+        agent_builder=lambda x, y: Agent.from_function(lambda _: x / y),
     )
 
     agent = agent_spec.build_agent()

--- a/smarts/core/tests/test_controller_lane.py
+++ b/smarts/core/tests/test_controller_lane.py
@@ -1,6 +1,7 @@
 import pytest
+
 import smarts.sstudio.types as t
-from smarts.core.agent import AgentPolicy, AgentSpec
+from smarts.core.agent import AgentSpec, Agent
 from smarts.core.agent_interface import AgentInterface, AgentType
 from smarts.core.controllers import LaneFollowingController
 from smarts.core.scenario import Scenario
@@ -20,15 +21,15 @@ AGENT_ID = "Agent-007"
         ((18, 0), AgentType.LanerWithSpeed),
     ]
 )
-def policy_and_agent_type(request):
-    class Policy(AgentPolicy):
+def agent_and_agent_type(request):
+    class FixedAgent(Agent):
         def __init__(self, action=request.param[0]):
             self.action = action
 
         def act(self, obs):
             return self.action
 
-    return (Policy, request.param[1])
+    return (FixedAgent, request.param[1])
 
 
 @pytest.fixture(
@@ -55,12 +56,12 @@ def scenarios(request):
 
 
 @pytest.fixture
-def agent_spec(policy_and_agent_type):
+def agent_spec(agent_and_agent_type):
     return AgentSpec(
         interface=AgentInterface.from_type(
-            policy_and_agent_type[1], max_episode_steps=5000
+            agent_and_agent_type[1], max_episode_steps=5000
         ),
-        policy_builder=policy_and_agent_type[0],
+        agent_builder=agent_and_agent_type[0],
     )
 
 

--- a/smarts/core/tests/test_observations.py
+++ b/smarts/core/tests/test_observations.py
@@ -11,7 +11,7 @@ from smarts.core.agent_interface import (
     RGB,
     RoadWaypoints,
 )
-from smarts.core.agent import AgentSpec, AgentPolicy
+from smarts.core.agent import AgentSpec, Agent
 from smarts.core.colors import SceneColors
 
 from panda3d.core import OrthographicLens, Point2, Point3
@@ -48,7 +48,7 @@ def agent_spec():
             rgb=RGB(width=MAP_WIDTH, height=MAP_HEIGHT, resolution=MAP_RESOLUTION),
             action=ActionSpaceType.Lane,
         ),
-        policy_builder=lambda: AgentPolicy.from_function(lambda _: "keep_lane"),
+        agent_builder=lambda: Agent.from_function(lambda _: "keep_lane"),
     )
 
 

--- a/smarts/core/traffic_history_provider.py
+++ b/smarts/core/traffic_history_provider.py
@@ -58,7 +58,7 @@ class TrafficHistoryProvider:
 
     @property
     def action_spaces(self) -> Set[ActionSpaceType]:
-        return {ActionSpaceType.TargetPose}
+        return {}
 
     def sync(self, provider_state):
         # Ignore other sim state

--- a/smarts/env/tests/test_determinism.py
+++ b/smarts/env/tests/test_determinism.py
@@ -5,7 +5,7 @@ import numpy as np
 from collections.abc import Sequence
 
 from smarts.core.agent_interface import AgentInterface
-from smarts.core.agent import AgentSpec, AgentPolicy
+from smarts.core.agent import AgentSpec, Agent
 from smarts.core.controllers import ActionSpaceType
 from smarts.core.utils.episodes import episodes
 
@@ -28,7 +28,7 @@ def agent_spec():
             neighborhood_vehicles=True,
             action=ActionSpaceType.Lane,
         ),
-        policy_builder=lambda: AgentPolicy.from_function(lambda _: "keep_lane"),
+        agent_builder=lambda: Agent.from_function(lambda _: "keep_lane"),
     )
 
 

--- a/smarts/env/tests/test_hiway_env.py
+++ b/smarts/env/tests/test_hiway_env.py
@@ -52,9 +52,7 @@ def agent_spec():
 
     return AgentSpec(
         interface=AgentInterface.from_type(AgentType.Laner, max_episode_steps=100),
-        agent_builder=lambda: Agent.from_function(
-            lambda _: ACTION_TO_BE_ADAPTED
-        ),
+        agent_builder=lambda: Agent.from_function(lambda _: ACTION_TO_BE_ADAPTED),
         observation_adapter=observation_adapter,
         reward_adapter=reward_adapter,
         action_adapter=action_adapter,

--- a/smarts/env/tests/test_hiway_env.py
+++ b/smarts/env/tests/test_hiway_env.py
@@ -4,7 +4,7 @@ import gym
 
 from smarts.core.utils.episodes import episodes
 from smarts.core.agent_interface import AgentInterface, AgentType
-from smarts.core.agent import AgentSpec, AgentPolicy
+from smarts.core.agent import AgentSpec, Agent
 
 AGENT_ID = "Agent-007"
 
@@ -52,7 +52,7 @@ def agent_spec():
 
     return AgentSpec(
         interface=AgentInterface.from_type(AgentType.Laner, max_episode_steps=100),
-        policy_builder=lambda: AgentPolicy.from_function(
+        agent_builder=lambda: Agent.from_function(
             lambda _: ACTION_TO_BE_ADAPTED
         ),
         observation_adapter=observation_adapter,

--- a/smarts/env/tests/test_learning.py
+++ b/smarts/env/tests/test_learning.py
@@ -1,5 +1,5 @@
 """This is a (long-running) regression test to ensure code changes have not impacted
-learning. It compares the mean episode reward of a newly trained policy with that
+learning. It compares the mean episode reward of a newly trained agent with that
 of a baseline from a past (baseline) commit. It is set to run for one hour.
 """
 import multiprocessing

--- a/smarts/env/tests/test_shutdown.py
+++ b/smarts/env/tests/test_shutdown.py
@@ -4,7 +4,7 @@ import gym
 import pytest
 
 from smarts.core.smarts import SMARTSNotSetupError
-from smarts.core.agent import AgentSpec, AgentPolicy
+from smarts.core.agent import AgentSpec, Agent
 from smarts.core.agent_interface import AgentInterface, AgentType
 
 AGENT_ID = "AGENT-007"
@@ -26,7 +26,7 @@ def test_graceful_shutdown():
     """SMARTS should not throw any exceptions when shutdown."""
     agent_spec = AgentSpec(
         interface=AgentInterface.from_type(AgentType.Laner),
-        policy_builder=lambda: AgentPolicy.from_function(lambda _: "keep_lane"),
+        agent_builder=lambda: Agent.from_function(lambda _: "keep_lane"),
     )
     env = build_env(agent_spec)
     agent = agent_spec.build_agent()
@@ -42,7 +42,7 @@ def test_graceful_interrupt(monkeypatch):
 
     agent_spec = AgentSpec(
         interface=AgentInterface.from_type(AgentType.Laner),
-        policy_builder=lambda: AgentPolicy.from_function(lambda _: "keep_lane"),
+        agent_builder=lambda: Agent.from_function(lambda _: "keep_lane"),
     )
     agent = agent_spec.build_agent()
     env = build_env(agent_spec)

--- a/smarts/env/tests/test_social_agent.py
+++ b/smarts/env/tests/test_social_agent.py
@@ -3,7 +3,7 @@ import pytest
 
 from smarts.core.utils.episodes import episodes
 from smarts.core.agent_interface import AgentInterface, AgentType
-from smarts.core.agent import AgentSpec, AgentPolicy
+from smarts.core.agent import AgentSpec, Agent
 
 AGENT_ID = "Agent-007"
 SOCIAL_AGENT_ID = "Alec Trevelyan"
@@ -15,7 +15,7 @@ MAX_EPISODES = 3
 def agent_spec():
     return AgentSpec(
         interface=AgentInterface.from_type(AgentType.Laner, max_episode_steps=100),
-        policy_builder=lambda: AgentPolicy.from_function(lambda _: "keep_lane"),
+        agent_builder=lambda: Agent.from_function(lambda _: "keep_lane"),
     )
 
 

--- a/smarts/zoo/registry.py
+++ b/smarts/zoo/registry.py
@@ -42,7 +42,7 @@ def register(locator: str, entry_point, **kwargs):
             locator="motion-planner-agent-v0",
             entry_point=lambda **kwargs: AgentSpec(
                 interface=AgentInterface(waypoints=True, action=ActionSpaceType.TargetPose),
-                policy_builder=MotionPlannerPolicy,
+                agent_builder=MotionPlannerAgent,
             ),
         )
     """

--- a/smarts/zoo/run_agent.py
+++ b/smarts/zoo/run_agent.py
@@ -77,9 +77,7 @@ parser.add_argument("socket_file", help="AF_UNIX domain socket file to be used f
 args = parser.parse_args()
 
 
-log.debug(
-    f"run_agent.py: socket_file={args.socket_file}"
-)
+log.debug(f"run_agent.py: socket_file={args.socket_file}")
 
 with Listener(args.socket_file, family="AF_UNIX") as listener:
     with listener.accept() as conn:

--- a/zoo/evaluation/scenarios/cross/ego_agent.py
+++ b/zoo/evaluation/scenarios/cross/ego_agent.py
@@ -1,15 +1,15 @@
 from smarts.core.utils.episodes import episodes
 from smarts.core.agent_interface import AgentInterface, ActionSpaceType
-from smarts.core.agent import AgentSpec, AgentPolicy
-from zoo.policies.non_interactive_policy import NonInteractivePolicy
+from smarts.core.agent import AgentSpec
+from zoo.policies.non_interactive_agent import NonInteractiveAgent
 
 
 AGENT_ID = "Agent-007"
 
 agent_spec = AgentSpec(
     interface=AgentInterface(waypoints=True, action=ActionSpaceType.TargetPose),
-    policy_builder=NonInteractivePolicy,
-    policy_params={"target_lane_index": {":J3_33": 1, "E3l-3": 1, "E3-35": 1}},
+    agent_builder=NonInteractiveAgent,
+    agent_params={"target_lane_index": {":J3_33": 1, "E3l-3": 1, "E3-35": 1}},
 )
 
 agent_specs = {AGENT_ID: agent_spec}

--- a/zoo/evaluation/scenarios/cross_1/ego_agent.py
+++ b/zoo/evaluation/scenarios/cross_1/ego_agent.py
@@ -1,15 +1,15 @@
 from smarts.core.utils.episodes import episodes
 from smarts.core.agent_interface import AgentInterface, ActionSpaceType
-from smarts.core.agent import AgentSpec, AgentPolicy
-from zoo.policies.non_interactive_policy import NonInteractivePolicy
+from smarts.core.agent import AgentSpec
+from zoo.policies.non_interactive_agent import NonInteractiveAgent
 
 
 AGENT_ID = "Agent-007"
 
 agent_spec = AgentSpec(
     interface=AgentInterface(waypoints=True, action=ActionSpaceType.TargetPose),
-    policy_builder=NonInteractivePolicy,
-    policy_params={"target_lane_index": {":J3_33": 1, "E3l-3": 1, "E3-35": 1}},
+    agent_builder=NonInteractiveAgent,
+    agent_params={"target_lane_index": {":J3_33": 1, "E3l-3": 1, "E3-35": 1}},
 )
 
 agent_specs = {AGENT_ID: agent_spec}

--- a/zoo/policies/__init__.py
+++ b/zoo/policies/__init__.py
@@ -3,16 +3,16 @@ from smarts.core.agent_interface import AgentInterface, AgentType
 from smarts.core.controllers import ActionSpaceType
 from smarts.zoo.registry import register
 
-from .keep_lane_policy import KeepLanePolicy
-from .non_interactive_policy import NonInteractivePolicy
+from .keep_lane_agent import KeepLaneAgent
+from .non_interactive_agent import NonInteractiveAgent
 
 
 register(
     locator="non-interactive-agent-v0",
     entry_point=lambda **kwargs: AgentSpec(
         interface=AgentInterface(waypoints=True, action=ActionSpaceType.TargetPose),
-        policy_builder=NonInteractivePolicy,
-        policy_params=kwargs,
+        agent_builder=NonInteractiveAgent,
+        agent_params=kwargs,
     ),
 )
 
@@ -20,6 +20,6 @@ register(
     locator="keep-lane-agent-v0",
     entry_point=lambda **kwargs: AgentSpec(
         interface=AgentInterface.from_type(AgentType.Laner, max_episode_steps=20000),
-        policy_builder=KeepLanePolicy,
+        agent_builder=KeepLaneAgent,
     ),
 )

--- a/zoo/policies/keep_lane_agent.py
+++ b/zoo/policies/keep_lane_agent.py
@@ -1,0 +1,6 @@
+from smarts.core.agent import Agent
+
+
+class KeepLaneAgent(Agent):
+    def act(self, obs):
+        return "keep_lane"

--- a/zoo/policies/keep_lane_policy.py
+++ b/zoo/policies/keep_lane_policy.py
@@ -1,6 +1,0 @@
-from smarts.core.agent import AgentPolicy
-
-
-class KeepLanePolicy(AgentPolicy):
-    def act(self, obs):
-        return "keep_lane"

--- a/zoo/policies/non_interactive_agent.py
+++ b/zoo/policies/non_interactive_agent.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-from smarts.core.agent import AgentPolicy
+from smarts.core.agent import Agent
 
 
-class NonInteractivePolicy(AgentPolicy):
+class NonInteractiveAgent(Agent):
     def __init__(self, speed=5, target_lane_index=None):
         self.speed = speed
         if target_lane_index is None:

--- a/zoo/policies/open-agent/open_agent/__init__.py
+++ b/zoo/policies/open-agent/open_agent/__init__.py
@@ -18,7 +18,7 @@ def entrypoint(
     debug=False,
     max_episode_steps=600,
 ):
-    from .policy import Policy
+    from .agent import OpEnAgent
 
     return AgentSpec(
         interface=AgentInterface(
@@ -27,8 +27,8 @@ def entrypoint(
             neighborhood_vehicles=True,
             max_episode_steps=max_episode_steps,
         ),
-        policy_params={"gains": gains, "debug": debug,},
-        policy_builder=Policy,
+        agent_params={"gains": gains, "debug": debug,},
+        agent_builder=OpEnAgent,
     )
 
 

--- a/zoo/policies/open-agent/open_agent/__init__.py
+++ b/zoo/policies/open-agent/open_agent/__init__.py
@@ -29,7 +29,6 @@ def entrypoint(
         ),
         policy_params={"gains": gains, "debug": debug,},
         policy_builder=Policy,
-        perform_self_test=False,
     )
 
 

--- a/zoo/policies/open-agent/open_agent/agent.py
+++ b/zoo/policies/open-agent/open_agent/agent.py
@@ -11,7 +11,7 @@ import casadi.casadi as cs
 import numpy as np
 import opengen as og
 
-from smarts.core.agent import AgentPolicy
+from smarts.core.agent import Agent
 from smarts.core.coordinates import Heading
 
 from .version import VERSION
@@ -341,7 +341,7 @@ def load_config():
         return json.load(config_fp)
 
 
-class Policy(AgentPolicy):
+class OpEnAgent(Agent):
     def __init__(
         self,
         gains={

--- a/zoo/policies/open-agent/setup.py
+++ b/zoo/policies/open-agent/setup.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from open_agent.version import VERSION
 
 try:
-    from open_agent.policy import compile_solver
+    from open_agent.agent import compile_solver
     import subprocess
     import shutil
     import glob

--- a/zoo/policies/open-agent/tests/test_open_agent.py
+++ b/zoo/policies/open-agent/tests/test_open_agent.py
@@ -4,7 +4,7 @@ from open_agent import entrypoint
 def test_building():
     agent_spec = entrypoint()
     agent = agent_spec.build_agent()
-    assert agent.policy.is_planner_running()
+    assert agent.is_planner_running()
 
 
 def test_build_multiple_agents():
@@ -12,4 +12,4 @@ def test_build_multiple_agents():
     agents = [agent_spec.build_agent() for _ in range(3)]
 
     for agent in agents:
-        assert agent.policy.is_planner_running()
+        assert agent.is_planner_running()

--- a/zoo/policies/rl-agent/rl_agent/__init__.py
+++ b/zoo/policies/rl-agent/rl_agent/__init__.py
@@ -41,7 +41,7 @@ def entrypoint(
             action_adapter=get_action_adapter(
                 target_speed=target_speed, lane_change_speed=lane_change_speed,
             ),
-            policy_builder=lambda: RLPolicy(
+            agent_builder=lambda: RLPolicy(
                 load_path=str(checkpoint_path.absolute()),
                 policy_name="default_policy",
                 observation_space=OBSERVATION_SPACE,

--- a/zoo/policies/rl-agent/rl_agent/__init__.py
+++ b/zoo/policies/rl-agent/rl_agent/__init__.py
@@ -9,7 +9,7 @@ from .lane_space import (
     agent_interface,
     get_observation_adapter,
 )
-from .policy import RLPolicy
+from .agent import RLAgent
 from . import checkpoint
 from smarts.zoo.registry import register
 
@@ -41,7 +41,7 @@ def entrypoint(
             action_adapter=get_action_adapter(
                 target_speed=target_speed, lane_change_speed=lane_change_speed,
             ),
-            agent_builder=lambda: RLPolicy(
+            agent_builder=lambda: RLAgent(
                 load_path=str(checkpoint_path.absolute()),
                 policy_name="default_policy",
                 observation_space=OBSERVATION_SPACE,

--- a/zoo/policies/rl-agent/rl_agent/agent.py
+++ b/zoo/policies/rl-agent/rl_agent/agent.py
@@ -13,7 +13,7 @@ from smarts.core.agent import Agent
 import tensorflow as tf
 
 
-class RLPolicy(Agent):
+class RLAgent(Agent):
     def __init__(self, load_path, policy_name, observation_space, action_space):
         self._checkpoint_path = load_path
         self._policy_name = policy_name

--- a/zoo/policies/rl-agent/rl_agent/policy.py
+++ b/zoo/policies/rl-agent/rl_agent/policy.py
@@ -8,12 +8,12 @@ import gym
 from ray.rllib.agents.ppo.ppo_tf_policy import PPOTFPolicy as LoadPolicy
 from ray.rllib.models import ModelCatalog
 
-from smarts.core.agent import AgentPolicy
+from smarts.core.agent import Agent
 
 import tensorflow as tf
 
 
-class RLPolicy(AgentPolicy):
+class RLPolicy(Agent):
     def __init__(self, load_path, policy_name, observation_space, action_space):
         self._checkpoint_path = load_path
         self._policy_name = policy_name


### PR DESCRIPTION
This PR merges Agent + AgentPolicy. The motivation for this change is to simplify our API surface area before we take on heterogeneous agent computing directly in #75.

AgentPolicy and Agent were nearly identical classes, doesn't make sense to have both.

I've made sure to keep these changes backwards compatible. We print noisy messages to our users to switch to the `Agent` class if we detect old api useage, but from a functional point of view, things should just work with the old API as well.


fixes #88 