### PR TITLE
WIP: Speed up imitation learning training by allowing users to jump to a timestamp

### DIFF
--- a/examples/history_vehicles_replacement_for_imitation_learning.py
+++ b/examples/history_vehicles_replacement_for_imitation_learning.py
@@ -41,7 +41,7 @@ def main(scenarios, headless, seed):
                 traffic_sim=SumoTrafficSimulation(headless=True, auto_start=True),
                 envision=Envision(),
             )
-            observations = smarts.reset(scenario)
+            observations = smarts.reset(scenario, mission.start_time)
 
             dones = {agent_id: False}
             while not dones[agent_id]:

--- a/smarts/core/smarts.py
+++ b/smarts/core/smarts.py
@@ -268,7 +268,7 @@ class SMARTS(ShowBase):
 
         self._teardown_agent_vehicles(agents_to_cleanup)
 
-    def reset(self, scenario: Scenario):
+    def reset(self, scenario: Scenario, start_time=0):
         if scenario == self._scenario and self._reset_agents_only:
             agent_ids = self._agent_manager.teardown_ego_agents()
             self._teardown_agent_vehicles(agent_ids)
@@ -283,7 +283,8 @@ class SMARTS(ShowBase):
         self._traffic_history_provider.set_replaced_ids(scenario.missions.keys())
 
         self.taskMgr.clock.reset()
-        self._elapsed_sim_time = 0
+        self.taskMgr.clock.set_frame_time(start_time)
+        self._elapsed_sim_time = start_time
 
         self._vehicle_states = [v.state for v in self._vehicle_index.vehicles]
         observations, _, _, _ = self._agent_manager.observe(self)

--- a/smarts/core/sumo_traffic_simulation.py
+++ b/smarts/core/sumo_traffic_simulation.py
@@ -289,17 +289,7 @@ class SumoTrafficSimulation:
         pass
 
     def step(self, provider_actions, dt, elapsed_sim_time) -> ProviderState:
-        """
-        Args:
-            dt: time (in seconds) to simulate during this simulation step
-            managed_vehicles: dict of {vehicle_id: (x, y, heading)}
-                !! The vehicle state should represent the state of the
-                !! vehicles at the start of the current simulation step
-        Returns:
-            ProviderState representing the state of the SUMO simulation
-        """
-        # we tell SUMO to step through dt more seconds of the simulation
-        self._cumulative_sim_seconds += dt
+        self._cumulative_sim_seconds = elapsed_sim_time
         self._traci_conn.simulationStep(self._cumulative_sim_seconds)
 
         return self._compute_provider_state()

--- a/smarts/core/traffic_history_provider.py
+++ b/smarts/core/traffic_history_provider.py
@@ -21,7 +21,7 @@ from itertools import cycle
 from typing import Set
 
 from .controllers import ActionSpaceType
-from .coordinates import Pose, Heading
+from .coordinates import Pose, Heading, BoundingBox
 from .provider import ProviderState
 from .vehicle import VEHICLE_CONFIGS, VehicleState
 

--- a/smarts/core/trap_manager.py
+++ b/smarts/core/trap_manager.py
@@ -54,7 +54,7 @@ class Trap:
         return elapsed_sim_time - self.emit_agent_at > self.patience
 
     def reset_trigger(self):
-        pass
+        self.emit_agent_at = float("+inf")
 
     @property
     def reactivates(self):
@@ -97,18 +97,6 @@ class TrapManager:
             mission_planner.plan(mission)
 
             trap = self._mission2trap(scenario.road_network, mission)
-            trap_config = self._mission2trap(scenario.road_network, mission)
-            trap_configs.append((agent_id, trap_config))
-
-        for agent_id, tc in trap_configs:
-            trap = Trap(
-                geometry=tc.zone.to_geometry(scenario.road_network),
-                mission=tc.mission,
-                exclusion_prefixes=tc.exclusion_prefixes,
-                reactivation_time=tc.reactivation_time,
-                emit_agent_at=tc.activation_delay,
-                patience=tc.patience,
-            )
             self.add_trap_for_agent_id(agent_id, trap)
 
     def add_trap_for_agent_id(self, agent_id, trap: Trap):
@@ -206,6 +194,7 @@ class TrapManager:
                     sim, vehicle_id, agent_id, mission
                 )
             elif trap.patience_expired(sim.elapsed_sim_time):
+                mission = trap.mission
                 if len(agent_vehicle_comp) > 0:
                     agent_vehicle_comp.sort(
                         key=lambda v: squared_dist(v[0], mission.start.position)
@@ -341,7 +330,7 @@ class TrapManager:
             # TODO: Make reactivation and activation delay configurable through
             #   scenario studio
             reactivation_time=-1,
-            remaining_time_to_reactivation=activation_delay,
+            emit_agent_at=activation_delay,
             patience=patience,
             mission=mission,
             exclusion_prefixes=mission.entry_tactic.exclusion_prefixes,


### PR DESCRIPTION
During the training, we will replace one of the vehicles in history data with an agent. However, this agent might appear in the middle of an episode but SMARTS still step through the replay data from the beginning until the agent shows up. 

In this PR, I exposed a param `start_time` to allow us to set the frame start time.