### PR TITLE
Only count waypoint if we have travelled sufficiently from prev wp

### DIFF
--- a/smarts/core/sensors.py
+++ b/smarts/core/sensors.py
@@ -862,7 +862,7 @@ class TripMeterSensor(Sensor):
             or wp_edge in self._mission_planner.route.edges
         )
 
-        if most_recent_wp != new_wp and should_count_wp:
+        if np.linalg.norm(new_wp.pos - most_recent_wp.pos) > 0.5 and should_count_wp:
             self._dist_travelled += TripMeterSensor._compute_additional_dist_travelled(
                 most_recent_wp, new_wp
             )

--- a/smarts/core/sensors.py
+++ b/smarts/core/sensors.py
@@ -862,8 +862,11 @@ class TripMeterSensor(Sensor):
             or wp_edge in self._mission_planner.route.edges
         )
 
-        threshold_for_counting_wp = 0.5 # meters from last tracked waypoint
-        if np.linalg.norm(new_wp.pos - most_recent_wp.pos) > threshold_for_counting_wp and should_count_wp:
+        threshold_for_counting_wp = 0.5  # meters from last tracked waypoint
+        if (
+            np.linalg.norm(new_wp.pos - most_recent_wp.pos) > threshold_for_counting_wp
+            and should_count_wp
+        ):
             self._dist_travelled += TripMeterSensor._compute_additional_dist_travelled(
                 most_recent_wp, new_wp
             )

--- a/smarts/core/sensors.py
+++ b/smarts/core/sensors.py
@@ -862,7 +862,8 @@ class TripMeterSensor(Sensor):
             or wp_edge in self._mission_planner.route.edges
         )
 
-        if np.linalg.norm(new_wp.pos - most_recent_wp.pos) > 0.5 and should_count_wp:
+        threshold_for_counting_wp = 0.5 # meters from last tracked waypoint
+        if np.linalg.norm(new_wp.pos - most_recent_wp.pos) > threshold_for_counting_wp and should_count_wp:
             self._dist_travelled += TripMeterSensor._compute_additional_dist_travelled(
                 most_recent_wp, new_wp
             )


### PR DESCRIPTION
With the equally spaced waypoint change, we can no longer rely on the fact that waypoints are fixed on the map, so we have to track distance from last waypoint instead.