### PR TITLE
fix: some agents use a `policy` attribute, we need to break backwards compat.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,6 @@ constantly==15.1.0
 coverage==5.3
 cycler==0.10.0
 Cython==0.29.21
-debtcollector==2.2.0
 decorator==4.4.2
 dm-tree==0.1.5
 evdev==1.3.0
@@ -63,7 +62,6 @@ panda3d==1.10.7
 panda3d-gltf==0.10
 panda3d-simplepbr==0.7
 pandas==1.1.3
-pbr==5.5.1
 Pillow==8.0.0
 pluggy==0.13.1
 protobuf==3.13.0

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,6 @@ setup(
         # The following are for /smarts/zoo
         "twisted",
         "PyYAML",
-        "debtcollector",
     ],
     extras_require={
         "train": ["tensorflow==2.2", "torch==1.3.0", "torchvision==0.4.1"],

--- a/smarts/core/agent.py
+++ b/smarts/core/agent.py
@@ -21,7 +21,6 @@ from typing import Optional, Any, Callable
 from dataclasses import dataclass, replace
 import warnings
 
-from debtcollector import removals
 import cloudpickle
 
 from .agent_interface import AgentInterface
@@ -31,14 +30,6 @@ warnings.simplefilter("once")
 
 class Agent:
     """The base class for agents"""
-
-    @removals.removed_property(
-        message="Simply use the agent instance as is, Agent and AgentPolicy have been merged"
-    )
-    @property
-    def policy(self):
-        """ Backwards compatibility with the old Agent class"""
-        return self
 
     @classmethod
     def from_function(cls, agent_function: Callable):
@@ -67,8 +58,6 @@ class Agent:
 
 # Remain backwards compatible with existing Agent's
 class AgentPolicy(Agent):
-    # we cannot use debtcollector here to signal deprecation because the wrapper object is
-    # not pickleable, instead we simply print.
     print("[DEPRECATED] AgentPolicy has been replaced with `smarts.core.agent.Agent`")
 
 


### PR DESCRIPTION
In particular, the RLAgent stores the tensorflow model on `self.policy`, this conflicts with the dummy `policy` property I had added to the Agent class to keep backwards compatibility