### PR TITLE
Bump tensorflow version for security reasons

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -111,7 +111,7 @@ tabulate==0.8.7
 tensorboard==2.2.2
 tensorboard-plugin-wit==1.7.0
 tensorboardX==2.1
-tensorflow==2.2.0
+tensorflow==2.2.1
 tensorflow-estimator==2.2.0
 termcolor==1.1.0
 threadpoolctl==2.1.0

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         #       and ray[rllib] under [train] it  prevents rllib from getting installed.
         #       For simplicity we just install both here. In the future we may want to
         #       address this bug head on to keep our SMARTS base install more lean.
-        "ray[rllib]==0.8.*",  # We use Ray for our multiprocessing needs
+        "ray[rllib]==0.8.3",  # We use Ray for our multiprocessing needs
         # The following are for Scenario Studio
         "yattag",
         # The following are for testing
@@ -57,7 +57,7 @@ setup(
         # The following are for /envision
         "tornado",
         "websocket-client",
-        "cloudpickle<1.4.*",
+        "cloudpickle<1.4.0",
         # The following are for the /smarts/algorithms
         "matplotlib",
         "scikit-image",
@@ -66,7 +66,7 @@ setup(
         "PyYAML",
     ],
     extras_require={
-        "train": ["tensorflow==2.2.*", "torch==1.3.*", "torchvision==0.4.*"],
+        "train": ["tensorflow==2.2.1", "torch==1.3.0", "torchvision==0.4.1"],
         "dev": [
             "black==19.10b0",
             "sphinx",

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         #       and ray[rllib] under [train] it  prevents rllib from getting installed.
         #       For simplicity we just install both here. In the future we may want to
         #       address this bug head on to keep our SMARTS base install more lean.
-        "ray[rllib]==0.8.3",  # We use Ray for our multiprocessing needs
+        "ray[rllib]==0.8.*",  # We use Ray for our multiprocessing needs
         # The following are for Scenario Studio
         "yattag",
         # The following are for testing
@@ -57,7 +57,7 @@ setup(
         # The following are for /envision
         "tornado",
         "websocket-client",
-        "cloudpickle<1.4.0",
+        "cloudpickle<1.4.*",
         # The following are for the /smarts/algorithms
         "matplotlib",
         "scikit-image",
@@ -66,7 +66,7 @@ setup(
         "PyYAML",
     ],
     extras_require={
-        "train": ["tensorflow==2.2", "torch==1.3.0", "torchvision==0.4.1"],
+        "train": ["tensorflow==2.2.*", "torch==1.3.*", "torchvision==0.4.*"],
         "dev": [
             "black==19.10b0",
             "sphinx",


### PR DESCRIPTION
This patch should fix cases using `requirements.txt` (i.e. docker and the CI) and set `Setup.py` to use the newest revision of `2.2.*`