### PR TITLE
Destroy SMARTS instance at end of training to fix multiple `ShowBase` error

### DIFF
--- a/examples/history_vehicles_replacement_for_imitation_learning.py
+++ b/examples/history_vehicles_replacement_for_imitation_learning.py
@@ -52,6 +52,8 @@ def main(scenarios, headless, seed):
                     {agent_id: agent_action}
                 )
 
+            smarts.destroy()
+
 
 if __name__ == "__main__":
     parser = default_argument_parser("history-vehicles-replacement-example")


### PR DESCRIPTION
Relevant to #184

@zbzhu99's training example is based on `history_vehicles_replacement_for_imitation_learning.py`. Both of these two scripts won't destroy the SMARTS instance, which causes the multiple `ShowBase` error.