### PR TITLE
Mitigate failures in `test_rllib_hiway_env`

### DIFF
--- a/smarts/core/remote_agent.py
+++ b/smarts/core/remote_agent.py
@@ -100,7 +100,8 @@ class RemoteAgent:
         )
 
     def terminate(self):
-        atexit.unregister(self.terminate)
+        if atexit.unregister is not None:
+            atexit.unregister(self.terminate)
         if self._agent_proc:
             if self._conn:
                 self._conn.close()

--- a/smarts/core/remote_agent_buffer.py
+++ b/smarts/core/remote_agent_buffer.py
@@ -40,7 +40,8 @@ class RemoteAgentBuffer:
         self.destroy()
 
     def destroy(self):
-        atexit.unregister(self.destroy)
+        if atexit.unregister is not None:
+            atexit.unregister(self.destroy)
         self._quiescing = True
         if self._replenish_thread_is_running():
             self._replenish_thread.join()  # wait for the replenisher to finish

--- a/smarts/env/tests/test_rllib_hiway_env.py
+++ b/smarts/env/tests/test_rllib_hiway_env.py
@@ -2,7 +2,9 @@ from pathlib import Path
 
 import gym
 import numpy as np
+import psutil
 import pytest
+import ray
 from ray import tune
 from ray.rllib.models import ModelCatalog
 from ray.rllib.models.tf.fcnet_v2 import FullyConnectedNetwork
@@ -115,6 +117,9 @@ def test_rllib_hiway_env(rllib_agent):
         "num_workers": 1,
     }
 
+    # Test tune with the number of physical cpus
+    num_cpus = max(1, psutil.cpu_count(logical=False) - 1)
+    ray.init(num_cpus=num_cpus, num_gpus=0)
     analysis = tune.run(
         "PPO",
         name="RLlibHiWayEnv test",

--- a/smarts/env/tests/test_rllib_hiway_env.py
+++ b/smarts/env/tests/test_rllib_hiway_env.py
@@ -117,8 +117,8 @@ def test_rllib_hiway_env(rllib_agent):
         "num_workers": 1,
     }
 
-    # Test tune with the number of physical cpus
-    num_cpus = max(1, psutil.cpu_count(logical=False) - 1)
+    # Test tune with the number of physical cpus with a minimum of 2 cpus
+    num_cpus = max(2, psutil.cpu_count(logical=False) - 1)
     ray.init(num_cpus=num_cpus, num_gpus=0)
     analysis = tune.run(
         "PPO",


### PR DESCRIPTION
The goal here is to lower the number of CPUs used by `ray.tune` and further lower the memory used to support those CPUs since there only needs to be a small number of workers to test out `rllib_hiway_env` we do not need all of the CPUs to be active. 

The issue that brought this up: https://github.com/huawei-noah/SMARTS/issues/181