### PR TITLE
Perform sensor stepping for all vehicles with sensors

### DIFF
--- a/smarts/core/agent_manager.py
+++ b/smarts/core/agent_manager.py
@@ -208,8 +208,7 @@ class AgentManager:
         return sim.vehicle_index.vehicle_by_id(vehicle_id).trip_meter_sensor()
 
     def step_sensors(self, sim):
-        for vehicle_id in sim.vehicle_index.sensor_states().keys():
-            sensor_state = sim.vehicle_index.sensor_states()[vehicle_id]
+        for vehicle_id, sensor_state in sim.vehicle_index.sensor_states().items():
             Sensors.step(self, sensor_state)
 
             vehicle = sim.vehicle_index.vehicle_by_id(vehicle_id)

--- a/smarts/core/agent_manager.py
+++ b/smarts/core/agent_manager.py
@@ -120,7 +120,7 @@ class AgentManager:
         for v_id in vehicle_ids:
             vehicle = sim.vehicle_index.vehicle_by_id(v_id)
             agent_id = self._vehicle_with_sensors[v_id]
-            sensor_state = sim.vehicle_index.sensor_states()[vehicle.id]
+            sensor_state = sim.vehicle_index.sensor_state_for_vehicle_id(vehicle.id)
             observations[agent_id], dones[agent_id] = Sensors.observe(
                 sim, agent_id, sensor_state, vehicle
             )
@@ -152,7 +152,9 @@ class AgentManager:
                 ]
                 # returns format of {<agent_id>: {<vehicle_id>: {...}}}
                 sensor_states = {
-                    vehicle.id: sim.vehicle_index.sensor_states()[vehicle.id]
+                    vehicle.id: sim.vehicle_index.sensor_state_for_vehicle_id(
+                        vehicle.id
+                    )
                     for vehicle in vehicles
                 }
                 observations[agent_id], dones[agent_id] = Sensors.observe_batch(
@@ -180,7 +182,7 @@ class AgentManager:
                 )
 
                 vehicle = sim.vehicle_index.vehicle_by_id(vehicle_ids[0])
-                sensor_state = sim.vehicle_index.sensor_states()[vehicle.id]
+                sensor_state = sim.vehicle_index.sensor_state_for_vehicle_id(vehicle.id)
                 observations[agent_id], dones[agent_id] = Sensors.observe(
                     sim, agent_id, sensor_state, vehicle
                 )
@@ -208,7 +210,7 @@ class AgentManager:
         return sim.vehicle_index.vehicle_by_id(vehicle_id).trip_meter_sensor()
 
     def step_sensors(self, sim):
-        for vehicle_id, sensor_state in sim.vehicle_index.sensor_states().items():
+        for vehicle_id, sensor_state in sim.vehicle_index.sensor_states_items():
             Sensors.step(self, sensor_state)
 
             vehicle = sim.vehicle_index.vehicle_by_id(vehicle_id)

--- a/smarts/core/agent_manager.py
+++ b/smarts/core/agent_manager.py
@@ -120,7 +120,7 @@ class AgentManager:
         for v_id in vehicle_ids:
             vehicle = sim.vehicle_index.vehicle_by_id(v_id)
             agent_id = self._vehicle_with_sensors[v_id]
-            sensor_state = sim.vehicle_index.sensor_state_for_vehicle_id(vehicle.id)
+            sensor_state = sim.vehicle_index.sensor_states()[vehicle.id]
             observations[agent_id], dones[agent_id] = Sensors.observe(
                 sim, agent_id, sensor_state, vehicle
             )
@@ -152,9 +152,7 @@ class AgentManager:
                 ]
                 # returns format of {<agent_id>: {<vehicle_id>: {...}}}
                 sensor_states = {
-                    vehicle.id: sim.vehicle_index.sensor_state_for_vehicle_id(
-                        vehicle.id
-                    )
+                    vehicle.id: sim.vehicle_index.sensor_states()[vehicle.id]
                     for vehicle in vehicles
                 }
                 observations[agent_id], dones[agent_id] = Sensors.observe_batch(
@@ -182,7 +180,7 @@ class AgentManager:
                 )
 
                 vehicle = sim.vehicle_index.vehicle_by_id(vehicle_ids[0])
-                sensor_state = sim.vehicle_index.sensor_state_for_vehicle_id(vehicle.id)
+                sensor_state = sim.vehicle_index.sensor_states()[vehicle.id]
                 observations[agent_id], dones[agent_id] = Sensors.observe(
                     sim, agent_id, sensor_state, vehicle
                 )
@@ -209,17 +207,14 @@ class AgentManager:
     def _vehicle_score(self, vehicle_id, sim):
         return sim.vehicle_index.vehicle_by_id(vehicle_id).trip_meter_sensor()
 
-    def step_agent_sensors(self, sim):
-        for agent_id in self.active_agents:
-            for vehicle_id in sim.vehicle_index.vehicle_ids_by_actor_id(
-                agent_id, include_shadowers=True
-            ):
-                sensor_state = sim.vehicle_index.sensor_state_for_vehicle_id(vehicle_id)
-                Sensors.step(self, sensor_state)
+    def step_sensors(self, sim):
+        for vehicle_id in sim.vehicle_index.sensor_states().keys():
+            sensor_state = sim.vehicle_index.sensor_states()[vehicle_id]
+            Sensors.step(self, sensor_state)
 
-                vehicle = sim.vehicle_index.vehicle_by_id(vehicle_id)
-                for sensor in vehicle.sensors.values():
-                    sensor.step()
+            vehicle = sim.vehicle_index.vehicle_by_id(vehicle_id)
+            for sensor in vehicle.sensors.values():
+                sensor.step()
 
     def _filter_for_active_ego(self, dict_):
         return {

--- a/smarts/core/sensors.py
+++ b/smarts/core/sensors.py
@@ -342,7 +342,7 @@ class Sensors:
 
         # TODO: check vehicles for agent individually
         for vehicle in vehicles:
-            sensor_state = sim.vehicle_index.sensor_states()[vehicle.id]
+            sensor_state = sim.vehicle_index.sensor_state_for_vehicle_id(vehicle.id)
             route_edges = sensor_state.mission_planner.route.edges
 
             vehicle_pos = vehicle.position[:2]

--- a/smarts/core/sensors.py
+++ b/smarts/core/sensors.py
@@ -342,7 +342,7 @@ class Sensors:
 
         # TODO: check vehicles for agent individually
         for vehicle in vehicles:
-            sensor_state = sim.vehicle_index.sensor_state_for_vehicle_id(vehicle.id)
+            sensor_state = sim.vehicle_index.sensor_states()[vehicle.id]
             route_edges = sensor_state.mission_planner.route.edges
 
             vehicle_pos = vehicle.position[:2]

--- a/smarts/core/smarts.py
+++ b/smarts/core/smarts.py
@@ -738,7 +738,7 @@ class SMARTS(ShowBase):
         #       its goal. Is this the behaviour we want?
         vehicles = self._vehicle_index.vehicles_by_actor_id(agent_id)
         for vehicle in vehicles:
-            sensor_state = self._vehicle_index.sensor_states()[vehicle.id]
+            sensor_state = self._vehicle_index.sensor_state_for_vehicle_id(vehicle.id)
             distance_travelled = vehicle.trip_meter_sensor()
             mission = sensor_state.mission_planner.mission
             reached_goal = mission.is_complete(vehicle, distance_travelled)
@@ -812,7 +812,9 @@ class SMARTS(ShowBase):
                     controller_state = self._vehicle_index.controller_state_for_vehicle_id(
                         vehicle.id
                     )
-                    sensor_state = self._vehicle_index.sensor_states()[vehicle.id]
+                    sensor_state = self._vehicle_index.sensor_state_for_vehicle_id(
+                        vehicle.id
+                    )
                     # TODO: Support performing batched actions
                     Controllers.perform_action(
                         self,
@@ -880,9 +882,9 @@ class SMARTS(ShowBase):
 
                 if self._agent_manager.is_ego(agent_id):
                     actor_type = envision_types.TrafficActorType.Agent
-                    mission_route_geometry = self._vehicle_index.sensor_states()[
+                    mission_route_geometry = self._vehicle_index.sensor_state_for_vehicle_id(
                         v.vehicle_id
-                    ].mission_planner.route.geometry
+                    ).mission_planner.route.geometry
                 else:
                     actor_type = envision_types.TrafficActorType.SocialAgent
                     mission_route_geometry = None

--- a/smarts/core/smarts.py
+++ b/smarts/core/smarts.py
@@ -225,11 +225,11 @@ class SMARTS(ShowBase):
         self._vehicle_states = [v.state for v in self._vehicle_index.vehicles]
 
         # Agents
-        self._agent_manager.step_agent_sensors(self)
+        self._agent_manager.step_sensors(self)
 
         # Panda3D
         # runs through the render pipeline
-        # MUST perform this after step_agent_sensors() above, and before observe() below,
+        # MUST perform this after step_sensors() above, and before observe() below,
         # so that all updates are ready before rendering happens per frame
         self.taskMgr.mgr.poll()
 
@@ -738,7 +738,7 @@ class SMARTS(ShowBase):
         #       its goal. Is this the behaviour we want?
         vehicles = self._vehicle_index.vehicles_by_actor_id(agent_id)
         for vehicle in vehicles:
-            sensor_state = self._vehicle_index.sensor_state_for_vehicle_id(vehicle.id)
+            sensor_state = self._vehicle_index.sensor_states()[vehicle.id]
             distance_travelled = vehicle.trip_meter_sensor()
             mission = sensor_state.mission_planner.mission
             reached_goal = mission.is_complete(vehicle, distance_travelled)
@@ -812,9 +812,7 @@ class SMARTS(ShowBase):
                     controller_state = self._vehicle_index.controller_state_for_vehicle_id(
                         vehicle.id
                     )
-                    sensor_state = self._vehicle_index.sensor_state_for_vehicle_id(
-                        vehicle.id
-                    )
+                    sensor_state = self._vehicle_index.sensor_states()[vehicle.id]
                     # TODO: Support performing batched actions
                     Controllers.perform_action(
                         self,
@@ -882,9 +880,9 @@ class SMARTS(ShowBase):
 
                 if self._agent_manager.is_ego(agent_id):
                     actor_type = envision_types.TrafficActorType.Agent
-                    mission_route_geometry = self._vehicle_index.sensor_state_for_vehicle_id(
+                    mission_route_geometry = self._vehicle_index.sensor_states()[
                         v.vehicle_id
-                    ).mission_planner.route.geometry
+                    ].mission_planner.route.geometry
                 else:
                     actor_type = envision_types.TrafficActorType.SocialAgent
                     mission_route_geometry = None

--- a/smarts/core/vehicle_index.py
+++ b/smarts/core/vehicle_index.py
@@ -526,8 +526,11 @@ class VehicleIndex:
 
         return vehicle
 
-    def sensor_states(self):
-        return self._sensor_states
+    def sensor_states_items(self):
+        return self._sensor_states.items()
+
+    def sensor_state_for_vehicle_id(self, vehicle_id):
+        return self._sensor_states[vehicle_id]
 
     def controller_state_for_vehicle_id(self, vehicle_id):
         return self._controller_states[vehicle_id]

--- a/smarts/core/vehicle_index.py
+++ b/smarts/core/vehicle_index.py
@@ -526,8 +526,8 @@ class VehicleIndex:
 
         return vehicle
 
-    def sensor_state_for_vehicle_id(self, vehicle_id):
-        return self._sensor_states[vehicle_id]
+    def sensor_states(self):
+        return self._sensor_states
 
     def controller_state_for_vehicle_id(self, vehicle_id):
         return self._controller_states[vehicle_id]


### PR DESCRIPTION
Currently, we manually match the vehicle list to be the same for step_sensors() and observe() in agent manager to avoid step mismatch. However, this is error-prone. 

Instead, it would be more robust to perform sensor stepping for all vehicles with sensors.

This is to address improvement suggestion by @Gamenot in https://github.com/huawei-noah/SMARTS/pull/169. 

