### PR TITLE
Disable memory tests

### DIFF
--- a/.github/workflows/ci-test-memory-growth.yml
+++ b/.github/workflows/ci-test-memory-growth.yml
@@ -3,7 +3,7 @@ name: SMARTS CI Master
 on:
   push:
     branches:
-      - master
+      - disabled
 
 env:
   venv_dir: .venv


### PR DESCRIPTION
We are disabling the memory tests because things like `logging.logger` mess with the memory tests.