### PR TITLE
Use hijack state instead of prev_pos for transitions

### DIFF
--- a/scenarios/loop/scenario.py
+++ b/scenarios/loop/scenario.py
@@ -30,12 +30,6 @@ laner_actor = t.SocialAgentActor(
     name="keep-lane-agent", agent_locator="zoo.policies:keep-lane-agent-v0",
 )
 
-slow_actor = t.SocialAgentActor(
-    name=f"slow-agent",
-    agent_locator="zoo.policies:non-interactive-agent-v0",
-    policy_kwargs={"speed": 10},
-)
-
 gen_scenario(
     t.Scenario(
         traffic={"basic": traffic},
@@ -46,10 +40,8 @@ gen_scenario(
             t.Bubble(
                 zone=t.PositionalZone(pos=(50, 0), size=(10, 15)),
                 margin=5,
-                actor=slow_actor,
-                follow_actor_id=t.Bubble.to_actor_id(
-                    open_agent_actor, mission_group="all"
-                ),
+                actor=open_agent_actor,
+                follow_actor_id=t.Bubble.to_actor_id(laner_actor, mission_group="all"),
                 follow_offset=(-7, 10),
             ),
         ],

--- a/scenarios/straight/scenario.py
+++ b/scenarios/straight/scenario.py
@@ -27,11 +27,11 @@ traffic = t.Traffic(
 scenario = t.Scenario(
     traffic={"all": traffic},
     bubbles=[
-        # t.Bubble(
-        #     zone=t.PositionalZone(pos=(50, 0), size=(40, 20)),
-        #     margin=5,
-        #     actor=trajectory_boid_agent,
-        # ),
+        t.Bubble(
+            zone=t.PositionalZone(pos=(50, 0), size=(40, 20)),
+            margin=5,
+            actor=trajectory_boid_agent,
+        ),
         t.Bubble(
             zone=t.PositionalZone(pos=(150, 0), size=(50, 20)),
             margin=5,

--- a/scenarios/straight/scenario.py
+++ b/scenarios/straight/scenario.py
@@ -27,11 +27,11 @@ traffic = t.Traffic(
 scenario = t.Scenario(
     traffic={"all": traffic},
     bubbles=[
-        t.Bubble(
-            zone=t.PositionalZone(pos=(50, 0), size=(40, 20)),
-            margin=5,
-            actor=trajectory_boid_agent,
-        ),
+        # t.Bubble(
+        #     zone=t.PositionalZone(pos=(50, 0), size=(40, 20)),
+        #     margin=5,
+        #     actor=trajectory_boid_agent,
+        # ),
         t.Bubble(
             zone=t.PositionalZone(pos=(150, 0), size=(50, 20)),
             margin=5,

--- a/smarts/core/trap_manager.py
+++ b/smarts/core/trap_manager.py
@@ -256,7 +256,7 @@ class TrapManager:
         planner.plan(mission=mission)
 
         # Apply agent vehicle association.
-        sim.vehicle_index.prepare_for_agent_control(
+        sim.vehicle_index.start_agent_observation(
             sim, vehicle_id, agent_id, agent_interface, planner
         )
         vehicle = sim.vehicle_index.switch_control_to_agent(

--- a/smarts/core/vehicle_index.py
+++ b/smarts/core/vehicle_index.py
@@ -255,7 +255,7 @@ class VehicleIndex:
 
         return positions[0] if len(positions) > 0 else None
 
-    def prepare_for_agent_control(
+    def start_agent_observation(
         self, sim, vehicle_id, agent_id, agent_interface, mission_planner, boid=False
     ):
         vehicle = self._vehicles[vehicle_id]
@@ -284,21 +284,6 @@ class VehicleIndex:
         #      chassis-specific states, such as tire rotation.
 
         return vehicle
-
-    def attach_sensors_to_vehicle(
-        self, sim, vehicle_id, agent_interface, mission_planner
-    ):
-        vehicle = self._vehicles[vehicle_id]
-
-        Vehicle.attach_sensors_to_vehicle(
-            sim, vehicle, agent_interface, mission_planner
-        )
-        self._sensor_states[vehicle_id] = SensorState(
-            agent_interface.max_episode_steps, mission_planner=mission_planner,
-        )
-        self._controller_states[vehicle_id] = ControllerState.from_action_space(
-            agent_interface.action_space, vehicle.position, sim
-        )
 
     def switch_control_to_agent(
         self, sim, vehicle_id, agent_id, boid=False, hijacking=False, recreate=False
@@ -329,6 +314,60 @@ class VehicleIndex:
         )
 
         return vehicle
+
+    def stop_agent_observation(self, vehicle_id):
+        vehicle = self._vehicles[vehicle_id]
+        Vehicle.detach_all_sensors_from_vehicle(vehicle)
+
+        v_index = self._controlled_by["vehicle_id"] == vehicle_id
+        entity = self._controlled_by[v_index][0]
+        entity = _ControlEntity(*entity)
+        self._controlled_by[v_index] = tuple(entity._replace(shadow_actor_id=""))
+
+        return vehicle
+
+    def relinquish_agent_control(self, sim, vehicle_id, social_vehicle_id):
+        self._log.debug(
+            f"Relinquishing agent control v_id={vehicle_id} sv_id={social_vehicle_id}"
+        )
+        vehicle = self._vehicles[vehicle_id]
+        box_chassis = BoxChassis(
+            pose=vehicle.chassis.pose,
+            speed=vehicle.chassis.speed,
+            dimensions=vehicle.chassis.dimensions,
+            bullet_client=sim.bc,
+        )
+        vehicle.swap_chassis(box_chassis)
+
+        v_index = self._controlled_by["vehicle_id"] == vehicle_id
+        entity = self._controlled_by[v_index][0]
+        entity = _ControlEntity(*entity)
+        self._controlled_by[v_index] = tuple(
+            entity._replace(
+                actor_type=_ActorType.Social,
+                actor_id="",
+                shadow_actor_id="",
+                is_boid=False,
+                is_hijacked=False,
+            )
+        )
+
+        return vehicle
+
+    def attach_sensors_to_vehicle(
+        self, sim, vehicle_id, agent_interface, mission_planner
+    ):
+        vehicle = self._vehicles[vehicle_id]
+
+        Vehicle.attach_sensors_to_vehicle(
+            sim, vehicle, agent_interface, mission_planner
+        )
+        self._sensor_states[vehicle_id] = SensorState(
+            agent_interface.max_episode_steps, mission_planner=mission_planner,
+        )
+        self._controller_states[vehicle_id] = ControllerState.from_action_space(
+            agent_interface.action_space, vehicle.position, sim
+        )
 
     def _switch_control_to_agent_recreate(
         self, sim, vehicle_id, agent_id, boid, hijacking
@@ -391,35 +430,6 @@ class VehicleIndex:
         )
 
         return new_vehicle
-
-    def relinquish_agent_control(self, sim, vehicle_id, social_vehicle_id):
-        self._log.debug(
-            f"Relinquishing agent control v_id={vehicle_id} sv_id={social_vehicle_id}"
-        )
-        vehicle = self._vehicles[vehicle_id]
-        box_chassis = BoxChassis(
-            pose=vehicle.chassis.pose,
-            speed=vehicle.chassis.speed,
-            dimensions=vehicle.chassis.dimensions,
-            bullet_client=sim.bc,
-        )
-        vehicle.swap_chassis(box_chassis)
-        Vehicle.detach_all_sensors_from_vehicle(vehicle)
-
-        v_index = self._controlled_by["vehicle_id"] == vehicle_id
-        entity = self._controlled_by[v_index][0]
-        entity = _ControlEntity(*entity)
-        self._controlled_by[v_index] = tuple(
-            entity._replace(
-                actor_type=_ActorType.Social,
-                actor_id="",
-                shadow_actor_id="",
-                is_boid=False,
-                is_hijacked=False,
-            )
-        )
-
-        return vehicle
 
     # TODO: Collapse build_social_vehicle and build_agent_vehicle
     def build_agent_vehicle(


### PR DESCRIPTION
closes #216 

Turns out the `in_*(prev_pos)` mechanics don't work for travelling bubbles because the previous and current position could be nearly identical while the travelling bubble forces a state change.

**(some other tests are failing now, needs further investigation)**