### PR TITLE
Fix collision detection

### DIFF
--- a/smarts/core/sensors.py
+++ b/smarts/core/sensors.py
@@ -285,7 +285,7 @@ class Sensors:
         done_criteria = interface.done_criteria
 
         collided = (
-            sim.vehicle_did_collide(vehicle) if done_criteria.collision else False
+            sim.vehicle_did_collide(vehicle.id) if done_criteria.collision else False
         )
         is_off_road = (
             cls._vehicle_is_off_road(sim, vehicle) if done_criteria.off_road else False

--- a/smarts/core/smarts.py
+++ b/smarts/core/smarts.py
@@ -833,8 +833,7 @@ class SMARTS(ShowBase):
             for bullet_id in collidee_bullet_ids:
                 collidee = self._bullet_id_to_vehicle(bullet_id)
                 collision = self._node_to_collision(collidee.np.node())
-                agent_id = self._vehicle_index.actor_id_from_vehicle_id(vehicle_id)
-                self._vehicle_collisions[agent_id].append(collision)
+                self._vehicle_collisions[vehicle_id].append(collision)
 
     def _bullet_id_to_vehicle(self, bullet_id):
         for vehicle in self._vehicle_index.vehicles:

--- a/smarts/core/tests/test_collision.py
+++ b/smarts/core/tests/test_collision.py
@@ -247,10 +247,13 @@ def test_sim_level_collision(smarts, scenarios):
     smarts.reset(scenario)
 
     collisions = []
+    agent_dones = []
 
     for _ in range(30):
-        observations, _, _, _ = smarts.step({AGENT_1: "keep_lane"})
+        observations, _, dones, _ = smarts.step({AGENT_1: "keep_lane"})
         if AGENT_1 in observations:
             collisions.extend(observations[AGENT_1].events.collisions)
+            agent_dones.append(dones[AGENT_1])
 
     assert len(collisions) > 0
+    assert any(agent_dones)


### PR DESCRIPTION
The issue was caused by:
1. The sim maintains the wrong keys of the agent collisions.
2. `sensor.py` passes a wrong vehicle ID to query the collision.

close #221 

* [x] Add a sim-level test to ensure collision detection works (Previously we test the detection at chassis level)
* [x] Fix the bug.