### PR TITLE
Disable logging warning and below to re-enable Memory Tests

### DIFF
--- a/smarts/core/tests/test_smarts_memory_growth.py
+++ b/smarts/core/tests/test_smarts_memory_growth.py
@@ -15,6 +15,7 @@ TIMESTEP_SEC = 0.1
 # Disable logging because it causes memory growth
 logging.disable(logging.WARNING)
 
+
 @pytest.fixture
 def agent_id():
     return "Agent-006"

--- a/smarts/core/tests/test_smarts_memory_growth.py
+++ b/smarts/core/tests/test_smarts_memory_growth.py
@@ -1,4 +1,5 @@
 import gc
+import logging
 
 import gym
 import pytest
@@ -11,7 +12,8 @@ from smarts.core.agent import AgentSpec, AgentPolicy
 SMARTS_MEMORY_GROWTH_LIMIT = 2e5
 EPISODE_MEMORY_GROWTH_LIMIT = 2e5
 TIMESTEP_SEC = 0.1
-
+# Disable logging because it causes memory growth
+logging.disable(logging.WARNING)
 
 @pytest.fixture
 def agent_id():


### PR DESCRIPTION
Disabling logging in the memory growth tests seems to cut down on memory growth from the `logging` package allowing the memory growth tests to used.