### PR TITLE
Improvments on cut in and u-turn interaction between agents and social vehicles

### DIFF
--- a/smarts/core/controllers/lane_following_controller.py
+++ b/smarts/core/controllers/lane_following_controller.py
@@ -77,7 +77,7 @@ class LaneFollowingController:
         # This lookahead value is coupled with a few calculations below, changing it
         # may affect stability of the controller.
         wp_paths = sensor_state.mission_planner.waypoint_paths_at(
-            sim, vehicle.pose, lookahead=30
+            sim, vehicle.pose, lookahead=30, vehicle=vehicle
         )
         current_lane = LaneFollowingController.find_current_lane(
             wp_paths, vehicle.position

--- a/smarts/core/mission_planner.py
+++ b/smarts/core/mission_planner.py
@@ -48,7 +48,7 @@ class MissionPlanner:
         self._route = None
         self._road_network = road_network
         self._did_plan = False
-        self._trigger_task = False
+        self._task_is_triggered = False
 
     def random_endless_mission(
         self, min_range_along_lane=0.3, max_range_along_lane=0.9
@@ -272,7 +272,7 @@ class MissionPlanner:
             vehicle=vehicle, radius=radius
         )
 
-        if not neighborhood_vehicles and not self._trigger_task:
+        if not neighborhood_vehicles and not self._task_is_triggered:
             return []
 
         start_lane = self._road_network.nearest_lane(
@@ -286,7 +286,7 @@ class MissionPlanner:
         if not start_edge.oncoming_edges:
             return []
 
-        self._trigger_task = True
+        self._task_is_triggered = True
 
         oncoming_edge = start_edge.oncoming_edges[0]
         oncoming_lanes = oncoming_edge.getLanes()

--- a/smarts/core/mission_planner.py
+++ b/smarts/core/mission_planner.py
@@ -29,7 +29,7 @@ from .sumo_road_network import SumoRoadNetwork
 from .scenario import EndlessGoal, LapMission, Mission, Start, default_entry_tactic
 from .waypoints import Waypoint, Waypoints
 from .route import ShortestRoute, EmptyRoute
-from .coordinates import Pose
+from .coordinates import Pose, Heading
 from .route import ShortestRoute, EmptyRoute
 from .scenario import EndlessGoal, LapMission, Mission, Start
 from .sumo_road_network import SumoRoadNetwork
@@ -245,7 +245,7 @@ class MissionPlanner:
         prev = position[:2]
         for i in range(len(p_x)):
             pos = np.array([p_x[i], p_y[i]])
-            heading = vec_to_radians(pos - prev)
+            heading = Heading(vec_to_radians(pos - prev))
             prev = pos
             lane = self._road_network.nearest_lane(pos)
             lane_id = lane.getID()
@@ -333,7 +333,7 @@ class MissionPlanner:
         trajectory = []
         for i in range(len(p_x)):
             pos = np.array([p_x[i], p_y[i]])
-            heading = vec_to_radians(target.pos - pos)
+            heading = Heading(vec_to_radians(target.pos - pos))
             lane = self._road_network.nearest_lane(pos)
             lane_id = lane.getID()
             lane_index = lane_id.split("_")[-1]

--- a/smarts/core/mission_planner.py
+++ b/smarts/core/mission_planner.py
@@ -229,7 +229,7 @@ class MissionPlanner:
         target_offset = self._road_network.offset_into_lane(
             target_lane, target_position
         )
-        if offset < target_offset:
+        if offset < target_offset + 5:
             # Need to catch up with the target vehicle first
             return []
 

--- a/smarts/core/mission_planner.py
+++ b/smarts/core/mission_planner.py
@@ -29,7 +29,7 @@ from .sumo_road_network import SumoRoadNetwork
 from .scenario import EndlessGoal, LapMission, Mission, Start, default_entry_tactic
 from .waypoints import Waypoint, Waypoints
 from .route import ShortestRoute, EmptyRoute
-from .coordinates import Pose, Heading
+from .coordinates import Heading, Pose
 from .route import ShortestRoute, EmptyRoute
 from .scenario import EndlessGoal, LapMission, Mission, Start
 from .sumo_road_network import SumoRoadNetwork

--- a/smarts/sstudio/generators.py
+++ b/smarts/sstudio/generators.py
@@ -204,6 +204,7 @@ class TrafficGenerator:
                     speedDev=actor.speed.sigma,
                     sigma=sigma,
                     minGap=min_gap,
+                    maxSpeed=actor.max_speed,
                     **actor.lane_changing_model,
                     **actor.junction_model,
                 )

--- a/smarts/sstudio/tests/baseline.rou.xml
+++ b/smarts/sstudio/tests/baseline.rou.xml
@@ -31,18 +31,18 @@
 -->
 
 <routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/routes_file.xsd">
-    <vType id="actor-car-5663952893791202157" minGap="2.50" speedFactor="normc(1.00,0.20,0.20,2.00)" vClass="passenger" accel="2.6" decel="4.5" sigma="0.5"/>
-    <vehicle id="car-flow-route-edge-east-EW_0_30-edge-west-EW_0_-30--4117495477927931840--5051055320591637769--1-0.0" type="actor-car-5663952893791202157" depart="0.00" departLane="0" departPos="30.00" departSpeed="max" arrivalLane="0" arrivalPos="-30.00">
+    <vType id="actor-car-5974851877247858186" minGap="2.50" maxSpeed="55.50" speedFactor="normc(1.00,0.20,0.20,2.00)" vClass="passenger" accel="2.6" decel="4.5" sigma="0.5"/>
+    <vehicle id="car-flow-route-edge-east-EW_0_30-edge-west-EW_0_-30--4117495477927931840--9115604273415384466--1-0.0" type="actor-car-5974851877247858186" depart="0.00" departLane="0" departPos="30.00" departSpeed="max" arrivalLane="0" arrivalPos="-30.00">
         <route edges="edge-east-EW edge-west-EW"/>
     </vehicle>
-    <vType id="actor-car--1412329320184032134" minGap="2.50" speedFactor="normc(0.80,0.20,0.20,2.00)" vClass="passenger" impatience="0.50" lcCooperative="0.25" lcImpatience="1" jmDriveAfterYellowTime="1.0" accel="2.6" decel="4.5" sigma="0.5"/>
-    <vehicle id="car-flow-route-edge-east-EW_0_30-edge-west-EW_0_-30--4117495477927931840--5051055320591637769--1-1.0" type="actor-car--1412329320184032134" depart="0.00" departLane="0" departPos="30.00" departSpeed="max" arrivalLane="0" arrivalPos="-30.00">
+    <vType id="actor-car--1856733372394314985" minGap="2.50" maxSpeed="55.50" speedFactor="normc(0.80,0.20,0.20,2.00)" vClass="passenger" impatience="0.50" lcCooperative="0.25" lcImpatience="1" jmDriveAfterYellowTime="1.0" accel="2.6" decel="4.5" sigma="0.5"/>
+    <vehicle id="car-flow-route-edge-east-EW_0_30-edge-west-EW_0_-30--4117495477927931840--9115604273415384466--1-1.0" type="actor-car--1856733372394314985" depart="0.00" departLane="0" departPos="30.00" departSpeed="max" arrivalLane="0" arrivalPos="-30.00">
         <route edges="edge-east-EW edge-west-EW"/>
     </vehicle>
-    <vehicle id="car-flow-route-edge-west-WE_0_30-edge-east-WE_0_-30--6121202786866783653--5051055320591637769--0-0.0" type="actor-car-5663952893791202157" depart="0.00" departLane="0" departPos="30.00" departSpeed="max" arrivalLane="0" arrivalPos="-30.00">
+    <vehicle id="car-flow-route-edge-west-WE_0_30-edge-east-WE_0_-30--6121202786866783653--9115604273415384466--0-0.0" type="actor-car-5974851877247858186" depart="0.00" departLane="0" departPos="30.00" departSpeed="max" arrivalLane="0" arrivalPos="-30.00">
         <route edges="edge-west-WE edge-east-WE"/>
     </vehicle>
-    <vehicle id="car-flow-route-edge-west-WE_0_30-edge-east-WE_0_-30--6121202786866783653--5051055320591637769--0-1.0" type="actor-car--1412329320184032134" depart="0.00" departLane="0" departPos="30.00" departSpeed="max" arrivalLane="0" arrivalPos="-30.00">
+    <vehicle id="car-flow-route-edge-west-WE_0_30-edge-east-WE_0_-30--6121202786866783653--9115604273415384466--0-1.0" type="actor-car--1856733372394314985" depart="0.00" departLane="0" departPos="30.00" departSpeed="max" arrivalLane="0" arrivalPos="-30.00">
         <route edges="edge-west-WE edge-east-WE"/>
     </vehicle>
 </routes>

--- a/smarts/sstudio/types.py
+++ b/smarts/sstudio/types.py
@@ -349,6 +349,9 @@ class TrapEntryTactic(EntryTactic):
 
 @dataclass(frozen=True)
 class UTurn:
+    trigger_radius: int = 100
+    """This task will be triggered if any vehicles within this radius"""
+
     target_lane_index: int = 0
 
     @property
@@ -358,6 +361,9 @@ class UTurn:
 
 @dataclass(frozen=True)
 class CutIn:
+    trigger_radius: int = 30
+    """This task will be triggered if any vehicles within this radius"""
+
     @property
     def name(self):
         return "cut_in"
@@ -377,9 +383,12 @@ class Mission:
     """The earliest simulation time that this mission starts but may start later in couple with
     `entry_tactic`.
     """
+
     entry_tactic: EntryTactic = None
     """A specific tactic the mission should employ to start the mission."""
+
     task: Tuple[UTurn, CutIn] = None
+    """A task for the actor to accomplish."""
 
 
 @dataclass(frozen=True)

--- a/smarts/sstudio/types.py
+++ b/smarts/sstudio/types.py
@@ -162,6 +162,8 @@ class TrafficActor(Actor):
     """Imperfection within range [0..1]"""
     min_gap: Distribution = Distribution(mean=2.5, sigma=0)
     """Minimum gap in meters."""
+    max_speed: float = 55.5
+    """The vehicle's maximum velocity (in m/s), defaults 200 km/h for vehicles"""
     vehicle_type: str = "passenger"
     """The type of vehicle this actor uses. ("passenger", "bus", "coach", "truck", "trailer")"""
     lane_changing_model: LaneChangingModel = field(

--- a/zoo/policies/open-agent/open_agent/agent.py
+++ b/zoo/policies/open-agent/open_agent/agent.py
@@ -407,6 +407,10 @@ class OpEnAgent(Agent):
         ego = obs.ego_vehicle_state
         lane_index = min(len(obs.waypoint_paths) - 1, ego.lane_index)
         wps = obs.waypoint_paths[lane_index]
+        for wp_path in obs.waypoint_paths:
+            if wp_path[0].lane_index == lane_index:
+                wps = wp_path
+                break
         # wps = min(
         #     obs.waypoint_paths,
         #     key=lambda wps: abs(wps[0].signed_lateral_error(ego.position)),

--- a/zoo/policies/open-agent/open_agent/agent.py
+++ b/zoo/policies/open-agent/open_agent/agent.py
@@ -405,7 +405,8 @@ class OpEnAgent(Agent):
 
     def act(self, obs):
         ego = obs.ego_vehicle_state
-        wps = obs.waypoint_paths[len(obs.waypoint_paths) // 2]
+        lane_index = min(len(obs.waypoint_paths) - 1, ego.lane_index)
+        wps = obs.waypoint_paths[lane_index]
         # wps = min(
         #     obs.waypoint_paths,
         #     key=lambda wps: abs(wps[0].signed_lateral_error(ego.position)),


### PR DESCRIPTION
1. Add trigger radius to task mission
2. Introduce `max_speed` to `TrafficActor`. This will allow setting the max speed lower than the road speed limit, which makes it easier to do a cut in or u turn.

The u-turn and cut in task become meaningful only when agents have interaction with other vehicles. Before we can pin a bubble to a social vehicle, we introduce this `trigger radius` to allow users to specify a radius, the task will be triggered if any vehicles within this radius.

![ezgif com-gif-maker (9)](https://user-images.githubusercontent.com/2217445/100952160-fe12e500-34dd-11eb-8b77-a47af91cf965.gif)


 The agent keeps going straight until the social vehicle shows up.