### PR TITLE
41 Include option for ordered scenarios

### DIFF
--- a/smarts/core/scenario.py
+++ b/smarts/core/scenario.py
@@ -232,7 +232,7 @@ class Scenario:
 
     @staticmethod
     def variations_for_all_scenario_roots(
-        scenario_roots, agents_to_be_briefed, shuffle_scenarios
+        scenario_roots, agents_to_be_briefed, shuffle_scenarios=True
     ):
         for scenario_root in scenario_roots:
             surface_patches = Scenario.discover_friction_map(scenario_root)

--- a/smarts/core/scenario.py
+++ b/smarts/core/scenario.py
@@ -259,14 +259,14 @@ class Scenario:
             agent_missions = agent_missions or [None]
             social_agents = social_agents or [None]
 
+            roll_routes = 0
+            roll_agent_missions = 0
+            roll_social_agents = 0
+ 
             if shuffle_scenarios:
                 roll_routes = random.randint(0, len(routes))
                 roll_agent_missions = random.randint(0, len(agent_missions))
                 roll_social_agents = random.randint(0, len(social_agents))
-            else:
-                roll_routes = 0
-                roll_agent_missions = 0
-                roll_social_agents = 0
 
             for (
                 concrete_route,

--- a/smarts/core/scenario.py
+++ b/smarts/core/scenario.py
@@ -204,7 +204,7 @@ class Scenario:
     def scenario_variations(
         scenarios_or_scenarios_dirs: Sequence[str],
         agents_to_be_briefed: Sequence[str],
-        ordered_scenarios: bool = False,
+        shuffle_scenarios: bool = True,
     ):
         """Generate a cycle of the configurations of scenarios.
 
@@ -223,7 +223,7 @@ class Scenario:
             else:
                 scenario_roots.extend(Scenario.discover_scenarios(root))
 
-        if not ordered_scenarios:
+        if not shuffle_scenarios:
             np.random.shuffle(scenario_roots)
 
         return Scenario.variations_for_all_scenario_roots(

--- a/smarts/core/scenario.py
+++ b/smarts/core/scenario.py
@@ -262,7 +262,7 @@ class Scenario:
             roll_routes = 0
             roll_agent_missions = 0
             roll_social_agents = 0
- 
+
             if shuffle_scenarios:
                 roll_routes = random.randint(0, len(routes))
                 roll_agent_missions = random.randint(0, len(agent_missions))

--- a/smarts/core/scenario.py
+++ b/smarts/core/scenario.py
@@ -223,15 +223,15 @@ class Scenario:
             else:
                 scenario_roots.extend(Scenario.discover_scenarios(root))
 
-        if not shuffle_scenarios:
+        if shuffle_scenarios:
             np.random.shuffle(scenario_roots)
 
         return Scenario.variations_for_all_scenario_roots(
-            cycle(scenario_roots), agents_to_be_briefed
+            cycle(scenario_roots), agents_to_be_briefed, shuffle_scenarios
         )
 
     @staticmethod
-    def variations_for_all_scenario_roots(scenario_roots, agents_to_be_briefed):
+    def variations_for_all_scenario_roots(scenario_roots, agents_to_be_briefed, shuffle_scenarios):
         for scenario_root in scenario_roots:
             surface_patches = Scenario.discover_friction_map(scenario_root)
 
@@ -257,9 +257,14 @@ class Scenario:
             agent_missions = agent_missions or [None]
             social_agents = social_agents or [None]
 
-            roll_routes = random.randint(0, len(routes))
-            roll_agent_missions = random.randint(0, len(agent_missions))
-            roll_social_agents = random.randint(0, len(social_agents))
+            if shuffle_scenarios:
+                roll_routes = random.randint(0, len(routes))
+                roll_agent_missions = random.randint(0, len(agent_missions))
+                roll_social_agents = random.randint(0, len(social_agents))
+            else:
+                roll_routes = 0
+                roll_agent_missions = 0
+                roll_social_agents = 0
 
             for (
                 concrete_route,

--- a/smarts/core/scenario.py
+++ b/smarts/core/scenario.py
@@ -202,7 +202,9 @@ class Scenario:
 
     @staticmethod
     def scenario_variations(
-        scenarios_or_scenarios_dirs: Sequence[str], agents_to_be_briefed: Sequence[str],
+        scenarios_or_scenarios_dirs: Sequence[str],
+        agents_to_be_briefed: Sequence[str],
+        ordered_scenarios: bool = False,
     ):
         """Generate a cycle of the configurations of scenarios.
 
@@ -220,7 +222,9 @@ class Scenario:
                 scenario_roots.append(root)
             else:
                 scenario_roots.extend(Scenario.discover_scenarios(root))
-        np.random.shuffle(scenario_roots)
+
+        if not ordered_scenarios:
+            np.random.shuffle(scenario_roots)
 
         return Scenario.variations_for_all_scenario_roots(
             cycle(scenario_roots), agents_to_be_briefed

--- a/smarts/core/scenario.py
+++ b/smarts/core/scenario.py
@@ -231,7 +231,9 @@ class Scenario:
         )
 
     @staticmethod
-    def variations_for_all_scenario_roots(scenario_roots, agents_to_be_briefed, shuffle_scenarios):
+    def variations_for_all_scenario_roots(
+        scenario_roots, agents_to_be_briefed, shuffle_scenarios
+    ):
         for scenario_root in scenario_roots:
             surface_patches = Scenario.discover_friction_map(scenario_root)
 

--- a/smarts/env/hiway_env.py
+++ b/smarts/env/hiway_env.py
@@ -69,6 +69,7 @@ class HiWayEnv(gym.Env):
         self,
         scenarios: Sequence[str],
         agent_specs,
+        ordered_scenarios=False,
         headless=False,
         visdom=False,
         timestep_sec=0.1,
@@ -89,7 +90,7 @@ class HiWayEnv(gym.Env):
         self._dones_registered = 0
 
         self._scenarios_iterator = Scenario.scenario_variations(
-            scenarios, list(agent_specs.keys()),
+            scenarios, list(agent_specs.keys()), ordered_scenarios,
         )
 
         agent_interfaces = {

--- a/smarts/env/hiway_env.py
+++ b/smarts/env/hiway_env.py
@@ -69,7 +69,7 @@ class HiWayEnv(gym.Env):
         self,
         scenarios: Sequence[str],
         agent_specs,
-        ordered_scenarios=False,
+        shuffle_scenarios=True,
         headless=False,
         visdom=False,
         timestep_sec=0.1,
@@ -90,7 +90,7 @@ class HiWayEnv(gym.Env):
         self._dones_registered = 0
 
         self._scenarios_iterator = Scenario.scenario_variations(
-            scenarios, list(agent_specs.keys()), ordered_scenarios,
+            scenarios, list(agent_specs.keys()), shuffle_scenarios,
         )
 
         agent_interfaces = {


### PR DESCRIPTION
Include option for ordered scenarios in `__init__()` of `class HiWayEnv(gym.Env)`
https://github.com/huawei-noah/SMARTS/blob/894809e7ae342d4ec0be017a9fb757d586e4531f/smarts/env/hiway_env.py#L68-L85

Closes #41 