### PR TITLE
Improved error message

### DIFF
--- a/smarts/core/smarts.py
+++ b/smarts/core/smarts.py
@@ -95,8 +95,8 @@ class SMARTS(ShowBase):
         except Exception as e:
             # Known reasons for this failing:
             raise Exception(
-                "SMARTS: Error in initializing parent class ShowBase."
-                "A potential reason is display not found. Try running with different configurations of "
+                "SMARTS: Error in initializing framework for opening graphical display and creating scene graph. "
+                "A typical reason is display not found. Try running with different configurations of "
                 "`export Display=` using `:0`, `:1`... . If this does not work please consult "
                 "the documentation."
             ) from e

--- a/smarts/core/smarts.py
+++ b/smarts/core/smarts.py
@@ -95,8 +95,9 @@ class SMARTS(ShowBase):
         except Exception as e:
             # Known reasons for this failing:
             raise Exception(
-                "Display is not found. Try running with different configurations of "
-                "`export Display=` using `:0`, `:1`... If this does not work please consult "
+                "SMARTS: Error in initializing parent class ShowBase."
+                "A potential reason is display not found. Try running with different configurations of "
+                "`export Display=` using `:0`, `:1`... . If this does not work please consult "
                 "the documentation."
             ) from e
 


### PR DESCRIPTION
This attempts to improve the error message thrown by `SMARTS` class when initializing its parent class `ShowBase`.

Closes #186 .