### PR TITLE
Improve description of vehicle 'position'

### DIFF
--- a/docs/sim/observations.rst
+++ b/docs/sim/observations.rst
@@ -21,8 +21,8 @@ is a Python `NamedTuple` with the following fields:
     * `reached_max_episode_steps` - `True` if the vehicle has reached its max episode steps
 * `ego_vehicle_state` - a `VehicleObservation` `NamedTuple` for the ego vehicle with the following fields:
     * `id` - a string identifier for this vehicle
-    * `position` - 3D numpy array (x, y, z) of vehicle position
-    * `bounding_box` - `BoundingBox` data class for the `length`, `width`, `height` of the vehicle.
+    * `position` - A 3D numpy array (x, y, z) of the center of the vehicle bounding box's bottom plane
+    * `bounding_box` - `BoundingBox` data class for the `length`, `width`, `height` of the vehicle
     * `heading` - vehicle heading in radians
     * `speed` - agent speed in m/s
     * `steering` - angle of front wheels in radians


### PR DESCRIPTION
Edited the description of vehicle 'position' in the documentation.

Closes #111 .