### PR TITLE
Fix for missing edge dividers

### DIFF
--- a/smarts/core/sumo_road_network.py
+++ b/smarts/core/sumo_road_network.py
@@ -477,7 +477,7 @@ class SumoRoadNetwork:
         edge = random.choice(self._graph.getEdges(False))
         return self.random_route_starting_at_edge(edge, max_route_len)
 
-    def compute_traffic_dividers(self):
+    def compute_traffic_dividers(self, threshold=1):
         lane_dividers = []  # divider between lanes with same traffic direction
         edge_dividers = []  # divider between lanes with opposite traffic direction
         edge_borders = []
@@ -504,7 +504,7 @@ class SumoRoadNetwork:
                 else:
                     lane_dividers.append(left_side)
 
-        # The edge borders that overlapped in positions form a edge divider
+        # The edge borders that overlapped in positions form an edge divider
         for i in range(len(edge_borders) - 1):
             for j in range(i + 1, len(edge_borders)):
                 edge_border_i = np.array(
@@ -513,7 +513,9 @@ class SumoRoadNetwork:
                 edge_border_j = np.array(
                     [edge_borders[j][-1], edge_borders[j][0]]
                 )  # start and end position with reverse traffic direction
-                if np.linalg.norm(edge_border_i - edge_border_j) < 0.001:
+
+                # The edge borders of two lanes do not always overlap perfectly, thus relax the tolerance threshold to 1
+                if np.linalg.norm(edge_border_i - edge_border_j) < threshold:
                     edge_dividers.append(edge_borders[i])
 
         return lane_dividers, edge_dividers


### PR DESCRIPTION
Quick fix for the mini-city demo for now:
Relax the tolerance threshold while checking if two edge borders overlap

Before:
![Screenshot from 2020-12-11 14-59-44](https://user-images.githubusercontent.com/57057376/101949389-8883d480-3bc1-11eb-802d-a00171f8aaa2.png)

After:
![Screenshot from 2020-12-11 14-53-15](https://user-images.githubusercontent.com/57057376/101949408-920d3c80-3bc1-11eb-8291-f7cf20b70ee0.png)
