### PR TITLE
Fix bubble geometry built from MapZone

### DIFF
--- a/smarts/sstudio/types.py
+++ b/smarts/sstudio/types.py
@@ -527,8 +527,8 @@ class MapZone(Zone):
             if len(lane_shape) == 1:
                 return lane_shape[0]
 
+            # We assume that there are only two splited shapes to choose from
             keep_index = 0
-
             if lane_shape[1].minimum_rotated_rectangle.contains(
                 Point(expected_midpoint)
             ):

--- a/smarts/sstudio/types.py
+++ b/smarts/sstudio/types.py
@@ -513,9 +513,7 @@ class MapZone(Zone):
             else:
                 return float(offset)
 
-        def pick_remaining_shape_after_split(
-            geometry_collection, expected_midpoint, lane
-        ):
+        def pick_remaining_shape_after_split(geometry_collection, expected_point, lane):
             lane_shape = geometry_collection
             if not isinstance(lane_shape, GeometryCollection):
                 return lane_shape
@@ -529,9 +527,7 @@ class MapZone(Zone):
 
             # We assume that there are only two splited shapes to choose from
             keep_index = 0
-            if lane_shape[1].minimum_rotated_rectangle.contains(
-                Point(expected_midpoint)
-            ):
+            if lane_shape[1].minimum_rotated_rectangle.contains(expected_point):
                 # 0 is the discard piece, keep the other
                 keep_index = 1
 
@@ -570,8 +566,10 @@ class MapZone(Zone):
             # Second cut takes into account shortening of geometry by `min_cut`.
             max_cut = min(min_cut + geom_length, lane_length)
 
-            midpoint = road_network.world_coord_from_offset(
-                lane, lane_offset + geom_length * 0.5
+            midpoint = Point(
+                road_network.world_coord_from_offset(
+                    lane, lane_offset + geom_length * 0.5
+                )
             )
 
             lane_shape = road_network.split_lane_shape_at_offset(

--- a/smarts/sstudio/types.py
+++ b/smarts/sstudio/types.py
@@ -513,29 +513,6 @@ class MapZone(Zone):
             else:
                 return float(offset)
 
-        def pick_remaining_shape_after_split(geometry_collection, length, lane):
-            lane_shape = geometry_collection
-            if not isinstance(lane_shape, GeometryCollection):
-                return lane_shape
-
-            # For simplicty, we only deal w/ the == 1 or 2 case
-            if len(lane_shape) not in {1, 2}:
-                return None
-
-            if len(lane_shape) == 1:
-                return lane_shape[0]
-
-            expected_bbox_area = lane.getWidth() * length
-            keep_index = 0
-            if (lane_shape[0].minimum_rotated_rectangle.area - expected_bbox_area) < (
-                lane_shape[1].minimum_rotated_rectangle.area - expected_bbox_area
-            ):
-                # 0 is the discard piece, keep the other
-                keep_index = 1
-            lane_shape = lane_shape[keep_index]
-
-            return lane_shape
-
         lane_shapes = []
         edge_id, lane_idx, offset = self.start
         edge = road_network.edge_by_id(edge_id)
@@ -565,21 +542,27 @@ class MapZone(Zone):
 
             min_cut = min(lane_offset, lane_length)
             # Second cut takes into account shortening of geometry by `min_cut`.
-            max_cut = min(min_cut + geom_length, lane_length - min_cut)
+            max_cut = min(min_cut + geom_length, lane_length)
 
             lane_shape = road_network.split_lane_shape_at_offset(
                 lane_shape, lane, min_cut
             )
-            lane_shape = pick_remaining_shape_after_split(lane_shape, min_cut, lane)
-            if lane_shape is None:
-                continue
+            if isinstance(lane_shape, GeometryCollection):
+                if len(lane_shape) not in {1, 2}:
+                    continue
+                else:
+                    lane_shape = lane_shape[0]
 
             lane_shape = road_network.split_lane_shape_at_offset(
                 lane_shape, lane, max_cut,
             )
-            lane_shape = pick_remaining_shape_after_split(lane_shape, max_cut, lane)
-            if lane_shape is None:
-                continue
+            if isinstance(lane_shape, GeometryCollection):
+                if len(lane_shape) not in {1, 2}:
+                    continue
+                elif len(lane_shape) == 1:
+                    lane_shape = lane_shape[0]
+                else:
+                    lane_shape = lane_shape[1]
 
             lane_shapes.append(lane_shape)
 


### PR DESCRIPTION
- Changed the logic to select splited shapes in MapZone
- Changed the definition of max cut in MapZone

I am not sure if this is a good solution for this problem because I did it in a rush. It mostly serves as a starting point. It is worth of discussion and double checking. Feel free to make adjustment on top of this.

I am inspired by this PR: https://github.com/huawei-noah/SMARTS/pull/248/files

The dark-red color of the bubbles shown below is only for illustration purpose.

**4lane_t** (The bubble on the left is built with MapZone)
![Screenshot from 2021-01-01 10-55-46](https://user-images.githubusercontent.com/57057376/103441995-28141000-4c20-11eb-9e15-0ab6dc073b70.png)

**minicity** (note that some bubbles have longer length with changes to `max_cut` in this PR)
![Screenshot from 2021-01-01 10-23-10](https://user-images.githubusercontent.com/57057376/103441365-6b1fb480-4c1b-11eb-8d80-4d7897633fec.png)
![Screenshot from 2021-01-01 10-34-48](https://user-images.githubusercontent.com/57057376/103441580-fcdbf180-4c1c-11eb-95ef-4dc4d23e2e10.png)
![Screenshot from 2021-01-01 10-47-42](https://user-images.githubusercontent.com/57057376/103441847-d6b75100-4c1e-11eb-92d4-2e81a3b663c3.png)



 

