### PR TITLE
Prevent crash from `done` during `HiWayEnv.reset()` (#54)

### DIFF
--- a/smarts/core/sensors.py
+++ b/smarts/core/sensors.py
@@ -48,6 +48,8 @@ from .masks import RenderMasks
 from .scenario import Mission, Via
 from .waypoints import Waypoint
 
+logger = logging.getLogger(__name__)
+
 
 class VehicleObservation(NamedTuple):
     id: str
@@ -291,6 +293,13 @@ class Sensors:
             sim, agent_id, vehicle, sensor_state
         )
 
+        if (
+            done
+            and sensor_state.steps_completed == 1
+            and agent_id in sim.agent_manager.ego_agent_ids
+        ):
+            logger.warning(f"{agent_id} is done on the first step")
+
         return (
             Observation(
                 events=events,
@@ -359,6 +368,7 @@ class Sensors:
             wrong_way=is_wrong_way,
             not_moving=is_not_moving,
         )
+
         return done, events
 
     @classmethod
@@ -564,6 +574,10 @@ class SensorState:
     @property
     def mission_planner(self):
         return self._mission_planner
+
+    @property
+    def steps_completed(self):
+        return self._step
 
 
 class CameraSensor(Sensor):

--- a/smarts/core/smarts.py
+++ b/smarts/core/smarts.py
@@ -181,6 +181,13 @@ class SMARTS(ShowBase):
             self.destroy()
             raise  # re-raise
 
+    def _check_if_acting_on_active_agents(self, agent_actions):
+        for agent_id in agent_actions.keys():
+            if agent_id not in self._agent_manager.ego_agent_ids:
+                self._log.warning(
+                    f"Attempted to perform actions on non-existing agent, {agent_id} "
+                )
+
     def _step(self, agent_actions):
         """Steps through the simulation while applying the given agent actions.
         Returns the observations, rewards, and done signals.
@@ -210,6 +217,7 @@ class SMARTS(ShowBase):
 
         # 2. Step all providers and harmonize state
         provider_state = self._step_providers(all_agent_actions, dt)
+        self._check_if_acting_on_active_agents(agent_actions)
 
         # 3. Step bubble manager and trap manager
         self._vehicle_index.sync()

--- a/smarts/env/hiway_env.py
+++ b/smarts/env/hiway_env.py
@@ -157,7 +157,6 @@ class HiWayEnv(gym.Env):
             agent_id: self._agent_specs[agent_id].action_adapter(action)
             for agent_id, action in agent_actions.items()
         }
-
         observations, rewards, agent_dones, extras = self._smarts.step(agent_actions)
 
         infos = {


### PR DESCRIPTION
Added a warning when an agent is done on its first step.
Added a warning when trying to give an action for a done agent.