### PR TITLE
ULTRA README - Instructions for adding a custom agent.

### DIFF
--- a/ultra/Dockerfile
+++ b/ultra/Dockerfile
@@ -153,14 +153,22 @@ COPY ./setup.py /SMARTS/
 ARG TINI_VERSION=v0.18.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
+#COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+#RUN chmod +x /usr/local/bin/entrypoint.sh
 
-COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
 
+# For Envision
+EXPOSE 8081
+
+# TODO: Find a better place to put this (e.g. through systemd). As it stands now ctrl-c
+#       could close x-server. Even though it's "running in the background".
+RUN echo "/usr/bin/Xorg " \
+    "-noreset +extension GLX +extension RANDR +extension RENDER" \
+    "-logfile ./xdummy.log -config /etc/X11/xorg.conf -novtswitch $DISPLAY &" >> ~/.bashrc
 #------------------------------------------------------------------------------
 # Entrypoint
 #------------------------------------------------------------------------------
-ENTRYPOINT ["/tini", "--", "entrypoint.sh"]
+# ENTRYPOINT ["/tini", "--", "entrypoint.sh"]
 CMD ["/bin/bash"]
 # Once in container can then run,
 #   python3 examples/competition

--- a/ultra/README.md
+++ b/ultra/README.md
@@ -70,7 +70,7 @@ We currently support PPO/SAC/TD3/DQN policies, for adding you own policy please 
 ### Run Evaluation Separately
 After training your agent, your models should be saved under `logs/your-experiment-name/models/` and you can re-run the evaluation:
   ```sh
-  $ python ultra/evaluate.py --task 1 --level easy --models logs/your-expierment-name/models
+  $ python ultra/evaluate.py --task 1 --level easy --models logs/your-experiment-name/models
   # other arguments --episodes 20000 --timestep 1 --headless
   ```
 

--- a/ultra/README.md
+++ b/ultra/README.md
@@ -122,7 +122,7 @@ After training your agent, your models should be saved under `logs/your-experime
     Additionally, see `smarts/core/controllers/__init__.py` to view available action space types and how they are performed.
 
 3. **Use Your Agent**
-    Finally, in `train.py` or `evaluate.py`, ensure that the `policy_class` variable references your agent using the string format shown below in order to use your agent for training or evaluation respectively:
+    Finally, in order to use your agent for training or evaluation, in `train.py` or `evaluate.py` respectively, ensure that the `policy_class` variable references your agent using the following string format:
     ```python
     policy_class = "<your.agents.package.name>.<your_agent_name>:<your_agent_name>-v<your_agent_version_number>"
     ```


### PR DESCRIPTION
Some basic instructions for adding a custom agent to the ULTRA framework. This is by no means a comprehensive tutorial, but will hopefully make it easier to add custom agents to the framework.

Of course, feel free to expand on anything where deemed necessary.