### PR TITLE
WIP fix sumo vehicle key error in history_vehicles_replacement example (#230)

### DIFF
--- a/examples/history_vehicles_replacement_for_imitation_learning.py
+++ b/examples/history_vehicles_replacement_for_imitation_learning.py
@@ -27,7 +27,7 @@ def main(scenarios, headless, seed):
         agent_missions = scenario.discover_missions_of_traffic_histories()
         print(f"All id length: {len(agent_missions.keys())}")
         for agent_id, mission in agent_missions.items():
-            # if agent_id not in set(["1","7","10","11"]):
+            # if agent_id not in set(["1","2","3","7","10","11"]):
             #     continue
             scenario.set_ego_missions({agent_id: mission})
 

--- a/smarts/core/remote_agent_buffer.py
+++ b/smarts/core/remote_agent_buffer.py
@@ -199,6 +199,6 @@ def get_manager_channel_stub(addr):
     except grpc.FutureTimeoutError:
         raise RemoteAgentException(
             "Timeout in connecting to remote zoo manager."
-        ) from e
+        )
     stub = manager_pb2_grpc.ManagerStub(channel)
     return channel, stub

--- a/smarts/core/remote_agent_buffer.py
+++ b/smarts/core/remote_agent_buffer.py
@@ -68,6 +68,7 @@ class RemoteAgentBuffer:
         self._local_zoo_manager = False
 
         # Populate zoo manager connection with address and process handles.
+        print(f"zoo address: {zoo_manager_addrs}")
         if not zoo_manager_addrs:
             # Spawn a local zoo manager since no remote zoo managers were provided.
             self._local_zoo_manager = True
@@ -109,6 +110,7 @@ class RemoteAgentBuffer:
                 raise e
 
         # If available, teardown local zoo manager.
+        print(f"zoo manager connections: {len(self._zoo_manager_conns)}")
         if self._local_zoo_manager:
             self._zoo_manager_conns[0]["channel"].close()
             self._zoo_manager_conns[0]["process"].terminate()
@@ -201,4 +203,5 @@ def get_manager_channel_stub(addr):
             "Timeout in connecting to remote zoo manager."
         )
     stub = manager_pb2_grpc.ManagerStub(channel)
+    print("gRPC succeeded")
     return channel, stub

--- a/smarts/core/smarts.py
+++ b/smarts/core/smarts.py
@@ -334,6 +334,11 @@ class SMARTS(ShowBase):
 
         return observations_for_ego
 
+    def switch_ego_agent(self, agent_interfaces, zoo_addrs=None):
+        # check why takes long
+        self._agent_manager = AgentManager(agent_interfaces, zoo_addrs)
+        self._is_setup = False
+
     def setup(self, scenario: Scenario):
         self._scenario = scenario
 

--- a/smarts/core/smarts.py
+++ b/smarts/core/smarts.py
@@ -315,14 +315,12 @@ class SMARTS(ShowBase):
 
         # Tell history provide to ignore vehicles if we have assigned mission to them
         self._traffic_history_provider.set_replaced_ids(scenario.missions.keys())
-
         self.taskMgr.clock.reset()
         self._elapsed_sim_time = 0
 
         self._vehicle_states = [v.state for v in self._vehicle_index.vehicles]
         observations, _, _, _ = self._agent_manager.observe(self)
         observations_for_ego = self._agent_manager.reset_agents(observations)
-
         # Visualization
         self._try_emit_visdom_obs(observations)
 
@@ -331,7 +329,6 @@ class SMARTS(ShowBase):
                 observations_for_ego, _, _, _ = self.step({})
 
         self._reset_providers()
-
         return observations_for_ego
 
     def switch_ego_agent(self, agent_interfaces, zoo_addrs=None):
@@ -343,8 +340,9 @@ class SMARTS(ShowBase):
         self._scenario = scenario
 
         self._root_np = NodePath("sim")
+        print("after _root_np")
         self._root_np.reparentTo(self.render)
-
+        print("after reparentTo")
         with pkg_resources.path(
             glsl, "unlit_shader.vert"
         ) as vshader_path, pkg_resources.path(
@@ -355,19 +353,32 @@ class SMARTS(ShowBase):
                 vertex=str(vshader_path.absolute()),
                 fragment=str(fshader_path.absolute()),
             )
+            print("after fshader_path")
         self._root_np.setShader(unlit_shader)
+        print("after setShader")
         self._setup_road_network()
+        print("after _setup_road_network")
         self._vehicles_np = self._root_np.attachNewNode("vehicles")
+        print("after _vehicles_np")
 
         self._bubble_manager = BubbleManager(scenario.bubbles, scenario.road_network)
+        print("after _bubble_manager")
         self._trap_manager = TrapManager(scenario)
+        print("after _trap_manager")
 
         self._setup_bullet_client(self._bullet_client)
+        print("after _setup_bullet_client")
+
         provider_state = self._setup_providers(self._scenario)
         self._agent_manager.setup_agents(self)
+        print("after provider_state")
 
+        self._agent_manager.setup_agents(self)
+        print("after setup_agents")
         self._harmonize_providers(provider_state)
+        print("after _harmonize_providers")
         self._last_provider_state = provider_state
+        print("after _last_provider_state")
 
         self._is_setup = True
 

--- a/smarts/core/sumo_traffic_simulation.py
+++ b/smarts/core/sumo_traffic_simulation.py
@@ -692,7 +692,9 @@ class SumoTrafficSimulation:
         self._reserved_areas[vehicle_id] = reserved_location
 
     def remove_traffic_vehicle(self, vehicle_id: str):
+        print(self._traci_conn.vehicle)
         self._traci_conn.vehicle.remove(vehicle_id)
+        print(self._sumo_vehicle_ids)
         self._sumo_vehicle_ids.remove(vehicle_id)
 
     def _shape_of_vehicle(self, sumo_vehicle_state, vehicle_id):

--- a/smarts/core/trap_manager.py
+++ b/smarts/core/trap_manager.py
@@ -145,6 +145,7 @@ class TrapManager:
                 ),
             )
             for v_id in sorted_vehicle_ids:
+                break
                 vehicle = vehicles[v_id]
                 point = Point(vehicle.position)
 
@@ -153,7 +154,7 @@ class TrapManager:
 
                 if not point.within(trap.geometry):
                     continue
-
+                print(f"trap geometry: {trap.geometry} point: {point}")
                 captures_by_agent_id[agent_id].append(
                     (
                         v_id,
@@ -171,6 +172,8 @@ class TrapManager:
         # Use fed in trapped vehicles.
         agents_given_vehicle = set()
         used_traps = []
+        print(f"agent manager: {sim._agent_manager.pending_agent_ids}")
+        print(f"self.traps: {self._traps.keys()}")
         for agent_id in sim._agent_manager.pending_agent_ids:
             if agent_id not in self._traps:
                 continue
@@ -183,6 +186,8 @@ class TrapManager:
                 continue
 
             vehicle = None
+            # 1st
+            print(f"Reached 1st {captures}")
             if len(captures) > 0:
                 vehicle_id, trap, mission = rand.choice(captures)
                 vehicle = TrapManager._hijack_vehicle(
@@ -251,6 +256,7 @@ class TrapManager:
         sim.vehicle_index.start_agent_observation(
             sim, vehicle_id, agent_id, agent_interface, planner
         )
+        print("reached 2")
         vehicle = sim.vehicle_index.switch_control_to_agent(
             sim, vehicle_id, agent_id, recreate=True, hijacking=False
         )
@@ -317,7 +323,7 @@ class TrapManager:
             )
 
             drive_distance = lane_speed * default_zone_dist
-
+            # sets trap zone area here
             start_offset_in_lane = vehicle_offset_into_lane - drive_distance
             start_offset_in_lane = clip(start_offset_in_lane, 1e-6, lane_length - 1e-6)
             length = max(1e-6, vehicle_offset_into_lane - start_offset_in_lane)

--- a/smarts/core/utils/logging.py
+++ b/smarts/core/utils/logging.py
@@ -32,7 +32,7 @@ def timeit(name: str):
     yield
     ellapsed_time = (time() - start) * 1000
 
-    logging.info(f'"{name}" took: {ellapsed_time:4f}ms')
+    print(f'"{name}" took: {ellapsed_time:4f}ms')
 
 
 def isnotebook():

--- a/smarts/core/vehicle_index.py
+++ b/smarts/core/vehicle_index.py
@@ -356,6 +356,8 @@ class VehicleIndex:
     def switch_control_to_agent(
         self, sim, vehicle_id, agent_id, boid=False, hijacking=False, recreate=False
     ):
+        # 3rd
+        print(f"Switching control of agent {agent_id} to {vehicle_id}")
         self._log.debug(f"Switching control of {agent_id} to {vehicle_id}")
 
         vehicle_id, agent_id = _2id(vehicle_id), _2id(agent_id)
@@ -363,6 +365,7 @@ class VehicleIndex:
             # XXX: Recreate is presently broken for bubbles because it impacts the
             #      sumo traffic sim sync(...) logic in how it detects a vehicle as
             #      being hijacked vs joining. Presently it's still used for trapping.
+            print(f"before _switch_contorl-to_agent: {vehicle_id} {agent_id}")
             return self._switch_control_to_agent_recreate(
                 sim, vehicle_id, agent_id, boid, hijacking
             )
@@ -495,8 +498,12 @@ class VehicleIndex:
         )
 
         # Remove the old vehicle
+        print(f"new vehicle id: {new_vehicle.id}")
+        print(f"removing old {vehicle.id}")
         self.teardown_vehicles_by_vehicle_ids([vehicle.id])
         # HACK: Directly remove the vehicle from the traffic provider
+        
+        # SHOULD REMOVE vehicle in traffic_history provider instead of sumo
         sim._traffic_sim.remove_traffic_vehicle(vehicle.id)
 
         # Take control of the new vehicle

--- a/smarts/sstudio/types.py
+++ b/smarts/sstudio/types.py
@@ -517,7 +517,6 @@ class MapZone(Zone):
             lane_shape = geometry_collection
             if not isinstance(lane_shape, GeometryCollection):
                 return lane_shape
-
             # For simplicty, we only deal w/ the == 1 or 2 case
             if len(lane_shape) not in {1, 2}:
                 return None
@@ -527,17 +526,23 @@ class MapZone(Zone):
 
             # We assume that there are only two splited shapes to choose from
             keep_index = 0
+            print(f"After keep_index = 0")
+            print(lane_shape[1])
+            print(f"This method causes the error: {lane_shape[1].minimum_rotated_rectangle.contains(expected_point)}")
             if lane_shape[1].minimum_rotated_rectangle.contains(expected_point):
+                print("Entered")
                 # 0 is the discard piece, keep the other
                 keep_index = 1
-
+            print("After lane_shape[1].minimum_rotated_rectangle.contains(expected_point):")
             lane_shape = lane_shape[keep_index]
-
+            print("After lane_shape = lane_shape[keep_index]")
             return lane_shape
 
         lane_shapes = []
         edge_id, lane_idx, offset = self.start
         edge = road_network.edge_by_id(edge_id)
+        print("After edge = road_network.edge_by_id(edge_id)")
+
         buffer_from_ends = 1e-6
         for lane_idx in range(lane_idx, lane_idx + self.n_lanes):
             lane = edge.getLanes()[lane_idx]
@@ -552,15 +557,18 @@ class MapZone(Zone):
                 geom_length = lane_length
 
             assert geom_length > 0  # Geom length is negative
-
+            print("After assert geom_length > 0")
             lane_shape = SumoRoadNetwork._buffered_lane_or_edge(
                 lane, width=lane.getWidth() + 0.3
             )
+            print("After SumoRoadNetwork._buffered_lane_or_edge")
 
             lane_offset = resolve_offset(offset, geom_length, lane_length)
+            print("After lane_offset = resolve_offset(offset, geom_length, lane_length)")
             lane_offset += buffer_from_ends
             geom_length = max(geom_length - buffer_from_ends, buffer_from_ends)
             lane_length = max(lane_length - buffer_from_ends, buffer_from_ends)
+            print("After lane_length = max(lane_length - buffer_from_ends, buffer_from_ends)")
 
             min_cut = min(lane_offset, lane_length)
             # Second cut takes into account shortening of geometry by `min_cut`.
@@ -571,18 +579,23 @@ class MapZone(Zone):
                     lane, lane_offset + geom_length * 0.5
                 )
             )
+            print("After Midepoint = Point(")
 
             lane_shape = road_network.split_lane_shape_at_offset(
                 lane_shape, lane, min_cut
             )
+            print("After lane_shape = road_network.split_lane_shape_at_offset(")
             lane_shape = pick_remaining_shape_after_split(lane_shape, midpoint, lane)
+            print("After pick_remaining_shape_after_split 1")
             if lane_shape is None:
                 continue
 
             lane_shape = road_network.split_lane_shape_at_offset(
                 lane_shape, lane, max_cut,
             )
+            print("After lane_shape = road_network.split_lane_shape_at_offset(")
             lane_shape = pick_remaining_shape_after_split(lane_shape, midpoint, lane)
+            print("After pick_remaining_shape_after_split 2")
             if lane_shape is None:
                 continue
 


### PR DESCRIPTION
When running the example, sometimes it reaches from agent id 1 to 297 then crashes, sometimes it reaches only agent id <20 then crashes. 

```
Traceback (most recent call last):
  File "/home/kyber/work/SMARTS/smarts/core/remote_agent_buffer.py", line 198, in get_manager_channel_stub
    grpc.channel_ready_future(channel).result(timeout=30)
  File "/home/kyber/work/SMARTS/.venv/lib/python3.7/site-packages/grpc/_utilities.py", line 140, in result
    self._block(timeout)
  File "/home/kyber/work/SMARTS/.venv/lib/python3.7/site-packages/grpc/_utilities.py", line 86, in _block
    raise grpc.FutureTimeoutError()
grpc.FutureTimeoutError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "examples/history_vehicles_replacement_for_imitation_learning.py", line 67, in <module>
    scenarios=args.scenarios, headless=args.headless, seed=args.seed,
  File "examples/history_vehicles_replacement_for_imitation_learning.py", line 46, in main
    envision=Envision(),
  File "/home/kyber/work/SMARTS/smarts/core/smarts.py", line 149, in __init__
    self._agent_manager = AgentManager(agent_interfaces, zoo_addrs)
  File "/home/kyber/work/SMARTS/smarts/core/agent_manager.py", line 45, in __init__
    self._remote_agent_buffer = RemoteAgentBuffer(zoo_manager_addrs=zoo_addrs)
  File "/home/kyber/work/SMARTS/smarts/core/remote_agent_buffer.py", line 86, in __init__
    conn["channel"], conn["stub"] = get_manager_channel_stub(conn["address"])
  File "/home/kyber/work/SMARTS/smarts/core/remote_agent_buffer.py", line 201, in get_manager_channel_stub
    "Timeout in connecting to remote zoo manager."
smarts.core.remote_agent.RemoteAgentException: Timeout in connecting to remote zoo manager.
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/home/kyber/work/SMARTS/smarts/core/sumo_traffic_simulation.py", line 116, in _destroy
    self._sumo_proc.terminate()
AttributeError: 'NoneType' object has no attribute 'terminate'
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/home/kyber/work/SMARTS/.venv/lib/python3.7/site-packages/direct/showbase/ShowBase.py", line 82, in exitfunc
    builtins.base.destroy()
  File "/home/kyber/work/SMARTS/smarts/core/smarts.py", line 456, in destroy
    self.teardown()
  File "/home/kyber/work/SMARTS/smarts/core/smarts.py", line 431, in teardown
    self._agent_manager.teardown()
AttributeError: 'SMARTS' object has no attribute '_agent_manager'
[xcb] Unknown sequence number while processing queue
[xcb] Most likely this is a multi-threaded client and XInitThreads has not been called
[xcb] Aborting, sorry about that.
python examples/history_vehicles_replacement_for_imitation_learning.py /home/kyber/datasets/interaction_dataset_merging: ../../src/xcb_io.c:259: poll_for_event: Assertion `!xcb_xlib_threads_sequence_lost' failed.
Aborted (core dumped)
```
Will debug to see why gRPC disconnected.

When it crashes, sometimes it shows the above error and sometimes it only shows:
```
[xcb] Unknown sequence number while processing queue
[xcb] Most likely this is a multi-threaded client and XInitThreads has not been called
[xcb] Aborting, sorry about that.
python examples/history_vehicles_replacement_for_imitation_learning.py /home/kyber/datasets/interaction_dataset_merging: ../../src/xcb_io.c:259: poll_for_event: Assertion `!xcb_xlib_threads_sequence_lost' failed.
Aborted (core dumped)
```

However the two errors seem to be independent of each other as gRPC succeeds most of the time and [xcb] error still shows