### PR TITLE
Remove all vehicle in SUMO when reset

### DIFF
--- a/smarts/core/sumo_traffic_simulation.py
+++ b/smarts/core/sumo_traffic_simulation.py
@@ -273,6 +273,10 @@ class SumoTrafficSimulation:
             self._traci_conn.close()
             self._traci_conn = None
 
+    def _remove_all_vehicles(self):
+        for vehicle_id in self._non_sumo_vehicle_ids.union(self._sumo_vehicle_ids):
+            self._traci_conn.vehicle.remove(vehicle_id)
+
     def teardown(self):
         self._log.debug("Tearing down SUMO traffic sim %s" % self)
         if not self._is_setup:
@@ -281,6 +285,7 @@ class SumoTrafficSimulation:
 
         assert self._is_setup
 
+        self._remove_all_vehicles()
         self._cumulative_sim_seconds = 0
         self._non_sumo_vehicle_ids = set()
         self._sumo_vehicle_ids = set()


### PR DESCRIPTION
This is to fix the agent teleport issue. #405 

Every time when we swap/reset a scenario, we will reload SUMO, this works well if we can successfully terminate SUMO. However, if the SUMO server continues running, it will take over the controller of our agents. To ensure the cleanup is nicely done, we manually remove the vehicles in the sumo traffic sim's `teardown`.