### PR TITLE
Manual and scheduled  triggering of Learning test.

### DIFF
--- a/.github/workflows/ci-base-tests.yml
+++ b/.github/workflows/ci-base-tests.yml
@@ -1,4 +1,4 @@
-name: SMARTS CI
+name: SMARTS CI Base Tests
 
 on: [push]
 
@@ -28,16 +28,7 @@ jobs:
             +extension RENDER \
             -logfile ./xdummy.log \
             -config /etc/X11/xorg.conf :1 &
-      # - name: Cache pip
-      #   id: cache-pip
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: |
-      #       .venv
-      #       /usr/local/bin/scl
-      #     key: pip-${{hashFiles('requirements.txt')}}-${{hashFiles('setup.py')}}
       - name: Install dependencies
-        # if: steps.cache-pip.outputs.cache-hit != 'true'
         run: |
           python3.7 -m venv .venv
           . .venv/bin/activate

--- a/.github/workflows/ci-formatting-and-dependencies.yml
+++ b/.github/workflows/ci-formatting-and-dependencies.yml
@@ -1,9 +1,10 @@
-name: SMARTS CI
+name: SMARTS CI Format & Dependencies
 
 on: [push]
 
 env:
   venv_dir: .venv
+
 jobs:
   test-formatting:
     runs-on: ubuntu-18.04
@@ -11,7 +12,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Run Black code formatter
+      - name: Check Black code format
         run: |
           cd $GITHUB_WORKSPACE
           pip install --upgrade pip

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   venv_dir: .venv
+
 jobs:
   test-benchmark:
     runs-on: ubuntu-18.04
@@ -14,7 +15,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1.2.0
-      - name: Install SMARTS package
+      - name: Setup package
         run: |
           /usr/bin/Xorg \
             -noreset \
@@ -24,21 +25,21 @@ jobs:
             -logfile ./xdummy.log \
             -config /etc/X11/xorg.conf :1 &
           cd $GITHUB_WORKSPACE
-          python3.7 -m venv "${venv_dir}"
-          . "${venv_dir}/bin/activate"
+          python3.7 -m venv ${{env.venv_dir}}
+          . ${{env.venv_dir}}/bin/activate
           pip install --upgrade pip
           pip install wheel
           pip install -r requirements.txt
-          pip install -e .[train]
+          pip install -e .[train,test]
       - name: SMARTS benchmark
         run: |
           cd $GITHUB_WORKSPACE
-          . "${venv_dir}/bin/activate"
+          . ${{env.venv_dir}}/bin/activate
           apt-get update && apt-get -y install git
           git checkout $(git log --merges -n 1 --format=format:"%H")
           scl scenario build-all --clean ./scenarios
           pytest --benchmark-save=previous --benchmark-min-rounds=10 --benchmark-timer=time.process_time ./smarts/env/tests/test_benchmark.py
           git checkout -
-          pip install -e .[train]
+          pip install -e .[train,test]
           scl scenario build-all --clean ./scenarios
           pytest --benchmark-compare=0001_previous --benchmark-compare-fail=mean:10% --benchmark-min-rounds=10 --benchmark-timer=time.process_time ./smarts/env/tests/test_benchmark.py

--- a/.github/workflows/ci-test-header.yml
+++ b/.github/workflows/ci-test-header.yml
@@ -1,9 +1,10 @@
-name: SMARTS CI Header Test
+name: SMARTS CI Header
 
 on: [push]
 
 env:
   venv_dir: .venv
+
 jobs:
   test-header:
     runs-on: ubuntu-18.04
@@ -11,7 +12,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: header-test
+      - name: Check header
         run: |
           cd $GITHUB_WORKSPACE
           make header-test

--- a/.github/workflows/ci-test-learning.yml
+++ b/.github/workflows/ci-test-learning.yml
@@ -1,9 +1,12 @@
-name: SMARTS CI Master
+name: SMARTS CI Learning
 
 on:
-  push:
-    branches:
-      - disabled
+  schedule:
+    - cron: '0 23 * * 2'
+      # Time is in UTC
+      # Runs at 11.00pm, UTC  , every Tuesday
+      # Runs at  6.00pm, UTC-5, every Tuesday
+  workflow_dispatch:
 
 env:
   venv_dir: .venv
@@ -15,7 +18,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Package setup
+        with:
+          ref: develop
+      - name: Setup package
         run: |
           /usr/bin/Xorg \
             -noreset \
@@ -25,14 +30,14 @@ jobs:
             -logfile ./xdummy.log \
             -config /etc/X11/xorg.conf :1 &
           cd $GITHUB_WORKSPACE
-          python3.7 -m venv "${venv_dir}"
-          . "${venv_dir}/bin/activate"
+          python3.7 -m venv ${{env.venv_dir}}
+          . ${{env.venv_dir}}/bin/activate
           pip install --upgrade pip
           pip install wheel
           pip install -r requirements.txt
-          pip install -e .[train]
-      - name: Test learning
+          pip install -e .[train,test]
+      - name: Verify learning
         run: |
           cd $GITHUB_WORKSPACE
-          . "${venv_dir}/bin/activate"
+          . ${{env.venv_dir}}/bin/activate
           make test-learning

--- a/.github/workflows/ci-test-memory-growth.yml
+++ b/.github/workflows/ci-test-memory-growth.yml
@@ -1,9 +1,12 @@
 name: SMARTS CI Memory
 
 on:
-  push:
-    branches:
-      - disabled
+  schedule:
+    - cron: '0 23 * * 2'
+      # Time is in UTC
+      # Runs at 11.00pm, UTC  , every Tuesday
+      # Runs at  6.00pm, UTC-5, every Tuesday
+  workflow_dispatch:
 
 env:
   venv_dir: .venv
@@ -15,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: develop
       - name: Setup package
         run: |
           /usr/bin/Xorg \

--- a/.github/workflows/ci-test-memory-growth.yml
+++ b/.github/workflows/ci-test-memory-growth.yml
@@ -1,4 +1,4 @@
-name: SMARTS CI Master
+name: SMARTS CI Memory
 
 on:
   push:
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Package setup
+      - name: Setup package
         run: |
           /usr/bin/Xorg \
             -noreset \
@@ -25,15 +25,15 @@ jobs:
             -logfile ./xdummy.log \
             -config /etc/X11/xorg.conf :1 &
           cd $GITHUB_WORKSPACE
-          python3.7 -m venv "${venv_dir}"
-          . "${venv_dir}/bin/activate"
+          python3.7 -m venv ${{env.venv_dir}}
+          . ${{env.venv_dir}}/bin/activate
           pip install --upgrade pip
           pip install wheel
           pip install pympler
           pip install -r requirements.txt
-          pip install -e .[train]
+          pip install -e .[train,test]
       - name: Test memory growth
         run: |
           cd $GITHUB_WORKSPACE
-          . "${venv_dir}/bin/activate"
+          . ${{env.venv_dir}}/bin/activate
           make test-memory-growth


### PR DESCRIPTION
**Changes**
A new workflow file named “SMARTS CI Learning” is added to the `master` branch. 

**Trigger**
This workflow file is triggered on a schedule every Tuesday at 6pm (UTC-5). Alternatively, this workflow may be triggered manually via `workflow_dispatch`. 

**Action**
Once triggered, this workflow checks out the latest commit from the `develop` branch and runs the `make test-learning` command in the `develop` branch. 

**Result**
Only the last person to edit this workflow file will receive an email if the `make test-learning` fails. Everyone will be able to check the progress of this workflow under the “SMARTS CI Learning” workflow in the Github Actions tab. 

**Appearance**
This workflow’s status indicator, namely, `in progress`, `fail`, `pass`, does not appear neither on the `main` code page nor on the `develop` code page. The status of this workflow only appears under the Github Actions Tab.