### PR TITLE
Run CI on pull request from forked repo

### DIFF
--- a/.github/workflows/ci-base-tests.yml
+++ b/.github/workflows/ci-base-tests.yml
@@ -1,6 +1,6 @@
 name: SMARTS CI Base Tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/workflows/ci-formatting-and-dependencies.yml
+++ b/.github/workflows/ci-formatting-and-dependencies.yml
@@ -1,6 +1,6 @@
 name: SMARTS CI Format & Dependencies
 
-on: [push]
+on: [push, pull_request]
 
 env:
   venv_dir: .venv

--- a/.github/workflows/ci-test-header.yml
+++ b/.github/workflows/ci-test-header.yml
@@ -1,6 +1,6 @@
 name: SMARTS CI Header
 
-on: [push]
+on: [push, pull_request]
 
 env:
   venv_dir: .venv


### PR DESCRIPTION
When a pull request is made from a forked repo, the CI does not run as it is currently configured to be triggered only on a `push`. Hence, added `pull_request` to the trigger conditions of the CI workflows.

Note: Having both `push` and `pull_request` triggers may cause some duplicated GitHub Actions, but it is a simple solution to prevent erroneous merge commits.