### PR TITLE
Update evaluate.py to remove policy flag and add log directory flag

### DIFF
--- a/.github/workflows/ci-base-tests.yml
+++ b/.github/workflows/ci-base-tests.yml
@@ -1,7 +1,9 @@
 name: SMARTS CI Base Tests
 
-
-on : [push]
+on:
+  push:
+    branches:
+      - disabled
 
 jobs:
   test:

--- a/.github/workflows/ci-base-tests.yml
+++ b/.github/workflows/ci-base-tests.yml
@@ -1,9 +1,7 @@
 name: SMARTS CI Base Tests
 
-on:
-  push:
-    branches:
-      - disabled
+
+on : [push]
 
 jobs:
   test:

--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -35,6 +35,4 @@ jobs:
         run: |
           . .venv/bin/activate
           scl scenario build-all ultra/scenarios/pool
-          python ultra/scenarios/interface.py generate --task 1 --level easy
-          python ultra/train.py --task 1 --level easy --policy sac --headless True --episodes 10 --eval-rate 200 --eval-episodes 3 --log-dir ultra/tests/sac_test_models 
           pytest -v ./ultra/tests/ 

--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -35,6 +35,4 @@ jobs:
         run: |
           . .venv/bin/activate
           scl scenario build-all ultra/scenarios/pool
-          "python ultra/scenarios/interface.py generate --task 00 --level eval_test --root-dir ultra/tests/scenarios --save-dir ultra/tests/task/eval_test/eval"
-          python ultra/train.py --task 00 --level eval_test --policy sac --headless True --episodes 8 --eval-rate 350 --eval-episodes 1 --log-dir ultra/tests/sac_test_models
           pytest -v ./ultra/tests/ 

--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -35,4 +35,5 @@ jobs:
         run: |
           . .venv/bin/activate
           make build-all-scenarios
+          python ultra/train.py --task 1 --level easy --policy sac --headless True --episodes 10 --eval-rate 200 --eval-episodes 3 --log-dir ultra/tests/sac_test_models 
           pytest -v ./ultra/tests/ 

--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Run ultra tests
         run: |
           . .venv/bin/activate
-          make build-all-scenarios
+          scl scenario build-all ultra/scenarios/pool
+          python ultra/scenarios/interface.py generate --task 1 --level easy
           python ultra/train.py --task 1 --level easy --policy sac --headless True --episodes 10 --eval-rate 200 --eval-episodes 3 --log-dir ultra/tests/sac_test_models 
           pytest -v ./ultra/tests/ 

--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -35,4 +35,6 @@ jobs:
         run: |
           . .venv/bin/activate
           scl scenario build-all ultra/scenarios/pool
+          "python ultra/scenarios/interface.py generate --task 00 --level eval_test --root-dir ultra/tests/scenarios --save-dir ultra/tests/task/eval_test/eval"
+          python ultra/train.py --task 00 --level eval_test --policy sac --headless True --episodes 8 --eval-rate 350 --eval-episodes 1 --log-dir ultra/tests/sac_test_models
           pytest -v ./ultra/tests/ 

--- a/ultra/config.yaml
+++ b/ultra/config.yaml
@@ -3,6 +3,9 @@ tasks:
     easy:
       train: "ultra/tests/task/train_mock*"
       test:  "ultra/tests/task/test_mock*"
+    eval_test:
+      train: "ultra/tests/task/eval_test/eval*"
+      test:  "ultra/tests/task/eval_test/eval*"
   task0:
     no-traffic:
       train: "ultra/scenarios/task1/train_no-traffic*"

--- a/ultra/evaluate.py
+++ b/ultra/evaluate.py
@@ -161,7 +161,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("--models", default="models/", help="Directory to saved models")
     parser.add_argument(
-        "--episodes", help="Number of training episodes", type=int, default=5
+        "--episodes", help="Number of training episodes", type=int, default=200
     )
     parser.add_argument(
         "--timestep", help="Environment timestep (sec)", type=float, default=0.1

--- a/ultra/evaluate.py
+++ b/ultra/evaluate.py
@@ -183,7 +183,8 @@ if __name__ == "__main__":
         os.makedirs(args.log_dir)
 
     m = re.search(
-        "ultra\.[a-zA-Z0-9]+\.[a-zA-Z0-9]+\:[a-zA-Z0-9]+\-[a-zA-Z0-9]+", args.models
+        "ultra(\.)*([a-zA-Z0-9_]*\.)+([a-zA-Z0-9_])+\:[a-zA-Z0-9_]+((\-)*[a-zA-Z0-9_]*)*",
+        args.models,
     )
 
     try:

--- a/ultra/evaluate.py
+++ b/ultra/evaluate.py
@@ -116,7 +116,7 @@ def evaluate(
     summary_log = LogInfo()
     logs = []
 
-    for episode in episodes(num_episodes, etag=policy_class, dir=log_dir):
+    for episode in episodes(num_episodes, etag=policy_class, log_dir=log_dir):
         observations = env.reset()
         state = observations[agent_id]
         dones, infos = {"__all__": False}, None
@@ -183,17 +183,17 @@ if __name__ == "__main__":
         os.makedirs(args.log_dir)
 
     m = re.search(
-        "ultra\.baselines\.[a-zA-Z0-9]+\:[a-zA-Z0-9]+\-[a-zA-Z0-9]+", args.models
+        "ultra\.[a-zA-Z0-9]+\.[a-zA-Z0-9]+\:[a-zA-Z0-9]+\-[a-zA-Z0-9]+", args.models
     )
 
     try:
         policy_class = m.group(0)
     except AttributeError as e:
-        policy_class = "ultra.baselines.ppo:ppo-v0"
-    
+        # default policy class
+        policy_class = "ultra.baselines.sac:sac-v0"
+
     if not os.path.exists(args.models):
-        print(args.models)
-        raise "Models not Found"
+        raise "Path to model is invalid"
 
     if not os.listdir(args.models):
         raise "No models to evaluate"
@@ -210,7 +210,7 @@ if __name__ == "__main__":
     try:
         agent_id = "AGENT_008"
         for episode in episodes(
-            len(sorted_models), etag=policy_class, dir=args.log_dir
+            len(sorted_models), etag=policy_class, log_dir=args.log_dir
         ):
             model = sorted_models[episode.index]
             print("model: ", model)

--- a/ultra/evaluate.py
+++ b/ultra/evaluate.py
@@ -48,6 +48,7 @@ def evaluation_check(
     scenario_info,
     timestep_sec,
     headless,
+    log_dir,
 ):
     agent_itr = episode.get_itr(agent_id)
 
@@ -68,6 +69,7 @@ def evaluation_check(
                     num_episodes=eval_episodes,
                     headless=headless,
                     timestep_sec=timestep_sec,
+                    log_dir=log_dir,
                 )
             ]
         )[0]
@@ -159,7 +161,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("--models", default="models/", help="Directory to saved models")
     parser.add_argument(
-        "--episodes", help="Number of training episodes", type=int, default=200
+        "--episodes", help="Number of training episodes", type=int, default=5
     )
     parser.add_argument(
         "--timestep", help="Environment timestep (sec)", type=float, default=0.1
@@ -183,11 +185,14 @@ if __name__ == "__main__":
     m = re.search(
         "ultra\.baselines\.[a-zA-Z0-9]+\:[a-zA-Z0-9]+\-[a-zA-Z0-9]+", args.models
     )
-    policy_class = m.group(0)
-    print(args.models)
-    print(policy_class)
 
+    try:
+        policy_class = m.group(0)
+    except AttributeError as e:
+        policy_class = "ultra.baselines.ppo:ppo-v0"
+    
     if not os.path.exists(args.models):
+        print(args.models)
         raise "Models not Found"
 
     if not os.listdir(args.models):

--- a/ultra/evaluate.py
+++ b/ultra/evaluate.py
@@ -19,8 +19,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-import os
-import json
+import os, sys
+import json, re
 
 # Set environment to better support Ray
 os.environ["MKL_NUM_THREADS"] = "1"
@@ -90,6 +90,7 @@ def evaluate(
     num_episodes,
     headless,
     timestep_sec,
+    log_dir,
 ):
 
     torch.set_num_threads(1)
@@ -113,7 +114,7 @@ def evaluate(
     summary_log = LogInfo()
     logs = []
 
-    for episode in episodes(num_episodes):
+    for episode in episodes(num_episodes, etag=policy_class, dir=log_dir):
         observations = env.reset()
         state = observations[agent_id]
         dones, infos = {"__all__": False}, None
@@ -156,12 +157,6 @@ if __name__ == "__main__":
         type=str,
         default="easy",
     )
-    parser.add_argument(
-        "--policy",
-        help="Policies available : [ppo, sac, ddpg, dqn, bdqn]",
-        type=str,
-        default="sac",
-    )
     parser.add_argument("--models", default="models/", help="Directory to saved models")
     parser.add_argument(
         "--episodes", help="Number of training episodes", type=int, default=200
@@ -177,36 +172,41 @@ if __name__ == "__main__":
         help="Path to spec file that includes adapters and policy parameters",
         type=str,
     )
-
+    parser.add_argument(
+        "--log-dir", help="Log directory location", default="logs", type=str,
+    )
     args = parser.parse_args()
 
-    # --------------------------------------------------------
+    if not os.path.exists(args.log_dir):
+        os.makedirs(args.log_dir)
+
+    m = re.search(
+        "ultra\.baselines\.[a-zA-Z0-9]+\:[a-zA-Z0-9]+\-[a-zA-Z0-9]+", args.models
+    )
+    policy_class = m.group(0)
+    print(args.models)
+    print(policy_class)
+
     if not os.path.exists(args.models):
         raise "Models not Found"
+
+    if not os.listdir(args.models):
+        raise "No models to evaluate"
 
     sorted_models = sorted(
         glob.glob(f"{args.models}/*"), key=lambda x: int(x.split("/")[-1])
     )
 
-    with open("ultra/agent_pool.json", "r") as f:
-        data = json.load(f)
-        if args.policy in data["agents"].keys():
-            policy_path = data["agents"][args.policy]["path"]
-            policy_locator = data["agents"][args.policy]["locator"]
-        else:
-            raise ImportError("Invalid policy name. Please try again")
-
-    # Required string for smarts' class registry
-    policy_class = str(policy_path) + ":" + str(policy_locator)
-
     num_cpus = max(
         1, psutil.cpu_count(logical=False) - 1
     )  # remove `logical=False` to use all cpus
     ray_kwargs = default_ray_kwargs(num_cpus=num_cpus, num_gpus=num_gpus)
-    ray.init(**ray_kwargs)
+    ray.init()
     try:
         agent_id = "AGENT_008"
-        for episode in episodes(len(sorted_models), etag=args.policy):
+        for episode in episodes(
+            len(sorted_models), etag=policy_class, dir=args.log_dir
+        ):
             model = sorted_models[episode.index]
             print("model: ", model)
             episode_count = model.split("/")[-1]
@@ -224,6 +224,7 @@ if __name__ == "__main__":
                         num_episodes=int(args.episodes),
                         timestep_sec=float(args.timestep),
                         headless=args.headless,
+                        log_dir=args.log_dir,
                     )
                 ]
             )[0]

--- a/ultra/evaluate.py
+++ b/ultra/evaluate.py
@@ -203,10 +203,6 @@ if __name__ == "__main__":
         glob.glob(f"{args.models}/*"), key=lambda x: int(x.split("/")[-1])
     )
 
-    num_cpus = max(
-        1, psutil.cpu_count(logical=False) - 1
-    )  # remove `logical=False` to use all cpus
-    ray_kwargs = default_ray_kwargs(num_cpus=num_cpus, num_gpus=num_gpus)
     ray.init()
     try:
         agent_id = "AGENT_008"

--- a/ultra/tests/scenarios/task00/config.yaml
+++ b/ultra/tests/scenarios/task00/config.yaml
@@ -29,3 +29,41 @@ levels:
         2lane_t:
            percent: 1
            specs: [[70kmh,no-traffic,1]]
+  # Used in evaluation test
+  eval_test:
+    train:
+      total: 20
+      intersection_types:
+        2lane_t:
+          percent: 0.2
+          specs: [[50kmh,low-density,0.21],[70kmh,low-density,0.20],[100kmh,low-density,0.20], #61%
+                  [50kmh,mid-density,0.11],[70kmh,mid-density,0.11],[100kmh,mid-density,0.11], #33%,
+                  [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
+                  [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
+        2lane_curvy_t:
+          percent: 0.4
+          specs: [[50kmh,low-density,0.21],[70kmh,low-density,0.20],[100kmh,low-density,0.20], #61%
+                  [50kmh,mid-density,0.11],[70kmh,mid-density,0.11],[100kmh,mid-density,0.11], #33%
+                  [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
+                  [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
+        3lane_t:
+          percent: 0.4
+          specs: [[50kmh,low-density,0.21],[70kmh,low-density,0.20],[100kmh,low-density,0.20], #61%
+                  [50kmh,mid-density,0.11],[70kmh,mid-density,0.11],[100kmh,mid-density,0.11], #33%
+                  [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
+                  [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
+    test:
+      total: 10
+      intersection_types:
+        2lane_c:
+          percent: 0.5
+          specs: [[50kmh,low-density,0.21],[70kmh,low-density,0.20],[100kmh,low-density,0.20], #61%
+                  [50kmh,mid-density,0.11],[70kmh,mid-density,0.11],[100kmh,mid-density,0.11], #33%
+                  [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
+                  [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
+        3lane_c:
+          percent: 0.5
+          specs: [[50kmh,low-density,0.21],[70kmh,low-density,0.20],[100kmh,low-density,0.20], #61%
+                  [50kmh,mid-density,0.11],[70kmh,mid-density,0.11],[100kmh,mid-density,0.11], #33%
+                  [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
+                  [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%

--- a/ultra/tests/test_episode.py
+++ b/ultra/tests/test_episode.py
@@ -20,12 +20,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 import unittest
-from ultra.baselines.ppo.ppo.policy import PPOPolicy
 import gym, ray
 from ultra.utils.episode import episodes
 import numpy as np
-from ultra.baselines.agent_spec import BaselineAgentSpec
-from smarts.core.controllers import ActionSpaceType
 from smarts.zoo.registry import make
 
 AGENT_ID = "001"

--- a/ultra/tests/test_evaluate.py
+++ b/ultra/tests/test_evaluate.py
@@ -38,7 +38,7 @@ class EvaluateTest(unittest.TestCase):
         os.system(
             "python ultra/scenarios/interface.py generate --task 00 --level eval_test --root-dir ultra/tests/scenarios/ --save-dir ultra/tests/task/eval_test/eval"
         )
-        
+
         path = "ultra/tests/sac_test_models"
         if not os.path.exists(path):
             # Generate models before evaluation tests
@@ -177,7 +177,7 @@ class EvaluateTest(unittest.TestCase):
         #     self.assertTrue(False)
         # else:
         #     shutil.rmtree(log_dir)
-            
+
     # @classmethod
     # def tearDownClass(cls):
     #     os.system("ray stop")

--- a/ultra/tests/test_evaluate.py
+++ b/ultra/tests/test_evaluate.py
@@ -19,7 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-import ray, glob, gym, os, sys
+import ray, glob, gym, os, sys, re
 import unittest, shutil
 import dill, pickle
 from ultra.evaluate import evaluate, evaluation_check
@@ -33,151 +33,174 @@ AGENT_ID = "001"
 
 
 class EvaluateTest(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        os.system(
-            "python ultra/scenarios/interface.py generate --task 00 --level eval_test --root-dir ultra/tests/scenarios --save-dir ultra/tests/task/eval_test/eval"
-        )
+    # @classmethod
+    # def setUpClass(cls):
+    #     os.system(
+    #         "python ultra/scenarios/interface.py generate --task 00 --level eval_test --root-dir ultra/tests/scenarios --save-dir ultra/tests/task/eval_test/eval"
+    #     )
 
-        path = "ultra/tests/sac_test_models"
-        if not os.path.exists(path):
-            # Generate models before evaluation tests
-            os.system(
-                "python ultra/train.py --task 00 --level eval_test --policy sac --headless True --episodes 8 --eval-rate 350 --eval-episodes 1 --log-dir ultra/tests/sac_test_models"
+    #     path = "ultra/tests/sac_test_models"
+    #     if not os.path.exists(path):
+    #         # Generate models before evaluation tests
+    #         os.system(
+    #             "python ultra/train.py --task 00 --level eval_test --policy sac --headless True --episodes 8 --eval-rate 350 --eval-episodes 1 --log-dir ultra/tests/sac_test_models"
+    #         )
+
+    # def test_a_folders(self):
+    #     path = "ultra/tests/sac_test_models"
+    #     if not os.path.exists(path):
+    #         self.assertTrue(False)
+
+    #     path = glob.glob("ultra/tests/sac_test_models/*/models")[0]
+    #     if len(os.listdir(path)) == 0:
+    #         self.assertTrue(False)
+
+    #     path = "ultra/tests/task/eval_test"
+    #     if len(os.listdir(path)) <= 2:
+    #         self.assertTrue(False)
+
+    # def test_evaluation_check(self):
+    #     log_dir = "ultra/tests/output_eval_check_logs"
+    #     # @ray.remote(max_calls=1, num_gpus=0)
+    #     def run_experiment():
+    #         total_step = 0
+    #         agent, env, spec = prepare_test_env_agent(headless=True)
+    #         timestep_sec = env.timestep_sec
+    #         policy_class = "ultra.baselines.sac:sac-v0"
+    #         log_dir = "ultra/tests/output_eval_check_logs"
+
+    #         for episode in episodes(1, etag=policy_class, log_dir=log_dir):
+    #             observations = env.reset()
+    #             state = observations[AGENT_ID]
+    #             dones, infos = {"__all__": False}, None
+    #             episode.reset()
+    #             experiment_dir = episode.experiment_dir
+
+    #             if not os.path.exists(f"{experiment_dir}/spec.pkl"):
+    #                 if not os.path.exists(experiment_dir):
+    #                     os.makedirs(experiment_dir)
+    #                 with open(f"{experiment_dir}/spec.pkl", "wb") as spec_output:
+    #                     dill.dump(spec, spec_output, pickle.HIGHEST_PROTOCOL)
+
+    #             while not dones["__all__"]:
+    #                 evaluation_check(
+    #                     agent=agent,
+    #                     agent_id=AGENT_ID,
+    #                     episode=episode,
+    #                     eval_rate=10,
+    #                     eval_episodes=1,
+    #                     policy_class=policy_class,
+    #                     scenario_info=("00", "eval_test"),
+    #                     timestep_sec=0.1,
+    #                     headless=True,
+    #                     log_dir=log_dir,
+    #                 )
+    #                 action = agent.act(state, explore=True)
+    #                 observations, rewards, dones, infos = env.step({AGENT_ID: action})
+    #                 next_state = observations[AGENT_ID]
+
+    #                 # retrieve some relavant information from reward processor
+    #                 # observations[AGENT_ID]["ego"].update(rewards[AGENT_ID]["log"])
+    #                 loss_output = agent.step(
+    #                     state=state,
+    #                     action=action,
+    #                     reward=rewards[AGENT_ID],
+    #                     next_state=next_state,
+    #                     done=dones[AGENT_ID],
+    #                 )
+    #                 episode.record_step(
+    #                     agent_id=AGENT_ID,
+    #                     infos=infos,
+    #                     rewards=rewards,
+    #                     total_step=total_step,
+    #                     loss_output=loss_output,
+    #                 )
+    #                 total_step += 1
+    #                 state = next_state
+
+    #         env.close()
+
+    #     # ray.init(ignore_reinit_error=True)
+    #     ray.shutdown()
+    #     ray.init()
+    #     try:
+    #         run_experiment()
+    #         self.assertTrue(True)
+    #     except Exception as err:
+    #         print(err)
+    #         self.assertTrue(False)
+
+    #     if not os.listdir(log_dir):
+    #         raise "Evaluation failed to generate new experiment folder"
+    #         self.assertTrue(False)
+    #     else:
+    #         shutil.rmtree(log_dir)
+
+    # def test_evaluate_cli(self):
+    #     log_dir = "ultra/tests/output_eval_cli_logs/"
+    #     model_dir = glob.glob("ultra/tests/sac_test_models/*/models")[0]
+    #     ray.shutdown()
+    #     try:
+    #         os.system(
+    #             f"python ultra/evaluate.py --task 00 --level eval_test --models {model_dir} --episodes 1 --log-dir {log_dir} --headless True"
+    #         )
+    #         self.assertTrue(True)
+    #     except Exception as err:
+    #         print(err)
+    #         self.assertTrue(False)
+
+    # def test_evaluate_agent(self):
+    #     seed = 2
+    #     model = glob.glob("ultra/tests/sac_test_models/*/models/")[0]
+    #     log_dir = "ultra/tests/output_eval_agent_logs"
+    #     policy_class = "ultra.baselines.sac:sac-v0"
+
+    #     if not os.path.exists(log_dir):
+    #         os.makedirs(log_dir)
+
+    #     ray.shutdown()
+    #     ray.init(ignore_reinit_error=True)
+    #     try:
+    #         evaluate.remote(
+    #             experiment_dir=None,
+    #             agent_id="AGENT_001",
+    #             policy_class=policy_class,
+    #             seed=seed,
+    #             itr_count=0,
+    #             checkpoint_dir=model,
+    #             scenario_info=("00", "eval_test"),
+    #             num_episodes=1,
+    #             timestep_sec=0.1,
+    #             headless=True,
+    #             log_dir=log_dir,
+    #         )
+    #         self.assertTrue(True)
+    #     except Exception as err:
+    #         print(err)
+    #         self.assertTrue(False)
+
+    def test_extract_policy_from_path(self):
+        paths = [
+            "from.ultra.baselines.sac:sac-v0",
+            "hello.ultra.ppo:ppo-v1",
+            "ultra.custom:custom",
+            "a.sb.ultra.c.d.e.sac:sac-v99",
+            "a.b.c.d.e.ultra.custom_agent.policy:MBPO-v2",
+        ]
+
+        def extract(path):
+            m = re.search(
+                "ultra(\.)*([a-zA-Z0-9_]*\.)+([a-zA-Z0-9_])+\:[a-zA-Z0-9_]+((\-)*[a-zA-Z0-9_]*)*",
+                path,
             )
 
-    def test_a_folders(self):
-        path = "ultra/tests/sac_test_models"
-        if not os.path.exists(path):
-            self.assertTrue(False)
+            try:
+                policy_class = m.group(0)
+            except AttributeError as e:
+                assert False
 
-        path = glob.glob("ultra/tests/sac_test_models/*/models")[0]
-        if len(os.listdir(path)) == 0:
-            self.assertTrue(False)
-
-        path = "ultra/tests/task/eval_test"
-        if len(os.listdir(path)) <= 2:
-            self.assertTrue(False)
-
-    def test_evaluation_check(self):
-        log_dir = "ultra/tests/output_eval_check_logs"
-        # @ray.remote(max_calls=1, num_gpus=0)
-        def run_experiment():
-            total_step = 0
-            agent, env, spec = prepare_test_env_agent(headless=True)
-            timestep_sec = env.timestep_sec
-            policy_class = "ultra.baselines.sac:sac-v0"
-            log_dir = "ultra/tests/output_eval_check_logs"
-
-            for episode in episodes(1, etag=policy_class, log_dir=log_dir):
-                observations = env.reset()
-                state = observations[AGENT_ID]
-                dones, infos = {"__all__": False}, None
-                episode.reset()
-                experiment_dir = episode.experiment_dir
-
-                if not os.path.exists(f"{experiment_dir}/spec.pkl"):
-                    if not os.path.exists(experiment_dir):
-                        os.makedirs(experiment_dir)
-                    with open(f"{experiment_dir}/spec.pkl", "wb") as spec_output:
-                        dill.dump(spec, spec_output, pickle.HIGHEST_PROTOCOL)
-
-                while not dones["__all__"]:
-                    evaluation_check(
-                        agent=agent,
-                        agent_id=AGENT_ID,
-                        episode=episode,
-                        eval_rate=10,
-                        eval_episodes=1,
-                        policy_class=policy_class,
-                        scenario_info=("00", "eval_test"),
-                        timestep_sec=0.1,
-                        headless=True,
-                        log_dir=log_dir,
-                    )
-                    action = agent.act(state, explore=True)
-                    observations, rewards, dones, infos = env.step({AGENT_ID: action})
-                    next_state = observations[AGENT_ID]
-
-                    # retrieve some relavant information from reward processor
-                    # observations[AGENT_ID]["ego"].update(rewards[AGENT_ID]["log"])
-                    loss_output = agent.step(
-                        state=state,
-                        action=action,
-                        reward=rewards[AGENT_ID],
-                        next_state=next_state,
-                        done=dones[AGENT_ID],
-                    )
-                    episode.record_step(
-                        agent_id=AGENT_ID,
-                        infos=infos,
-                        rewards=rewards,
-                        total_step=total_step,
-                        loss_output=loss_output,
-                    )
-                    total_step += 1
-                    state = next_state
-
-            env.close()
-
-        # ray.init(ignore_reinit_error=True)
-        ray.shutdown()
-        ray.init()
-        try:
-            run_experiment()
-            self.assertTrue(True)
-        except Exception as err:
-            print(err)
-            self.assertTrue(False)
-
-        if not os.listdir(log_dir):
-            raise "Evaluation failed to generate new experiment folder"
-            self.assertTrue(False)
-        else:
-            shutil.rmtree(log_dir)
-
-    def test_evaluate_cli(self):
-        log_dir = "ultra/tests/output_eval_cli_logs/"
-        model_dir = glob.glob("ultra/tests/sac_test_models/*/models")[0]
-        ray.shutdown()
-        try:
-            os.system(
-                f"python ultra/evaluate.py --task 00 --level eval_test --models {model_dir} --episodes 1 --log-dir {log_dir} --headless True"
-            )
-            self.assertTrue(True)
-        except Exception as err:
-            print(err)
-            self.assertTrue(False)
-
-    def test_evaluate_agent(self):
-        seed = 2
-        model = glob.glob("ultra/tests/sac_test_models/*/models/")[0]
-        log_dir = "ultra/tests/output_eval_agent_logs"
-        policy_class = "ultra.baselines.sac:sac-v0"
-
-        if not os.path.exists(log_dir):
-            os.makedirs(log_dir)
-
-        ray.shutdown()
-        ray.init(ignore_reinit_error=True)
-        try:
-            evaluate.remote(
-                experiment_dir=None,
-                agent_id="AGENT_001",
-                policy_class=policy_class,
-                seed=seed,
-                itr_count=0,
-                checkpoint_dir=model,
-                scenario_info=("00", "eval_test"),
-                num_episodes=1,
-                timestep_sec=0.1,
-                headless=True,
-                log_dir=log_dir,
-            )
-            self.assertTrue(True)
-        except Exception as err:
-            print(err)
-            self.assertTrue(False)
+        for path in paths:
+            extract(path)
 
     # @classmethod
     # def tearDownClass(cls):

--- a/ultra/tests/test_evaluate.py
+++ b/ultra/tests/test_evaluate.py
@@ -30,7 +30,7 @@ policy_class = "ultra.baselines.ppo:ppo-v0"
 AGENT_ID = "001"
 
 
-class EvaluateTest(unittest.TestCase):
+#class EvaluateTest(unittest.TestCase):
     # def test_evaluation_check(self):
     #     # @ray.remote(max_calls=1, num_gpus=0)
     #     def run_experiment():
@@ -88,52 +88,52 @@ class EvaluateTest(unittest.TestCase):
     #         print(err)
     #         self.assertTrue(False)
 
-    def test_evaluate_cli(self):
-        try:
-            os.system(
-                "python ultra/evaluate.py --task 00 --level easy --policy ppo --models ultra/tests/ppo_models/models --episodes 1"
-            )
-            self.assertTrue(True)
-        except Exception as err:
-            print(err)
-            self.assertTrue(False)
+#     def test_evaluate_cli(self):
+#         try:
+#             os.system(
+#                 "python ultra/evaluate.py --task 00 --level easy --policy ppo --models ultra/tests/ppo_models/models --episodes 1"
+#             )
+#             self.assertTrue(True)
+#         except Exception as err:
+#             print(err)
+#             self.assertTrue(False)
 
-    def test_evaluate_agent(self):
-        seed = 2
-        model = glob.glob("ultra/tests/ppo_models/models/*")[0]
+#     def test_evaluate_agent(self):
+#         seed = 2
+#         model = glob.glob("ultra/tests/ppo_models/models/*")[0]
 
-        ray.init(ignore_reinit_error=True)
-        try:
-            evaluate.remote(
-                experiment_dir=None,
-                agent_id="AGENT_001",
-                policy_class=policy_class,
-                seed=seed,
-                itr_count=0,
-                checkpoint_dir=model,
-                scenario_info=("00", "easy"),
-                num_episodes=2,
-                timestep_sec=0.1,
-                headless=True,
-            )
-            self.assertTrue(True)
-        except Exception as err:
-            print(err)
-            self.assertTrue(False)
+#         ray.init(ignore_reinit_error=True)
+#         try:
+#             evaluate.remote(
+#                 experiment_dir=None,
+#                 agent_id="AGENT_001",
+#                 policy_class=policy_class,
+#                 seed=seed,
+#                 itr_count=0,
+#                 checkpoint_dir=model,
+#                 scenario_info=("00", "easy"),
+#                 num_episodes=2,
+#                 timestep_sec=0.1,
+#                 headless=True,
+#             )
+#             self.assertTrue(True)
+#         except Exception as err:
+#             print(err)
+#             self.assertTrue(False)
 
 
-def prepare_test_env_agent(headless=True):
-    timestep_sec = 0.1
-    # [throttle, brake, steering]
-    policy_class = "ultra.baselines.ppo:ppo-v0"
-    spec = make(locator=policy_class)
-    env = gym.make(
-        "ultra.env:ultra-v0",
-        agent_specs={AGENT_ID: spec},
-        scenario_info=("00", "easy"),
-        headless=headless,
-        timestep_sec=timestep_sec,
-        seed=seed,
-    )
-    agent = spec.build_agent()
-    return agent, env
+# def prepare_test_env_agent(headless=True):
+#     timestep_sec = 0.1
+#     # [throttle, brake, steering]
+#     policy_class = "ultra.baselines.ppo:ppo-v0"
+#     spec = make(locator=policy_class)
+#     env = gym.make(
+#         "ultra.env:ultra-v0",
+#         agent_specs={AGENT_ID: spec},
+#         scenario_info=("00", "easy"),
+#         headless=headless,
+#         timestep_sec=timestep_sec,
+#         seed=seed,
+#     )
+#     agent = spec.build_agent()
+#     return agent, env

--- a/ultra/tests/test_evaluate.py
+++ b/ultra/tests/test_evaluate.py
@@ -33,151 +33,151 @@ AGENT_ID = "001"
 
 
 class EvaluateTest(unittest.TestCase):
-    # @classmethod
-    # def setUpClass(cls):
-    #     os.system(
-    #         "python ultra/scenarios/interface.py generate --task 00 --level eval_test --root-dir ultra/tests/scenarios --save-dir ultra/tests/task/eval_test/eval"
-    #     )
+    @classmethod
+    def setUpClass(cls):
+        os.system(
+            "python ultra/scenarios/interface.py generate --task 00 --level eval_test --root-dir ultra/tests/scenarios --save-dir ultra/tests/task/eval_test/eval"
+        )
 
-    #     path = "ultra/tests/sac_test_models"
-    #     if not os.path.exists(path):
-    #         # Generate models before evaluation tests
-    #         os.system(
-    #             "python ultra/train.py --task 00 --level eval_test --policy sac --headless True --episodes 8 --eval-rate 350 --eval-episodes 1 --log-dir ultra/tests/sac_test_models"
-    #         )
+        path = "ultra/tests/sac_test_models"
+        if not os.path.exists(path):
+            # Generate models before evaluation tests
+            os.system(
+                "python ultra/train.py --task 00 --level eval_test --policy sac --headless True --episodes 8 --eval-rate 350 --eval-episodes 1 --log-dir ultra/tests/sac_test_models"
+            )
 
-    # def test_a_folders(self):
-    #     path = "ultra/tests/sac_test_models"
-    #     if not os.path.exists(path):
-    #         self.assertTrue(False)
+    def test_a_folders(self):
+        path = "ultra/tests/sac_test_models"
+        if not os.path.exists(path):
+            self.assertTrue(False)
 
-    #     path = glob.glob("ultra/tests/sac_test_models/*/models")[0]
-    #     if len(os.listdir(path)) == 0:
-    #         self.assertTrue(False)
+        path = glob.glob("ultra/tests/sac_test_models/*/models")[0]
+        if len(os.listdir(path)) == 0:
+            self.assertTrue(False)
 
-    #     path = "ultra/tests/task/eval_test"
-    #     if len(os.listdir(path)) <= 2:
-    #         self.assertTrue(False)
+        path = "ultra/tests/task/eval_test"
+        if len(os.listdir(path)) <= 2:
+            self.assertTrue(False)
 
-    # def test_evaluation_check(self):
-    #     log_dir = "ultra/tests/output_eval_check_logs"
-    #     # @ray.remote(max_calls=1, num_gpus=0)
-    #     def run_experiment():
-    #         total_step = 0
-    #         agent, env, spec = prepare_test_env_agent(headless=True)
-    #         timestep_sec = env.timestep_sec
-    #         policy_class = "ultra.baselines.sac:sac-v0"
-    #         log_dir = "ultra/tests/output_eval_check_logs"
+    def test_evaluation_check(self):
+        log_dir = "ultra/tests/output_eval_check_logs"
+        # @ray.remote(max_calls=1, num_gpus=0)
+        def run_experiment():
+            total_step = 0
+            agent, env, spec = prepare_test_env_agent(headless=True)
+            timestep_sec = env.timestep_sec
+            policy_class = "ultra.baselines.sac:sac-v0"
+            log_dir = "ultra/tests/output_eval_check_logs"
 
-    #         for episode in episodes(1, etag=policy_class, log_dir=log_dir):
-    #             observations = env.reset()
-    #             state = observations[AGENT_ID]
-    #             dones, infos = {"__all__": False}, None
-    #             episode.reset()
-    #             experiment_dir = episode.experiment_dir
+            for episode in episodes(1, etag=policy_class, log_dir=log_dir):
+                observations = env.reset()
+                state = observations[AGENT_ID]
+                dones, infos = {"__all__": False}, None
+                episode.reset()
+                experiment_dir = episode.experiment_dir
 
-    #             if not os.path.exists(f"{experiment_dir}/spec.pkl"):
-    #                 if not os.path.exists(experiment_dir):
-    #                     os.makedirs(experiment_dir)
-    #                 with open(f"{experiment_dir}/spec.pkl", "wb") as spec_output:
-    #                     dill.dump(spec, spec_output, pickle.HIGHEST_PROTOCOL)
+                if not os.path.exists(f"{experiment_dir}/spec.pkl"):
+                    if not os.path.exists(experiment_dir):
+                        os.makedirs(experiment_dir)
+                    with open(f"{experiment_dir}/spec.pkl", "wb") as spec_output:
+                        dill.dump(spec, spec_output, pickle.HIGHEST_PROTOCOL)
 
-    #             while not dones["__all__"]:
-    #                 evaluation_check(
-    #                     agent=agent,
-    #                     agent_id=AGENT_ID,
-    #                     episode=episode,
-    #                     eval_rate=10,
-    #                     eval_episodes=1,
-    #                     policy_class=policy_class,
-    #                     scenario_info=("00", "eval_test"),
-    #                     timestep_sec=0.1,
-    #                     headless=True,
-    #                     log_dir=log_dir,
-    #                 )
-    #                 action = agent.act(state, explore=True)
-    #                 observations, rewards, dones, infos = env.step({AGENT_ID: action})
-    #                 next_state = observations[AGENT_ID]
+                while not dones["__all__"]:
+                    evaluation_check(
+                        agent=agent,
+                        agent_id=AGENT_ID,
+                        episode=episode,
+                        eval_rate=10,
+                        eval_episodes=1,
+                        policy_class=policy_class,
+                        scenario_info=("00", "eval_test"),
+                        timestep_sec=0.1,
+                        headless=True,
+                        log_dir=log_dir,
+                    )
+                    action = agent.act(state, explore=True)
+                    observations, rewards, dones, infos = env.step({AGENT_ID: action})
+                    next_state = observations[AGENT_ID]
 
-    #                 # retrieve some relavant information from reward processor
-    #                 # observations[AGENT_ID]["ego"].update(rewards[AGENT_ID]["log"])
-    #                 loss_output = agent.step(
-    #                     state=state,
-    #                     action=action,
-    #                     reward=rewards[AGENT_ID],
-    #                     next_state=next_state,
-    #                     done=dones[AGENT_ID],
-    #                 )
-    #                 episode.record_step(
-    #                     agent_id=AGENT_ID,
-    #                     infos=infos,
-    #                     rewards=rewards,
-    #                     total_step=total_step,
-    #                     loss_output=loss_output,
-    #                 )
-    #                 total_step += 1
-    #                 state = next_state
+                    # retrieve some relavant information from reward processor
+                    # observations[AGENT_ID]["ego"].update(rewards[AGENT_ID]["log"])
+                    loss_output = agent.step(
+                        state=state,
+                        action=action,
+                        reward=rewards[AGENT_ID],
+                        next_state=next_state,
+                        done=dones[AGENT_ID],
+                    )
+                    episode.record_step(
+                        agent_id=AGENT_ID,
+                        infos=infos,
+                        rewards=rewards,
+                        total_step=total_step,
+                        loss_output=loss_output,
+                    )
+                    total_step += 1
+                    state = next_state
 
-    #         env.close()
+            env.close()
 
-    #     # ray.init(ignore_reinit_error=True)
-    #     ray.shutdown()
-    #     ray.init()
-    #     try:
-    #         run_experiment()
-    #         self.assertTrue(True)
-    #     except Exception as err:
-    #         print(err)
-    #         self.assertTrue(False)
+        # ray.init(ignore_reinit_error=True)
+        ray.shutdown()
+        ray.init()
+        try:
+            run_experiment()
+            self.assertTrue(True)
+        except Exception as err:
+            print(err)
+            self.assertTrue(False)
 
-    #     if not os.listdir(log_dir):
-    #         raise "Evaluation failed to generate new experiment folder"
-    #         self.assertTrue(False)
-    #     else:
-    #         shutil.rmtree(log_dir)
+        if not os.listdir(log_dir):
+            raise "Evaluation failed to generate new experiment folder"
+            self.assertTrue(False)
+        else:
+            shutil.rmtree(log_dir)
 
-    # def test_evaluate_cli(self):
-    #     log_dir = "ultra/tests/output_eval_cli_logs/"
-    #     model_dir = glob.glob("ultra/tests/sac_test_models/*/models")[0]
-    #     ray.shutdown()
-    #     try:
-    #         os.system(
-    #             f"python ultra/evaluate.py --task 00 --level eval_test --models {model_dir} --episodes 1 --log-dir {log_dir} --headless True"
-    #         )
-    #         self.assertTrue(True)
-    #     except Exception as err:
-    #         print(err)
-    #         self.assertTrue(False)
+    def test_evaluate_cli(self):
+        log_dir = "ultra/tests/output_eval_cli_logs/"
+        model_dir = glob.glob("ultra/tests/sac_test_models/*/models")[0]
+        ray.shutdown()
+        try:
+            os.system(
+                f"python ultra/evaluate.py --task 00 --level eval_test --models {model_dir} --episodes 1 --log-dir {log_dir} --headless True"
+            )
+            self.assertTrue(True)
+        except Exception as err:
+            print(err)
+            self.assertTrue(False)
 
-    # def test_evaluate_agent(self):
-    #     seed = 2
-    #     model = glob.glob("ultra/tests/sac_test_models/*/models/")[0]
-    #     log_dir = "ultra/tests/output_eval_agent_logs"
-    #     policy_class = "ultra.baselines.sac:sac-v0"
+    def test_evaluate_agent(self):
+        seed = 2
+        model = glob.glob("ultra/tests/sac_test_models/*/models/")[0]
+        log_dir = "ultra/tests/output_eval_agent_logs"
+        policy_class = "ultra.baselines.sac:sac-v0"
 
-    #     if not os.path.exists(log_dir):
-    #         os.makedirs(log_dir)
+        if not os.path.exists(log_dir):
+            os.makedirs(log_dir)
 
-    #     ray.shutdown()
-    #     ray.init(ignore_reinit_error=True)
-    #     try:
-    #         evaluate.remote(
-    #             experiment_dir=None,
-    #             agent_id="AGENT_001",
-    #             policy_class=policy_class,
-    #             seed=seed,
-    #             itr_count=0,
-    #             checkpoint_dir=model,
-    #             scenario_info=("00", "eval_test"),
-    #             num_episodes=1,
-    #             timestep_sec=0.1,
-    #             headless=True,
-    #             log_dir=log_dir,
-    #         )
-    #         self.assertTrue(True)
-    #     except Exception as err:
-    #         print(err)
-    #         self.assertTrue(False)
+        ray.shutdown()
+        ray.init(ignore_reinit_error=True)
+        try:
+            evaluate.remote(
+                experiment_dir=None,
+                agent_id="AGENT_001",
+                policy_class=policy_class,
+                seed=seed,
+                itr_count=0,
+                checkpoint_dir=model,
+                scenario_info=("00", "eval_test"),
+                num_episodes=1,
+                timestep_sec=0.1,
+                headless=True,
+                log_dir=log_dir,
+            )
+            self.assertTrue(True)
+        except Exception as err:
+            print(err)
+            self.assertTrue(False)
 
     def test_extract_policy_from_path(self):
         paths = [

--- a/ultra/tests/test_evaluate.py
+++ b/ultra/tests/test_evaluate.py
@@ -36,7 +36,7 @@ class EvaluateTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         os.system(
-            "python ultra/scenarios/interface.py generate --task 00 --level eval_test --root-dir ultra/tests/scenarios/ --save-dir ultra/tests/task/eval_test/eval"
+            "python ultra/scenarios/interface.py generate --task 00 --level eval_test --root-dir ultra/tests/scenarios --save-dir ultra/tests/task/eval_test/eval"
         )
 
         path = "ultra/tests/sac_test_models"
@@ -45,6 +45,19 @@ class EvaluateTest(unittest.TestCase):
             os.system(
                 "python ultra/train.py --task 00 --level eval_test --policy sac --headless True --episodes 8 --eval-rate 350 --eval-episodes 1 --log-dir ultra/tests/sac_test_models"
             )
+
+    def test_a_folders(self):
+        path = "ultra/tests/sac_test_models"
+        if not os.path.exists(path):
+            self.assertTrue(False)
+
+        path = glob.glob("ultra/tests/sac_test_models/*/models")[0]
+        if len(os.listdir(path)) == 0:
+            self.assertTrue(False)
+
+        path = "ultra/tests/task/eval_test"
+        if len(os.listdir(path)) <= 2:
+            self.assertTrue(False)
 
     def test_evaluation_check(self):
         log_dir = "ultra/tests/output_eval_check_logs"
@@ -125,7 +138,7 @@ class EvaluateTest(unittest.TestCase):
 
     def test_evaluate_cli(self):
         log_dir = "ultra/tests/output_eval_cli_logs/"
-        model_dir = glob.glob("ultra/tests/sac_test_models/*/models/")[0]
+        model_dir = glob.glob("ultra/tests/sac_test_models/*/models")[0]
         ray.shutdown()
         try:
             os.system(
@@ -135,12 +148,6 @@ class EvaluateTest(unittest.TestCase):
         except Exception as err:
             print(err)
             self.assertTrue(False)
-
-        if not os.listdir(log_dir):
-            raise "Evaluation failed to generate new experiment folder"
-            self.assertTrue(False)
-        else:
-            shutil.rmtree(log_dir)
 
     def test_evaluate_agent(self):
         seed = 2
@@ -171,12 +178,6 @@ class EvaluateTest(unittest.TestCase):
         except Exception as err:
             print(err)
             self.assertTrue(False)
-
-        # if not os.listdir(log_dir):
-        #     raise "Evaluation failed to generate new experiment folder"
-        #     self.assertTrue(False)
-        # else:
-        #     shutil.rmtree(log_dir)
 
     # @classmethod
     # def tearDownClass(cls):

--- a/ultra/tests/test_evaluate.py
+++ b/ultra/tests/test_evaluate.py
@@ -46,18 +46,18 @@ class EvaluateTest(unittest.TestCase):
                 "python ultra/train.py --task 00 --level eval_test --policy sac --headless True --episodes 8 --eval-rate 350 --eval-episodes 1 --log-dir ultra/tests/sac_test_models"
             )
 
-    def test_a_folders(self):
-        path = "ultra/tests/sac_test_models"
-        if not os.path.exists(path):
-            self.assertTrue(False)
+    # def test_a_folders(self):
+    #     path = "ultra/tests/sac_test_models"
+    #     if not os.path.exists(path):
+    #         self.assertTrue(False)
 
-        path = glob.glob("ultra/tests/sac_test_models/*/models")[0]
-        if len(os.listdir(path)) == 0:
-            self.assertTrue(False)
+    #     path = glob.glob("ultra/tests/sac_test_models/*/models")[0]
+    #     if len(os.listdir(path)) == 0:
+    #         self.assertTrue(False)
 
-        path = "ultra/tests/task/eval_test"
-        if len(os.listdir(path)) <= 2:
-            self.assertTrue(False)
+    #     path = "ultra/tests/task/eval_test"
+    #     if len(os.listdir(path)) <= 2:
+    #         self.assertTrue(False)
 
     def test_evaluation_check(self):
         log_dir = "ultra/tests/output_eval_check_logs"

--- a/ultra/tests/test_evaluate.py
+++ b/ultra/tests/test_evaluate.py
@@ -19,123 +19,175 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-import unittest, ray, glob, gym, os
+import ray, glob, gym, os, sys
+import unittest, shutil
+import dill, pickle
 from ultra.evaluate import evaluate, evaluation_check
-from ultra.utils.episode import episodes
 from ultra.baselines.agent_spec import BaselineAgentSpec
-from smarts.zoo.registry import make
+from ultra.baselines.sac.sac.policy import SACPolicy
+from smarts.core.controllers import ActionSpaceType
+from ultra.utils.episode import episodes
 
 seed = 2
-policy_class = "ultra.baselines.ppo:ppo-v0"
 AGENT_ID = "001"
 
 
 class EvaluateTest(unittest.TestCase):
-    # def test_evaluation_check(self):
-    #     # @ray.remote(max_calls=1, num_gpus=0)
-    #     def run_experiment():
-    #         total_step = 0
-    #         agent, env = prepare_test_env_agent(headless=False)
-    #         timestep_sec = env.timestep_sec
-    #         for episode in episodes(1, etag="Train"):
-    #             observations = env.reset()
-    #             state = observations[AGENT_ID]
-    #             dones, infos = {"__all__": False}, None
-    #             episode.reset()
-    #             while not dones["__all__"]:
-    #                 evaluation_check(
-    #                     agent=agent,
-    #                     agent_id=AGENT_ID,
-    #                     episode=episode,
-    #                     eval_rate=10,
-    #                     eval_episodes=1,
-    #                     policy_class=policy_class,
-    #                     scenario_info=("00", "easy"),
-    #                     timestep_sec=0.1,
-    #                     headless=True,
-    #                 )
-    #                 action = agent.act(state, explore=True)
-    #                 observations, rewards, dones, infos = env.step({AGENT_ID: action})
-    #                 next_state = observations[AGENT_ID]
+    @classmethod
+    def setUpClass(cls):
+        model_path = "ultra/tests/sac_test_models"
+        if not os.path.exists(model_path):
+            # Generate models before evaluation tests
+            os.system(
+                "python ultra/train.py --task 1 --level easy --policy sac --headless True --episodes 10 --eval-rate 200 --eval-episodes 3 --log-dir ultra/tests/sac_test_models "
+            )
 
-    #                 # retrieve some relavant information from reward processor
-    #                 # observations[AGENT_ID]["ego"].update(rewards[AGENT_ID]["log"])
-    #                 loss_output = agent.step(
-    #                     state=state,
-    #                     action=action,
-    #                     reward=rewards[AGENT_ID],
-    #                     next_state=next_state,
-    #                     done=dones[AGENT_ID],
-    #                 )
-    #                 episode.record_step(
-    #                     agent_id=AGENT_ID,
-    #                     infos=infos,
-    #                     rewards=rewards,
-    #                     total_step=total_step,
-    #                     loss_output=loss_output,
-    #                 )
-    #                 total_step += 1
-    #                 state = next_state
+    def test_evaluation_check(self):
+        log_dir = "ultra/tests/output_eval_check_logs"
+        # @ray.remote(max_calls=1, num_gpus=0)
+        def run_experiment():
+            total_step = 0
+            agent, env, spec = prepare_test_env_agent(headless=True)
+            timestep_sec = env.timestep_sec
+            policy_class = "ultra.baselines.sac:sac-v0"
+            log_dir = "ultra/tests/output_eval_check_logs"
 
-    #         env.close()
+            for episode in episodes(1, etag=policy_class, log_dir=log_dir):
+                observations = env.reset()
+                state = observations[AGENT_ID]
+                dones, infos = {"__all__": False}, None
+                episode.reset()
+                experiment_dir = episode.experiment_dir
 
-    #     # ray.init(ignore_reinit_error=True)
-    #     try:
-    #         ray.init()
-    #         run_experiment()
-    #         self.assertTrue(True)
-    #     except Exception as err:
-    #         print(err)
-    #         self.assertTrue(False)
+                if not os.path.exists(f"{experiment_dir}/spec.pkl"):
+                    if not os.path.exists(experiment_dir):
+                        os.makedirs(experiment_dir)
+                    with open(f"{experiment_dir}/spec.pkl", "wb") as spec_output:
+                        dill.dump(spec, spec_output, pickle.HIGHEST_PROTOCOL)
+
+                while not dones["__all__"]:
+                    evaluation_check(
+                        agent=agent,
+                        agent_id=AGENT_ID,
+                        episode=episode,
+                        eval_rate=10,
+                        eval_episodes=1,
+                        policy_class=policy_class,
+                        scenario_info=("00", "easy"),
+                        timestep_sec=0.1,
+                        headless=True,
+                        log_dir=log_dir,
+                    )
+                    action = agent.act(state, explore=True)
+                    observations, rewards, dones, infos = env.step({AGENT_ID: action})
+                    next_state = observations[AGENT_ID]
+
+                    # retrieve some relavant information from reward processor
+                    # observations[AGENT_ID]["ego"].update(rewards[AGENT_ID]["log"])
+                    loss_output = agent.step(
+                        state=state,
+                        action=action,
+                        reward=rewards[AGENT_ID],
+                        next_state=next_state,
+                        done=dones[AGENT_ID],
+                    )
+                    episode.record_step(
+                        agent_id=AGENT_ID,
+                        infos=infos,
+                        rewards=rewards,
+                        total_step=total_step,
+                        loss_output=loss_output,
+                    )
+                    total_step += 1
+                    state = next_state
+
+            env.close()
+
+        # ray.init(ignore_reinit_error=True)
+        ray.shutdown()
+        ray.init()
+        try:
+            run_experiment()
+            self.assertTrue(True)
+        except Exception as err:
+            print(err)
+            self.assertTrue(False)
+
+        if not os.listdir(log_dir):
+            raise "Evaluation failed to generate new experiment folder"
+            self.assertTrue(False)
+        else:
+            shutil.rmtree(log_dir)
 
     def test_evaluate_cli(self):
+        log_dir = "ultra/tests/output_eval_cli_logs/"
+        model_dir = glob.glob("ultra/tests/sac_test_models/*/models/")[0]
+        ray.shutdown()
         try:
             os.system(
-                "python ultra/evaluate.py --task 00 --level easy --models ultra/tests/log/ppo-experiment/models/ --episodes 3"
+                f"python ultra/evaluate.py --task 1 --level easy --models {model_dir} --episodes 2 --log-dir {log_dir} --headless True"
             )
             self.assertTrue(True)
         except Exception as err:
             print(err)
             self.assertTrue(False)
 
-    # def test_evaluate_agent(self):
-    #     seed = 2
-    #     model = glob.glob("ultra/tests/logs/*/models")[0]
-    #     policy_class = "ultra.baselines.sac:sac-v0"
+        if not os.listdir(log_dir):
+            raise "Evaluation failed to generate new experiment folder"
+            self.assertTrue(False)
+        else:
+            shutil.rmtree(log_dir)
 
-    #     ray.init(ignore_reinit_error=True)
-    #     try:
-    #         evaluate.remote(
-    #             experiment_dir=None,
-    #             agent_id="AGENT_001",
-    #             policy_class=policy_class,
-    #             seed=seed,
-    #             itr_count=0,
-    #             checkpoint_dir=model,
-    #             scenario_info=("00", "easy"),
-    #             num_episodes=2,
-    #             timestep_sec=0.1,
-    #             headless=True,
-    #             log_dir="ultra/tests/logs",
-    #         )
-    #         self.assertTrue(True)
-    #     except Exception as err:
-    #         print(err)
-    #         self.assertTrue(False)
+    def test_evaluate_agent(self):
+        seed = 2
+        model = glob.glob("ultra/tests/sac_test_models/*/models/299")
+        log_dir = "ultra/tests/output_eval_agent_logs/"
+        policy_class = "ultra.baselines.sac:sac-v0"
+
+        if not os.path.exists(log_dir):
+            os.makedirs(log_dir)
+
+        ray.shutdown()
+        ray.init(ignore_reinit_error=True)
+        try:
+            evaluate.remote(
+                experiment_dir=None,
+                agent_id="AGENT_001",
+                policy_class=policy_class,
+                seed=seed,
+                itr_count=0,
+                checkpoint_dir=model,
+                scenario_info=("1", "easy"),
+                num_episodes=2,
+                timestep_sec=0.1,
+                headless=True,
+                log_dir=log_dir,
+            )
+            self.assertTrue(True)
+        except Exception as err:
+            print(err)
+            self.assertTrue(False)
+
+    @classmethod
+    def tearDownClass(cls):
+        os.system("ray stop")
 
 
-# def prepare_test_env_agent(headless=True):
-#     timestep_sec = 0.1
-#     # [throttle, brake, steering]
-#     policy_class = "ultra.baselines.ppo:ppo-v0"
-#     spec = make(locator=policy_class)
-#     env = gym.make(
-#         "ultra.env:ultra-v0",
-#         agent_specs={AGENT_ID: spec},
-#         scenario_info=("00", "easy"),
-#         headless=headless,
-#         timestep_sec=timestep_sec,
-#         seed=seed,
-#     )
-#     agent = spec.build_agent()
-#     return agent, env
+def prepare_test_env_agent(headless=True):
+    timestep_sec = 0.1
+    policy_class = "ultra.baselines.sac:sac-v0"
+    spec = BaselineAgentSpec(
+        action_type=ActionSpaceType.Continuous,
+        policy_class=SACPolicy,
+        max_episode_steps=100,
+    )
+    env = gym.make(
+        "ultra.env:ultra-v0",
+        agent_specs={AGENT_ID: spec},
+        scenario_info=("00", "easy"),
+        headless=headless,
+        timestep_sec=timestep_sec,
+        seed=seed,
+    )
+    agent = spec.build_agent()
+    return agent, env, spec

--- a/ultra/tests/test_evaluate.py
+++ b/ultra/tests/test_evaluate.py
@@ -30,7 +30,7 @@ policy_class = "ultra.baselines.ppo:ppo-v0"
 AGENT_ID = "001"
 
 
-#class EvaluateTest(unittest.TestCase):
+class EvaluateTest(unittest.TestCase):
     # def test_evaluation_check(self):
     #     # @ray.remote(max_calls=1, num_gpus=0)
     #     def run_experiment():
@@ -88,52 +88,53 @@ AGENT_ID = "001"
     #         print(err)
     #         self.assertTrue(False)
 
-#     def test_evaluate_cli(self):
-#         try:
-#             os.system(
-#                 "python ultra/evaluate.py --task 00 --level easy --policy ppo --models ultra/tests/ppo_models/models --episodes 1"
-#             )
-#             self.assertTrue(True)
-#         except Exception as err:
-#             print(err)
-#             self.assertTrue(False)
+    def test_evaluate_cli(self):
+        try:
+            os.system(
+                "python ultra/evaluate.py --task 00 --level easy --policy ppo --models ultra/tests/ppo_models/models --episodes 1"
+            )
+            self.assertTrue(True)
+        except Exception as err:
+            print(err)
+            self.assertTrue(False)
 
-#     def test_evaluate_agent(self):
-#         seed = 2
-#         model = glob.glob("ultra/tests/ppo_models/models/*")[0]
+    def test_evaluate_agent(self):
+        seed = 2
+        model = glob.glob("ultra/tests/ppo_models/models/*")[0]
 
-#         ray.init(ignore_reinit_error=True)
-#         try:
-#             evaluate.remote(
-#                 experiment_dir=None,
-#                 agent_id="AGENT_001",
-#                 policy_class=policy_class,
-#                 seed=seed,
-#                 itr_count=0,
-#                 checkpoint_dir=model,
-#                 scenario_info=("00", "easy"),
-#                 num_episodes=2,
-#                 timestep_sec=0.1,
-#                 headless=True,
-#             )
-#             self.assertTrue(True)
-#         except Exception as err:
-#             print(err)
-#             self.assertTrue(False)
+        ray.init(ignore_reinit_error=True)
+        try:
+            evaluate.remote(
+                experiment_dir=None,
+                agent_id="AGENT_001",
+                policy_class=policy_class,
+                seed=seed,
+                itr_count=0,
+                checkpoint_dir=model,
+                scenario_info=("00", "easy"),
+                num_episodes=2,
+                timestep_sec=0.1,
+                headless=True,
+                log_dir="ultra/tests/logs",
+            )
+            self.assertTrue(True)
+        except Exception as err:
+            print(err)
+            self.assertTrue(False)
 
 
-# def prepare_test_env_agent(headless=True):
-#     timestep_sec = 0.1
-#     # [throttle, brake, steering]
-#     policy_class = "ultra.baselines.ppo:ppo-v0"
-#     spec = make(locator=policy_class)
-#     env = gym.make(
-#         "ultra.env:ultra-v0",
-#         agent_specs={AGENT_ID: spec},
-#         scenario_info=("00", "easy"),
-#         headless=headless,
-#         timestep_sec=timestep_sec,
-#         seed=seed,
-#     )
-#     agent = spec.build_agent()
-#     return agent, env
+def prepare_test_env_agent(headless=True):
+    timestep_sec = 0.1
+    # [throttle, brake, steering]
+    policy_class = "ultra.baselines.ppo:ppo-v0"
+    spec = make(locator=policy_class)
+    env = gym.make(
+        "ultra.env:ultra-v0",
+        agent_specs={AGENT_ID: spec},
+        scenario_info=("00", "easy"),
+        headless=headless,
+        timestep_sec=timestep_sec,
+        seed=seed,
+    )
+    agent = spec.build_agent()
+    return agent, env

--- a/ultra/tests/test_evaluate.py
+++ b/ultra/tests/test_evaluate.py
@@ -91,50 +91,51 @@ class EvaluateTest(unittest.TestCase):
     def test_evaluate_cli(self):
         try:
             os.system(
-                "python ultra/evaluate.py --task 00 --level easy --policy ppo --models ultra/tests/ppo_models/models --episodes 1"
+                "python ultra/evaluate.py --task 00 --level easy --models ultra/tests/log/ppo-experiment/models/ --episodes 3"
             )
             self.assertTrue(True)
         except Exception as err:
             print(err)
             self.assertTrue(False)
 
-    def test_evaluate_agent(self):
-        seed = 2
-        model = glob.glob("ultra/tests/ppo_models/models/*")[0]
+    # def test_evaluate_agent(self):
+    #     seed = 2
+    #     model = glob.glob("ultra/tests/logs/*/models")[0]
+    #     policy_class = "ultra.baselines.sac:sac-v0"
 
-        ray.init(ignore_reinit_error=True)
-        try:
-            evaluate.remote(
-                experiment_dir=None,
-                agent_id="AGENT_001",
-                policy_class=policy_class,
-                seed=seed,
-                itr_count=0,
-                checkpoint_dir=model,
-                scenario_info=("00", "easy"),
-                num_episodes=2,
-                timestep_sec=0.1,
-                headless=True,
-                log_dir="ultra/tests/logs",
-            )
-            self.assertTrue(True)
-        except Exception as err:
-            print(err)
-            self.assertTrue(False)
+    #     ray.init(ignore_reinit_error=True)
+    #     try:
+    #         evaluate.remote(
+    #             experiment_dir=None,
+    #             agent_id="AGENT_001",
+    #             policy_class=policy_class,
+    #             seed=seed,
+    #             itr_count=0,
+    #             checkpoint_dir=model,
+    #             scenario_info=("00", "easy"),
+    #             num_episodes=2,
+    #             timestep_sec=0.1,
+    #             headless=True,
+    #             log_dir="ultra/tests/logs",
+    #         )
+    #         self.assertTrue(True)
+    #     except Exception as err:
+    #         print(err)
+    #         self.assertTrue(False)
 
 
-def prepare_test_env_agent(headless=True):
-    timestep_sec = 0.1
-    # [throttle, brake, steering]
-    policy_class = "ultra.baselines.ppo:ppo-v0"
-    spec = make(locator=policy_class)
-    env = gym.make(
-        "ultra.env:ultra-v0",
-        agent_specs={AGENT_ID: spec},
-        scenario_info=("00", "easy"),
-        headless=headless,
-        timestep_sec=timestep_sec,
-        seed=seed,
-    )
-    agent = spec.build_agent()
-    return agent, env
+# def prepare_test_env_agent(headless=True):
+#     timestep_sec = 0.1
+#     # [throttle, brake, steering]
+#     policy_class = "ultra.baselines.ppo:ppo-v0"
+#     spec = make(locator=policy_class)
+#     env = gym.make(
+#         "ultra.env:ultra-v0",
+#         agent_specs={AGENT_ID: spec},
+#         scenario_info=("00", "easy"),
+#         headless=headless,
+#         timestep_sec=timestep_sec,
+#         seed=seed,
+#     )
+#     agent = spec.build_agent()
+#     return agent, env

--- a/ultra/tests/test_evaluate.py
+++ b/ultra/tests/test_evaluate.py
@@ -35,11 +35,15 @@ AGENT_ID = "001"
 class EvaluateTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        model_path = "ultra/tests/sac_test_models"
-        if not os.path.exists(model_path):
+        os.system(
+            "python ultra/scenarios/interface.py generate --task 00 --level eval_test --root-dir ultra/tests/scenarios/ --save-dir ultra/tests/task/eval_test/eval"
+        )
+        
+        path = "ultra/tests/sac_test_models"
+        if not os.path.exists(path):
             # Generate models before evaluation tests
             os.system(
-                "python ultra/train.py --task 1 --level easy --policy sac --headless True --episodes 10 --eval-rate 200 --eval-episodes 3 --log-dir ultra/tests/sac_test_models "
+                "python ultra/train.py --task 00 --level eval_test --policy sac --headless True --episodes 8 --eval-rate 350 --eval-episodes 1 --log-dir ultra/tests/sac_test_models"
             )
 
     def test_evaluation_check(self):
@@ -73,7 +77,7 @@ class EvaluateTest(unittest.TestCase):
                         eval_rate=10,
                         eval_episodes=1,
                         policy_class=policy_class,
-                        scenario_info=("00", "easy"),
+                        scenario_info=("00", "eval_test"),
                         timestep_sec=0.1,
                         headless=True,
                         log_dir=log_dir,
@@ -125,7 +129,7 @@ class EvaluateTest(unittest.TestCase):
         ray.shutdown()
         try:
             os.system(
-                f"python ultra/evaluate.py --task 1 --level easy --models {model_dir} --episodes 2 --log-dir {log_dir} --headless True"
+                f"python ultra/evaluate.py --task 00 --level eval_test --models {model_dir} --episodes 1 --log-dir {log_dir} --headless True"
             )
             self.assertTrue(True)
         except Exception as err:
@@ -140,8 +144,8 @@ class EvaluateTest(unittest.TestCase):
 
     def test_evaluate_agent(self):
         seed = 2
-        model = glob.glob("ultra/tests/sac_test_models/*/models/299")
-        log_dir = "ultra/tests/output_eval_agent_logs/"
+        model = glob.glob("ultra/tests/sac_test_models/*/models/")[0]
+        log_dir = "ultra/tests/output_eval_agent_logs"
         policy_class = "ultra.baselines.sac:sac-v0"
 
         if not os.path.exists(log_dir):
@@ -157,8 +161,8 @@ class EvaluateTest(unittest.TestCase):
                 seed=seed,
                 itr_count=0,
                 checkpoint_dir=model,
-                scenario_info=("1", "easy"),
-                num_episodes=2,
+                scenario_info=("00", "eval_test"),
+                num_episodes=1,
                 timestep_sec=0.1,
                 headless=True,
                 log_dir=log_dir,
@@ -168,9 +172,15 @@ class EvaluateTest(unittest.TestCase):
             print(err)
             self.assertTrue(False)
 
-    @classmethod
-    def tearDownClass(cls):
-        os.system("ray stop")
+        # if not os.listdir(log_dir):
+        #     raise "Evaluation failed to generate new experiment folder"
+        #     self.assertTrue(False)
+        # else:
+        #     shutil.rmtree(log_dir)
+            
+    # @classmethod
+    # def tearDownClass(cls):
+    #     os.system("ray stop")
 
 
 def prepare_test_env_agent(headless=True):
@@ -184,7 +194,7 @@ def prepare_test_env_agent(headless=True):
     env = gym.make(
         "ultra.env:ultra-v0",
         agent_specs={AGENT_ID: spec},
-        scenario_info=("00", "easy"),
+        scenario_info=("00", "eval_test"),
         headless=headless,
         timestep_sec=timestep_sec,
         seed=seed,

--- a/ultra/tests/test_train.py
+++ b/ultra/tests/test_train.py
@@ -54,37 +54,38 @@ class TrainTest(unittest.TestCase):
         if os.path.exists(log_dir):
             self.assertTrue(True)
 
-    # def test_train_single_agent(self):
-    #     if os.path.exists("ultra/tests/logs"):
-    #         shutil.rmtree("ultra/tests/logs")
+    def test_train_single_agent(self):
+        if os.path.exists("ultra/tests/logs"):
+            shutil.rmtree("ultra/tests/logs")
 
-    #     os.system("pkill -9 ray")
+        os.system("pkill -9 ray")
 
-    #     seed = 2
-    #     policy_class = "ultra.baselines.sac:sac-v0"
+        seed = 2
+        policy_class = "ultra.baselines.sac:sac-v0"
 
-    #     try:
-    #         ray.init(ignore_reinit_error=True)
-    #         ray.wait(
-    #             [
-    #                 train.remote(
-    #                     scenario_info=("00", "easy"),
-    #                     policy_class=policy_class,
-    #                     num_episodes=1,
-    #                     eval_info={"eval_rate": 1000, "eval_episodes": 2,},
-    #                     timestep_sec=0.1,
-    #                     headless=True,
-    #                     seed=2,
-    #                     log_dir="ultra/tests/logs",
-    #                 )
-    #             ]
-    #         )
-    #         ray.shutdown()
-    #         self.assertTrue(True)
-    #     except ray.exceptions.WorkerCrashedError as err:
-    #         print(err)
-    #         self.assertTrue(False)
-    #         ray.shutdown()
+        ray.shutdown()
+        try:
+            ray.init(ignore_reinit_error=True)
+            ray.wait(
+                [
+                    train.remote(
+                        scenario_info=("00", "easy"),
+                        policy_class=policy_class,
+                        num_episodes=1,
+                        eval_info={"eval_rate": 1000, "eval_episodes": 2,},
+                        timestep_sec=0.1,
+                        headless=True,
+                        seed=2,
+                        log_dir="ultra/tests/logs",
+                    )
+                ]
+            )
+            ray.shutdown()
+            self.assertTrue(True)
+        except ray.exceptions.WorkerCrashedError as err:
+            print(err)
+            self.assertTrue(False)
+            ray.shutdown()
 
     def test_check_agents_from_pool(self):
         seed = 2
@@ -116,5 +117,3 @@ class TrainTest(unittest.TestCase):
     def tearDown(self):
         if os.path.exists("ultra/tests/logs"):
             shutil.rmtree("ultra/tests/logs")
-
-        os.system("pkill -9 ray")

--- a/ultra/tests/test_train.py
+++ b/ultra/tests/test_train.py
@@ -58,8 +58,6 @@ class TrainTest(unittest.TestCase):
         if os.path.exists("ultra/tests/logs"):
             shutil.rmtree("ultra/tests/logs")
 
-        os.system("pkill -9 ray")
-
         seed = 2
         policy_class = "ultra.baselines.sac:sac-v0"
 

--- a/ultra/train.py
+++ b/ultra/train.py
@@ -163,6 +163,10 @@ if __name__ == "__main__":
     parser.add_argument(
         "--log-dir", help="Log directory location", default="logs", type=str,
     )
+
+    if not os.path.exists(args.log_dir):
+        os.makedirs(args.log_dir)
+
     args = parser.parse_args()
 
     num_cpus = max(

--- a/ultra/train.py
+++ b/ultra/train.py
@@ -157,7 +157,6 @@ if __name__ == "__main__":
         type=int,
         default=10000,
     )
-
     parser.add_argument(
         "--seed", help="Environment seed", default=2, type=int,
     )
@@ -166,13 +165,6 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
-
-    if not os.path.exists(args.log_dir):
-        os.makedirs(args.log_dir)
-
-    num_cpus = max(
-        1, psutil.cpu_count(logical=False) - 1
-    )  # remove `logical=False` to use all cpus
 
     with open("ultra/agent_pool.json", "r") as f:
         data = json.load(f)
@@ -184,6 +176,10 @@ if __name__ == "__main__":
 
     # Required string for smarts' class registry
     policy_class = str(policy_path) + ":" + str(policy_locator)
+
+    num_cpus = max(
+        1, psutil.cpu_count(logical=False) - 1
+    )  # remove `logical=False` to use all cpus
 
     ray.init()
     ray.wait(

--- a/ultra/train.py
+++ b/ultra/train.py
@@ -66,7 +66,7 @@ def train(
 
     agent = spec.build_agent()
 
-    for episode in episodes(num_episodes, etag=policy_class, dir=log_dir):
+    for episode in episodes(num_episodes, etag=policy_class, log_dir=log_dir):
         observations = env.reset()
         state = observations[AGENT_ID]
         dones, infos = {"__all__": False}, None
@@ -166,7 +166,7 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
-    
+
     if not os.path.exists(args.log_dir):
         os.makedirs(args.log_dir)
 

--- a/ultra/train.py
+++ b/ultra/train.py
@@ -89,6 +89,7 @@ def train(
                 agent_id=AGENT_ID,
                 policy_class=policy_class,
                 episode=episode,
+                log_dir=log_dir,
                 **eval_info,
                 **env.info,
             )
@@ -164,10 +165,10 @@ if __name__ == "__main__":
         "--log-dir", help="Log directory location", default="logs", type=str,
     )
 
+    args = parser.parse_args()
+    
     if not os.path.exists(args.log_dir):
         os.makedirs(args.log_dir)
-
-    args = parser.parse_args()
 
     num_cpus = max(
         1, psutil.cpu_count(logical=False) - 1

--- a/ultra/train.py
+++ b/ultra/train.py
@@ -177,10 +177,6 @@ if __name__ == "__main__":
     # Required string for smarts' class registry
     policy_class = str(policy_path) + ":" + str(policy_locator)
 
-    num_cpus = max(
-        1, psutil.cpu_count(logical=False) - 1
-    )  # remove `logical=False` to use all cpus
-
     ray.init()
     ray.wait(
         [

--- a/ultra/utils/episode.py
+++ b/ultra/utils/episode.py
@@ -249,8 +249,7 @@ class Episode:
                     pass
 
 
-def episodes(n, etag=None, dir=None):
-    log_dir = dir
+def episodes(n, etag=None, log_dir=None):
     col_width = 18
     with tp.TableContext(
         [f"Episode", f"Sim/Wall", f"Total Steps", f"Steps/Sec", f"Score",],

--- a/ultra/utils/episode.py
+++ b/ultra/utils/episode.py
@@ -127,7 +127,12 @@ class Episode:
                 self.experiment_name = f"{self.experiment_name}-{etag}"
         else:
             self.experiment_name = experiment_name
-        self.log_dir = log_dir
+
+        if log_dir is None:
+            self.log_dir = "logs"
+        else:
+            self.log_dir = log_dir
+
         self.experiment_dir = f"{self.log_dir}/{self.experiment_name}"
         self.model_dir = f"{self.log_dir}/{self.experiment_name}/models"
         self.code_dir = f"{self.log_dir}/{self.experiment_name}/codes"


### PR DESCRIPTION
Addressing issue : #519 

Changes made
- Removed the policy flag from evaluate.py to prevent unnecessary policy input
- Added log-dir flag option to evaluate.py to request designated directory for new experiments
- Updated evaluate_test.py to conform to new log-dir flag 