### PR TITLE
Fix Docker Cache Problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ $ python examples/single_agent.py scenarios/loop
 docker login
 
 export VERSION=v0.4.3-pre
-docker build -t smarts:$VERSION .
+docker build --no-cache -t smarts:$VERSION .
 docker tag smarts:$VERSION huaweinoah/smarts:$VERSION
 docker push huaweinoah/smarts:$VERSION
 ```


### PR DESCRIPTION
Docker's cache was causing an issue with the version of SMARTS in the docker image.