### PR TITLE
Minimal docker image.

### DIFF
--- a/.github/workflows/ci-base-tests.yml
+++ b/.github/workflows/ci-base-tests.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     runs-on: ubuntu-18.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    container: huaweinoah/smarts:v0.4.3-pre
+    container: adaickalavan/smarts:v0.4.13-minimal
     strategy:
       matrix:
         tests:

--- a/.github/workflows/ci-base-tests.yml
+++ b/.github/workflows/ci-base-tests.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     runs-on: ubuntu-18.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    container: adaickalavan/smarts:v0.4.13-minimal
+    container: huaweinoah/smarts:v0.4.13-minimal
     strategy:
       matrix:
         tests:

--- a/.github/workflows/ci-base-tests.yml
+++ b/.github/workflows/ci-base-tests.yml
@@ -1,7 +1,6 @@
 name: SMARTS CI Base Tests
 
-
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/workflows/ci-formatting-and-dependencies.yml
+++ b/.github/workflows/ci-formatting-and-dependencies.yml
@@ -9,7 +9,7 @@ jobs:
   test-formatting:
     runs-on: ubuntu-18.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    container: huaweinoah/smarts:v0.4.3-pre
+    container: adaickalavan/smarts:v0.4.13-minimal
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -27,7 +27,7 @@ jobs:
   test-requirements:
     runs-on: ubuntu-18.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    container: huaweinoah/smarts:v0.4.3-pre
+    container: adaickalavan/smarts:v0.4.13-minimal
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci-formatting-and-dependencies.yml
+++ b/.github/workflows/ci-formatting-and-dependencies.yml
@@ -9,7 +9,7 @@ jobs:
   test-formatting:
     runs-on: ubuntu-18.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    container: adaickalavan/smarts:v0.4.13-minimal
+    container: huaweinoah/smarts:v0.4.13-minimal
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -27,7 +27,7 @@ jobs:
   test-requirements:
     runs-on: ubuntu-18.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    container: adaickalavan/smarts:v0.4.13-minimal
+    container: huaweinoah/smarts:v0.4.13-minimal
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   test-benchmark:
     runs-on: ubuntu-18.04
-    container: adaickalavan/smarts:v0.4.13-minimal
+    container: huaweinoah/smarts:v0.4.13-minimal
     steps:
       - name: Checkout
         uses: actions/checkout@v1.2.0

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   test-benchmark:
     runs-on: ubuntu-18.04
-    container: huaweinoah/smarts:v0.4.3-pre
+    container: adaickalavan/smarts:v0.4.13-minimal
     steps:
       - name: Checkout
         uses: actions/checkout@v1.2.0

--- a/.github/workflows/ci-test-header.yml
+++ b/.github/workflows/ci-test-header.yml
@@ -9,7 +9,7 @@ jobs:
   test-header:
     runs-on: ubuntu-18.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    container: adaickalavan/smarts:v0.4.13-minimal
+    container: huaweinoah/smarts:v0.4.13-minimal
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci-test-header.yml
+++ b/.github/workflows/ci-test-header.yml
@@ -9,7 +9,7 @@ jobs:
   test-header:
     runs-on: ubuntu-18.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    container: huaweinoah/smarts:v0.4.3-pre
+    container: adaickalavan/smarts:v0.4.13-minimal
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci-test-learning.yml
+++ b/.github/workflows/ci-test-learning.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   test_learning:
     runs-on: ubuntu-18.04
-    container: adaickalavan/smarts:v0.4.13-minimal
+    container: huaweinoah/smarts:v0.4.13-minimal
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci-test-learning.yml
+++ b/.github/workflows/ci-test-learning.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   test_learning:
     runs-on: ubuntu-18.04
-    container: huaweinoah/smarts:v0.4.3-pre
+    container: adaickalavan/smarts:v0.4.13-minimal
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci-test-long-determinism.yml
+++ b/.github/workflows/ci-test-long-determinism.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   test_learning:
     runs-on: ubuntu-18.04
-    container: adaickalavan/smarts:v0.4.13-minimal
+    container: huaweinoah/smarts:v0.4.13-minimal
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci-test-long-determinism.yml
+++ b/.github/workflows/ci-test-long-determinism.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   test_learning:
     runs-on: ubuntu-18.04
-    container: huaweinoah/smarts:v0.4.3-pre
+    container: adaickalavan/smarts:v0.4.13-minimal
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci-test-memory-growth.yml
+++ b/.github/workflows/ci-test-memory-growth.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   test_memory:
     runs-on: ubuntu-18.04
-    container: adaickalavan/smarts:v0.4.13-minimal
+    container: huaweinoah/smarts:v0.4.13-minimal
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci-test-memory-growth.yml
+++ b/.github/workflows/ci-test-memory-growth.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   test_memory:
     runs-on: ubuntu-18.04
-    container: huaweinoah/smarts:v0.4.3-pre
+    container: adaickalavan/smarts:v0.4.13-minimal
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -6,7 +6,7 @@ jobs:
   test-base:
     runs-on: ubuntu-18.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    container: huaweinoah/smarts:v0.4.3-pre
+    container: adaickalavan/smarts:v0.4.13-minimal
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -41,7 +41,7 @@ jobs:
   test-package-via-setup:
     runs-on: ubuntu-18.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    container: huaweinoah/smarts:v0.4.3-pre
+    container: adaickalavan/smarts:v0.4.13-minimal
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -71,7 +71,7 @@ jobs:
   test-package-via-wheel:
     runs-on: ubuntu-18.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    container: huaweinoah/smarts:v0.4.3-pre
+    container: adaickalavan/smarts:v0.4.13-minimal
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -6,7 +6,7 @@ jobs:
   test-base:
     runs-on: ubuntu-18.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    container: adaickalavan/smarts:v0.4.13-minimal
+    container: huaweinoah/smarts:v0.4.13-minimal
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -41,7 +41,7 @@ jobs:
   test-package-via-setup:
     runs-on: ubuntu-18.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    container: adaickalavan/smarts:v0.4.13-minimal
+    container: huaweinoah/smarts:v0.4.13-minimal
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -71,7 +71,7 @@ jobs:
   test-package-via-wheel:
     runs-on: ubuntu-18.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    container: adaickalavan/smarts:v0.4.13-minimal
+    container: huaweinoah/smarts:v0.4.13-minimal
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -105,7 +105,7 @@ jobs:
   # test-package-via-pypi:
   #   runs-on: ubuntu-18.04
   #   if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-  #   container: huaweinoah/smarts:v0.4.3-pre
+  #   container: huaweinoah/smarts:v0.4.13-minimal
   #   steps:
   #     - name: Checkout
   #       uses: actions/checkout@v2

--- a/minimal.Dockerfile
+++ b/minimal.Dockerfile
@@ -1,0 +1,64 @@
+# Steps to build and push minimal SMARTS docker image
+# ```bash
+# $ export VERSION=v0.4.13
+# $ cd /path/to/SMARTS
+# $ docker build --network=host -t huaweinoah/smarts:$VERSION-minimal -f minimal.Dockerfile .
+# $ docker push huaweinoah/smarts:$VERSION-minimal
+# ```
+
+FROM ubuntu:bionic
+
+# Install libraries
+RUN apt-get update --fix-missing && \
+    apt-get install -y \
+        software-properties-common && \
+    add-apt-repository -y ppa:deadsnakes/ppa && \
+    add-apt-repository -y ppa:sumo/stable && \
+    apt-get update && \
+    apt-get install -y \
+        libsm6 \
+        libspatialindex-dev \
+        libxext6 \
+        libxrender-dev \
+        python3.7 \
+        python3.7-dev \
+        python3.7-venv \
+        sumo \
+        sumo-doc \
+        sumo-tools \
+        wget \
+        x11-apps \
+        xserver-xorg-video-dummy && \
+    apt-get autoremove && \
+    rm -rf /var/lib/apt/lists/*
+
+# Update default python version
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.7 1
+
+# Install pip
+RUN wget https://bootstrap.pypa.io/get-pip.py -O get-pip.py && \
+    python get-pip.py && \
+    pip install --upgrade pip
+
+# Setup DISPLAY
+ENV DISPLAY :1
+# VOLUME /tmp/.X11-unix
+RUN wget -O /etc/X11/xorg.conf http://xpra.org/xorg.conf && \
+    cp /etc/X11/xorg.conf /usr/share/X11/xorg.conf.d/xorg.conf
+
+# Setup SUMO
+ENV SUMO_HOME /usr/share/sumo
+
+# For Envision
+EXPOSE 8081
+
+# TODO: Find a better place to put this (e.g. through systemd). As it stands now ctrl-c
+#       could close x-server. Even though it's "running in the background".
+RUN echo "/usr/bin/Xorg " \
+    "-noreset +extension GLX +extension RANDR +extension RENDER" \
+    "-logfile ./xdummy.log -config /etc/X11/xorg.conf -novtswitch $DISPLAY &" >> ~/.bashrc
+
+SHELL ["/bin/bash", "-c", "-l"]
+
+# $ docker build --network=host -t adaickalavan/smarts:v0.4.13-minimal -f minimal.Dockerfile .
+# $ docker push adaickalavan/smarts:v0.4.13-minimal

--- a/minimal.Dockerfile
+++ b/minimal.Dockerfile
@@ -2,7 +2,7 @@
 # ```bash
 # $ export VERSION=v0.4.13
 # $ cd /path/to/SMARTS
-# $ docker build --network=host -t huaweinoah/smarts:$VERSION-minimal -f minimal.Dockerfile .
+# $ docker build -t huaweinoah/smarts:$VERSION-minimal -f minimal.Dockerfile .
 # $ docker push huaweinoah/smarts:$VERSION-minimal
 # ```
 
@@ -29,7 +29,7 @@ RUN apt-get update --fix-missing && \
         wget \
         x11-apps \
         xserver-xorg-video-dummy && \
-    apt-get autoremove && \
+    apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
 # Update default python version
@@ -59,6 +59,3 @@ RUN echo "/usr/bin/Xorg " \
     "-logfile ./xdummy.log -config /etc/X11/xorg.conf -novtswitch $DISPLAY &" >> ~/.bashrc
 
 SHELL ["/bin/bash", "-c", "-l"]
-
-# $ docker build --network=host -t adaickalavan/smarts:v0.4.13-minimal -f minimal.Dockerfile .
-# $ docker push adaickalavan/smarts:v0.4.13-minimal


### PR DESCRIPTION
+ minimal.Dockerfile to create minimal docker image.
+ SMARTS CI and ULTRA CI uses minimal docker image.
+ Minimal docker image size: 909MB
+ Steps to build and push minimal SMARTS docker image
  ```bash
  $ export VERSION=v0.4.13
  $ cd /path/to/SMARTS
  $ docker build -t huaweinoah/smarts:$VERSION-minimal -f minimal.Dockerfile .
  $ docker login
  $ docker push huaweinoah/smarts:$VERSION-minimal
  ```
+ Need to push docker image to huaweinoah DockerHub. 
+ Currently, CI checks fail as docker image is not yet available.

Closes #527.