### PR TITLE
Speed up imitation learning jump to timestamp

### DIFF
--- a/examples/history_vehicles_replacement_for_imitation_learning.py
+++ b/examples/history_vehicles_replacement_for_imitation_learning.py
@@ -1,5 +1,11 @@
 import logging
 
+from smarts.core.smarts import SMARTS
+from smarts.core.agent_interface import AgentInterface, AgentType
+from smarts.core.agent import AgentSpec, Agent
+from smarts.core.sumo_traffic_simulation import SumoTrafficSimulation
+from smarts.core.scenario import Scenario
+from smarts.core.scenario import Mission
 from envision.client import Client as Envision
 from examples import default_argument_parser
 from smarts.core.agent import Agent, AgentSpec
@@ -23,14 +29,11 @@ def main(scenarios, headless, seed):
         traffic_sim=SumoTrafficSimulation(headless=True, auto_start=True),
         envision=Envision(),
     )
-
     for _ in scenarios:
         scenario = next(scenarios_iterator)
         agent_missions = scenario.discover_missions_of_traffic_histories()
 
         for agent_id, mission in agent_missions.items():
-            scenario.set_ego_missions({agent_id: mission})
-
             agent_spec = AgentSpec(
                 interface=AgentInterface.from_type(
                     AgentType.Laner, max_episode_steps=None
@@ -40,7 +43,13 @@ def main(scenarios, headless, seed):
             agent = agent_spec.build_agent()
 
             smarts.switch_ego_agent({agent_id: agent_spec.interface})
-
+            smarts.history_set_start_elapsed_time(mission.start_time)
+            modified_mission = Mission(
+                goal=agent_missions[agent_id].goal,
+                start_time=0.0,
+                start=agent_missions[agent_id].start,
+            )
+            scenario.set_ego_missions({agent_id: modified_mission})
             observations = smarts.reset(scenario)
 
             dones = {agent_id: False}

--- a/examples/history_vehicles_replacement_for_imitation_learning.py
+++ b/examples/history_vehicles_replacement_for_imitation_learning.py
@@ -1,4 +1,5 @@
 import logging
+from dataclasses import replace
 
 from smarts.core.smarts import SMARTS
 from smarts.core.agent_interface import AgentInterface, AgentType
@@ -44,11 +45,7 @@ def main(scenarios, headless, seed):
 
             smarts.switch_ego_agent({agent_id: agent_spec.interface})
             smarts.history_set_start_elapsed_time(mission.start_time)
-            modified_mission = Mission(
-                goal=agent_missions[agent_id].goal,
-                start_time=0.0,
-                start=agent_missions[agent_id].start,
-            )
+            modified_mission = replace(mission, start_time=0.0)
             scenario.set_ego_missions({agent_id: modified_mission})
             observations = smarts.reset(scenario)
 

--- a/examples/history_vehicles_replacement_for_imitation_learning.py
+++ b/examples/history_vehicles_replacement_for_imitation_learning.py
@@ -40,7 +40,9 @@ def main(scenarios, headless, seed):
 
             smarts.switch_ego_agent({agent_id: agent_spec.interface})
             # required: get traffic_history_provider and set time offset
-            traffic_history_provider = smarts.get_provider_by_type(TrafficHistoryProvider)
+            traffic_history_provider = smarts.get_provider_by_type(
+                TrafficHistoryProvider
+            )
             assert traffic_history_provider
             traffic_history_provider.set_start_time(mission.start_time)
 

--- a/examples/history_vehicles_replacement_for_imitation_learning.py
+++ b/examples/history_vehicles_replacement_for_imitation_learning.py
@@ -8,6 +8,7 @@ from smarts.core.agent_interface import AgentInterface, AgentType
 from smarts.core.scenario import Mission, Scenario
 from smarts.core.smarts import SMARTS
 from smarts.core.sumo_traffic_simulation import SumoTrafficSimulation
+from smarts.core.traffic_history_provider import TrafficHistoryProvider
 
 logging.basicConfig(level=logging.INFO)
 
@@ -38,7 +39,11 @@ def main(scenarios, headless, seed):
             agent = agent_spec.build_agent()
 
             smarts.switch_ego_agent({agent_id: agent_spec.interface})
-            smarts.history_set_start_elapsed_time(mission.start_time)
+            # required: find traffic_history_provider and set time offset
+            for provider in smarts.providers:
+                if provider is TrafficHistoryProvider:
+                    provider.set_start_time(mission.start_time)
+
             modified_mission = replace(mission, start_time=0.0)
             scenario.set_ego_missions({agent_id: modified_mission})
             observations = smarts.reset(scenario)

--- a/examples/history_vehicles_replacement_for_imitation_learning.py
+++ b/examples/history_vehicles_replacement_for_imitation_learning.py
@@ -1,17 +1,11 @@
 import logging
 from dataclasses import replace
 
-from smarts.core.smarts import SMARTS
-from smarts.core.agent_interface import AgentInterface, AgentType
-from smarts.core.agent import AgentSpec, Agent
-from smarts.core.sumo_traffic_simulation import SumoTrafficSimulation
-from smarts.core.scenario import Scenario
-from smarts.core.scenario import Mission
 from envision.client import Client as Envision
 from examples import default_argument_parser
 from smarts.core.agent import Agent, AgentSpec
 from smarts.core.agent_interface import AgentInterface, AgentType
-from smarts.core.scenario import Scenario
+from smarts.core.scenario import Mission, Scenario
 from smarts.core.smarts import SMARTS
 from smarts.core.sumo_traffic_simulation import SumoTrafficSimulation
 

--- a/examples/history_vehicles_replacement_for_imitation_learning.py
+++ b/examples/history_vehicles_replacement_for_imitation_learning.py
@@ -39,10 +39,10 @@ def main(scenarios, headless, seed):
             agent = agent_spec.build_agent()
 
             smarts.switch_ego_agent({agent_id: agent_spec.interface})
-            # required: find traffic_history_provider and set time offset
-            for provider in smarts.providers:
-                if provider is TrafficHistoryProvider:
-                    provider.set_start_time(mission.start_time)
+            # required: get traffic_history_provider and set time offset
+            traffic_history_provider = smarts.get_provider_by_type(TrafficHistoryProvider)
+            assert traffic_history_provider
+            traffic_history_provider.set_start_time(mission.start_time)
 
             modified_mission = replace(mission, start_time=0.0)
             scenario.set_ego_missions({agent_id: modified_mission})

--- a/smarts/core/smarts.py
+++ b/smarts/core/smarts.py
@@ -479,10 +479,6 @@ class SMARTS(ShowBase):
     def observe_from(self, vehicle_ids):
         return self._agent_manager.observe_from(self, vehicle_ids)
 
-    def history_set_start_elapsed_time(self, start_time: float):
-        """Set the time off set for traffic_history provider"""
-        self._traffic_history_provider.set_start_time(start_time)
-
     @property
     def road_stiffness(self):
         return self._bullet_client.getDynamicsInfo(self._ground_bullet_id, -1)[9]

--- a/smarts/core/smarts.py
+++ b/smarts/core/smarts.py
@@ -651,6 +651,11 @@ class SMARTS(ShowBase):
         # TODO: It's inconsistent that pybullet is not here
         return self._providers
 
+    def get_provider_by_type(self, requested_type):
+        for provider in self._providers:
+            if isinstance(provider, requested_type):
+                return provider
+
     def _setup_providers(self, scenario) -> ProviderState:
         provider_state = ProviderState()
         for provider in self.providers:

--- a/smarts/core/smarts.py
+++ b/smarts/core/smarts.py
@@ -479,6 +479,11 @@ class SMARTS(ShowBase):
     def observe_from(self, vehicle_ids):
         return self._agent_manager.observe_from(self, vehicle_ids)
 
+    def history_set_start_elapsed_time(self, start_time: float):
+        """ Set the time off set for traffic_history provider
+        """
+        self._traffic_history_provider.set_start_time(start_time)
+
     @property
     def road_stiffness(self):
         return self._bullet_client.getDynamicsInfo(self._ground_bullet_id, -1)[9]

--- a/smarts/core/smarts.py
+++ b/smarts/core/smarts.py
@@ -480,8 +480,7 @@ class SMARTS(ShowBase):
         return self._agent_manager.observe_from(self, vehicle_ids)
 
     def history_set_start_elapsed_time(self, start_time: float):
-        """ Set the time off set for traffic_history provider
-        """
+        """Set the time off set for traffic_history provider"""
         self._traffic_history_provider.set_start_time(start_time)
 
     @property

--- a/smarts/core/sumo_traffic_simulation.py
+++ b/smarts/core/sumo_traffic_simulation.py
@@ -330,9 +330,6 @@ class SumoTrafficSimulation:
         """
         Args:
             dt: time (in seconds) to simulate during this simulation step
-            managed_vehicles: dict of {vehicle_id: (x, y, heading)}
-                !! The vehicle state should represent the state of the
-                !! vehicles at the start of the current simulation step
         Returns:
             ProviderState representing the state of the SUMO simulation
         """

--- a/smarts/core/traffic_history_provider.py
+++ b/smarts/core/traffic_history_provider.py
@@ -31,6 +31,10 @@ class TrafficHistoryProvider:
         self._is_setup = False
         self._current_traffic_history = None
         self.replaced_vehicle_ids = set()
+        self.start_time_offset = 0
+
+    def set_start_time(self, start_time: float):
+        self.start_time_offset = start_time
 
     def setup(self, scenario) -> ProviderState:
         self._is_setup = True
@@ -69,10 +73,12 @@ class TrafficHistoryProvider:
         if (
             not self._current_traffic_history
             or timestamp is None
-            or str(timestamp) not in self._current_traffic_history
+            or str(round(timestamp + self.start_time_offset, 1))
+            not in self._current_traffic_history
         ):
             return ProviderState(vehicles=[], traffic_light_systems=[])
 
+        time_with_offset = round(timestamp + self.start_time_offset, 1)
         vehicle_type = "passenger"
         states = ProviderState(
             vehicles=[
@@ -106,7 +112,7 @@ class TrafficHistoryProvider:
                     source="HISTORY",
                 )
                 for v_id, vehicle_state in self._current_traffic_history[
-                    str(timestamp)
+                    str(time_with_offset)
                 ].items()
                 if v_id not in self.replaced_vehicle_ids
             ],

--- a/smarts/core/traffic_history_provider.py
+++ b/smarts/core/traffic_history_provider.py
@@ -74,7 +74,7 @@ class TrafficHistoryProvider:
         if not self._current_traffic_history or timestamp is None:
             return ProviderState(vehicles=[], traffic_light_systems=[])
 
-        time_with_offset = round(timestamp + self.start_time_offset, 1)
+        time_with_offset = str(round(timestamp + self.start_time_offset, 1))
         if time_with_offset not in self._current_traffic_history:
             return ProviderState(vehicles=[], traffic_light_systems=[])
 
@@ -111,7 +111,7 @@ class TrafficHistoryProvider:
                     source="HISTORY",
                 )
                 for v_id, vehicle_state in self._current_traffic_history[
-                    str(time_with_offset)
+                    time_with_offset
                 ].items()
                 if v_id not in self.replaced_vehicle_ids
             ],

--- a/smarts/core/traffic_history_provider.py
+++ b/smarts/core/traffic_history_provider.py
@@ -34,6 +34,7 @@ class TrafficHistoryProvider:
         self.start_time_offset = 0
 
     def set_start_time(self, start_time: float):
+        assert start_time >= 0, "start_time should be positive"
         self.start_time_offset = start_time
 
     def setup(self, scenario) -> ProviderState:
@@ -73,12 +74,13 @@ class TrafficHistoryProvider:
         if (
             not self._current_traffic_history
             or timestamp is None
-            or str(round(timestamp + self.start_time_offset, 1))
-            not in self._current_traffic_history
         ):
             return ProviderState(vehicles=[], traffic_light_systems=[])
 
         time_with_offset = round(timestamp + self.start_time_offset, 1)
+        if time_with_offset not in self._current_traffic_history:
+            return ProviderState(vehicles=[], traffic_light_systems=[])
+
         vehicle_type = "passenger"
         states = ProviderState(
             vehicles=[

--- a/smarts/core/traffic_history_provider.py
+++ b/smarts/core/traffic_history_provider.py
@@ -71,10 +71,7 @@ class TrafficHistoryProvider:
             ),
             default=None,
         )
-        if (
-            not self._current_traffic_history
-            or timestamp is None
-        ):
+        if not self._current_traffic_history or timestamp is None:
             return ProviderState(vehicles=[], traffic_light_systems=[])
 
         time_with_offset = round(timestamp + self.start_time_offset, 1)


### PR DESCRIPTION
Original issue was that during imitation learning, smarts had to step through all the time histories before the ego car appears. This is obvious when envision has large amount of time of no activity. 

Fixed this issue by adding a `start_time_offset` in traffic_history_provider, and exposed an api in smarts for `history_vehicles_replacement_for_imitation_learning.py` to set this start_time_offset. Traffic_history_provider will only fetch histories from time `timestamp+start_time_offset`. 

Related previous PR: #163 