### PR TITLE
Remove ultra package from site-packages during ci test

### DIFF
--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -27,6 +27,7 @@ jobs:
           pip install --upgrade --upgrade-strategy eager pip
           pip install --upgrade --upgrade-strategy eager wheel
           pip install --upgrade --upgrade-strategy eager -e .
+          rm -rf .venv/lib/python3.7/site-packages/ultra 
       - name: Run ultra tests
         run: |
           cd ultra

--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -27,7 +27,6 @@ jobs:
           pip install --upgrade --upgrade-strategy eager pip
           pip install --upgrade --upgrade-strategy eager wheel
           pip install --upgrade --upgrade-strategy eager -e .
-          rm -rf .venv/lib/python3.7/site-packages/ultra
       - name: Run ultra tests
         run: |
           cd ultra

--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -27,6 +27,7 @@ jobs:
           pip install --upgrade --upgrade-strategy eager pip
           pip install --upgrade --upgrade-strategy eager wheel
           pip install --upgrade --upgrade-strategy eager -e .
+          rm -rf .venv/lib/python3.7/site-packages/ultra
       - name: Run ultra tests
         run: |
           cd ultra

--- a/ultra/setup.py
+++ b/ultra/setup.py
@@ -45,7 +45,7 @@ setup(
     zip_safe=True,
     python_requires=">=3.7",
     install_requires=[
-        "smarts[train, test]==0.4.13",
+        "smarts[train,test]==0.4.13",
         "setuptools>=41.0.0,!=50.0",
         "dill",
         "black==20.8b1",

--- a/ultra/setup.py
+++ b/ultra/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     version="0.1.1",
-    packages=find_packages(exclude=["tests"]),
+    packages=find_packages(exclude=["ultra", "tests"]),
     include_package_data=True,
     zip_safe=True,
     python_requires=">=3.7",


### PR DESCRIPTION
- When using smarts==0.4.13, an ultra folder is added to the site-packages in the virtual env. When running any features, the ultra package from the site-packages is referenced (in the path) rather than the developing ultra folder. Not too sure why this is happening, because when using smarts<0.4.11 there isn't ultra package folder created in the virtual env.  
