### PR TITLE
Remove unused traffic light functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ OpEn_build/
 
 # Ignore generated ULTRA tasks
 ultra/ultra/scenarios/task*/*/
+.bugtest

--- a/.gitignore
+++ b/.gitignore
@@ -128,4 +128,3 @@ OpEn_build/
 
 # Ignore generated ULTRA tasks
 ultra/ultra/scenarios/task*/*/
-.bugtest

--- a/smarts/core/motion_planner_provider.py
+++ b/smarts/core/motion_planner_provider.py
@@ -99,7 +99,6 @@ class MotionPlannerProvider:
                 )
                 for idx, v_id in enumerate(self._vehicle_id_to_index.keys())
             ],
-            traffic_light_systems=[],
         )
 
     def _normalize_target_pose(self, vehicle_index, target_poses, dt):

--- a/smarts/core/provider.py
+++ b/smarts/core/provider.py
@@ -27,35 +27,15 @@ from .vehicle import VehicleState
 
 
 @dataclass
-class ProviderTrafficLight:
-    lane_in: str
-    lane_via: str
-    lane_out: str
-    state: str
-
-
-@dataclass
-class ProviderTLS:
-    tls_id: str
-    lights: List[ProviderTrafficLight]
-
-
-@dataclass
 class ProviderState:
     vehicles: List[VehicleState] = field(default_factory=list)
-    traffic_light_systems: List[ProviderTLS] = field(default_factory=list)
 
     def merge(self, other: "ProviderState"):
         our_vehicles = {v.vehicle_id for v in self.vehicles}
         other_vehicles = {v.vehicle_id for v in other.vehicles}
         assert our_vehicles.isdisjoint(other_vehicles)
 
-        our_tlss = {tls.tls_id for tls in self.traffic_light_systems}
-        other_tlss = {tls.tls_id for tls in other.traffic_light_systems}
-        assert our_tlss.isdisjoint(other_tlss)
-
         self.vehicles += other.vehicles
-        self.traffic_light_systems += other.traffic_light_systems
 
     def filter(self, vehicle_ids):
         provider_vehicle_ids = [v.vehicle_id for v in self.vehicles]

--- a/smarts/core/tests/helpers/providers.py
+++ b/smarts/core/tests/helpers/providers.py
@@ -41,7 +41,6 @@ class MockProvider:
                 )
                 for vehicle_id, pose, speed in vehicles
             ],
-            traffic_light_systems=[],
         )
 
     def clear_next_provider_state(self):
@@ -59,7 +58,7 @@ class MockProvider:
 
     def step(self, provider_actions, dt, elapsed_sim_time) -> ProviderState:
         if self._next_provider_state is None:
-            return ProviderState(vehicles=[], traffic_light_systems=[])
+            return ProviderState(vehicles=[])
 
         return self._next_provider_state
 

--- a/smarts/core/traffic_history_provider.py
+++ b/smarts/core/traffic_history_provider.py
@@ -72,13 +72,13 @@ class TrafficHistoryProvider:
             default=None,
         )
         if not self._traffic_history_service or timestamp is None:
-            return ProviderState(vehicles=[], traffic_light_systems=[])
+            return ProviderState(vehicles=[])
 
         time_with_offset = str(round(timestamp + self.start_time_offset, 1))
         if not self._traffic_history_service.fetch_history_at_timestep(
             time_with_offset
         ):
-            return ProviderState(vehicles=[], traffic_light_systems=[])
+            return ProviderState(vehicles=[])
 
         vehicle_type = "passenger"
         states = ProviderState(
@@ -117,7 +117,6 @@ class TrafficHistoryProvider:
                 ).items()
                 if v_id not in self.replaced_vehicle_ids
             ],
-            traffic_light_systems=[],
         )
         return states
 


### PR DESCRIPTION
Traffic light information is not used. It is to be removed for now because it is using up simulation time for no gain.