### PR TITLE
bugfix: parameter misspelling

### DIFF
--- a/examples/multi_instance.py
+++ b/examples/multi_instance.py
@@ -189,6 +189,6 @@ if __name__ == "__main__":
         evaluation_scenarios=[args.evaluation_scenario],
         sim_name=args.sim_name,
         headless=args.headless,
-        num_episodes=args.num_episodes,
+        num_episodes=args.episodes,
         seed=args.seed,
     )


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "examples/multi_instance.py", line 192, in <module>
    num_episodes=args.num_episodes,
AttributeError: 'Namespace' object has no attribute 'num_episodes'
```