### PR TITLE
Make `--headless` flag default to True in ULTRA

### DIFF
--- a/ultra/docs/getting_started.md
+++ b/ultra/docs/getting_started.md
@@ -52,7 +52,7 @@ Implementations of baseline agents are available in `ultra/baselines/`. Notice, 
   - `--level`: The level of the task (default is easy).
   - `--episodes`: The number of training episodes to run (default is 1000000).
   - `--timestep`: The environment timestep in seconds (default is 0.1).
-  - `--headless`: Whether to run training without Envision (default is False).
+  - `--headless`: Whether to run training without Envision (default is True).
   - `--eval-episodes`: The number of evaluation episodes (default is 200).
   - `--eval-rate`: The rate at which evaluation occurs based on the number of observations (default is 10000).
   - `--seed`: The environment seed (default is 2).
@@ -82,7 +82,7 @@ After training your agent, your models should be saved under `logs/<timestamped_
   - `--models`: The path to the saved model (default is models/).
   - `--episodes`: The number of evaluation episodes (default is 200).
   - `--timestep`: The environment timestep in seconds (default is 0.1).
-  - `--headless`: Whether to run evaluation without Envision (default is False).
+  - `--headless`: Whether to run evaluation without Envision (default is True).
   - `--experiment-dir`: The path to the spec file that includes adapters and policy parameters.
   - `--policy`: The policy (agent) to evaluate (default is sac).
   - `--max-steps-episode`: The option to limit the number of steps per epsiodes (default is 10000).

--- a/ultra/docs/rllib.md
+++ b/ultra/docs/rllib.md
@@ -26,7 +26,7 @@ of the steps is shown below
   - `--level`: The level of the task (default is easy).
   - `--episodes`: The number of training episodes to run (default is 100).
   - `--timestep`: The environment timestep in seconds (default is 0.1).
-  - `--headless`: Whether to run training without Envision (default is False).
+  - `--headless`: Whether to run training without Envision (default is True).
   - `--eval-episodes`: The number of evaluation episodes (default is 200).
   - `--eval-rate`: The rate at which evaluation occurs based on the number of episodes (default is 10000).
   - `--seed`: The environment seed (default is 2).

--- a/ultra/ultra/evaluate.py
+++ b/ultra/ultra/evaluate.py
@@ -226,7 +226,7 @@ if __name__ == "__main__":
         "--timestep", help="Environment timestep (sec)", type=float, default=0.1
     )
     parser.add_argument(
-        "--headless", help="Run without envision", type=bool, default=False
+        "--headless", help="Run without envision", type=bool, default=True
     )
     parser.add_argument(
         "--experiment-dir",

--- a/ultra/ultra/rllib_train.py
+++ b/ultra/ultra/rllib_train.py
@@ -179,7 +179,7 @@ if __name__ == "__main__":
         "--timestep", help="environment timestep (sec)", type=float, default=0.1
     )
     parser.add_argument(
-        "--headless", help="run without envision", type=bool, default=False
+        "--headless", help="run without envision", type=bool, default=True
     )
     parser.add_argument(
         "--eval-episodes", help="number of evaluation episodes", type=int, default=100

--- a/ultra/ultra/train.py
+++ b/ultra/ultra/train.py
@@ -224,7 +224,7 @@ if __name__ == "__main__":
         "--timestep", help="Environment timestep (sec)", type=float, default=0.1
     )
     parser.add_argument(
-        "--headless", help="Run without envision", type=bool, default=False
+        "--headless", help="Run without envision", type=bool, default=True
     )
     parser.add_argument(
         "--eval-episodes", help="Number of evaluation episodes", type=int, default=200


### PR DESCRIPTION
Longer experiments require running ULTRA in headless mode to avoid a RayOutOfMemoryError (#557). Make running in headless mode the default.