### PR TITLE
map offset fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ the missions for all agents.
 we now initially shift road networks (maps) that are offset back to the origin
 using [netconvert](https://sumo.dlr.de/docs/netconvert.html).
 We adapt Sumo vehicle positions to take this into account to allow Sumo to continue
-using the original coordinate system.  See Issue #325.
+using the original coordinate system.  See Issue #325 and #716.
 - Cleanly close down the traffic history provider thread. See PR #665.
 - Improved the disposal of a SMARTS instance. See issue #378.
 - Envision now resumes from current frame after un-pausing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ we now initially shift road networks (maps) that are offset back to the origin
 using [netconvert](https://sumo.dlr.de/docs/netconvert.html).
 We adapt Sumo vehicle positions to take this into account to allow Sumo to continue
 using the original coordinate system.  See Issue #325.
+    - This fix will require all Scenarios to be rebuilt (`scl scenario build-all --clean ./scenarios`).
 - Cleanly close down the traffic history provider thread. See PR #665.
 - Improved the disposal of a SMARTS instance. See issue #378.
 - Envision now resumes from current frame after un-pausing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Added `sanity-test` script and asked new users to run `sanity-test` instead of `make test` to ease the setup
 process
 - Added `on_shoulder` as part of events in observation returned from each step of simulation
+### Fixed
+- Fixed sumo road network offset bug for shifted maps.  See issue #716.
 
 ## [0.4.15] - 2021-03-18
 ### Added
@@ -33,7 +35,7 @@ the missions for all agents.
 we now initially shift road networks (maps) that are offset back to the origin
 using [netconvert](https://sumo.dlr.de/docs/netconvert.html).
 We adapt Sumo vehicle positions to take this into account to allow Sumo to continue
-using the original coordinate system.  See Issue #325 and #716.
+using the original coordinate system.  See Issue #325.
 - Cleanly close down the traffic history provider thread. See PR #665.
 - Improved the disposal of a SMARTS instance. See issue #378.
 - Envision now resumes from current frame after un-pausing.

--- a/smarts/core/sumo_road_network.py
+++ b/smarts/core/sumo_road_network.py
@@ -38,7 +38,6 @@ from shapely.geometry.base import CAP_STYLE, JOIN_STYLE
 from shapely.ops import snap, triangulate
 from trimesh.exchange import gltf
 
-from .utils.id import Id
 from .utils.math import rotate_around_point
 
 from smarts.core.utils.sumo import sumolib  # isort:skip
@@ -101,8 +100,8 @@ class SumoRoadNetwork:
     @lru_cache(maxsize=1)
     def _shift_coordinates(cls, net_file_path):
         net_file_folder = os.path.dirname(net_file_path)
-        uniqname = Id.new("shifted_map")
-        out_path = os.path.join(net_file_folder, f"{uniqname}.net.xml")
+        out_path = os.path.join(net_file_folder, f"shifted_map-AUTOGEN.net.xml")
+        assert out_path != net_file_path
         logger = logging.getLogger(cls.__name__)
         logger.info(f"normalizing net coordinates into {out_path}...")
         ## Translate the map's origin to remove huge (imprecise) offsets.

--- a/smarts/core/sumo_road_network.py
+++ b/smarts/core/sumo_road_network.py
@@ -38,6 +38,7 @@ from shapely.geometry.base import CAP_STYLE, JOIN_STYLE
 from shapely.ops import snap, triangulate
 from trimesh.exchange import gltf
 
+from .utils.id import Id
 from .utils.math import rotate_around_point
 
 from smarts.core.utils.sumo import sumolib  # isort:skip
@@ -100,7 +101,8 @@ class SumoRoadNetwork:
     @lru_cache(maxsize=1)
     def _shift_coordinates(cls, net_file_path):
         net_file_folder = os.path.dirname(net_file_path)
-        out_path = os.path.join(net_file_folder, "shifted_map.net.xml")
+        uniqname = Id.new("shifted_map")
+        out_path = os.path.join(net_file_folder, f"{uniqname}.net.xml")
         logger = logging.getLogger(cls.__name__)
         logger.info(f"normalizing net coordinates into {out_path}...")
         ## Translate the map's origin to remove huge (imprecise) offsets.

--- a/smarts/core/sumo_traffic_simulation.py
+++ b/smarts/core/sumo_traffic_simulation.py
@@ -206,7 +206,7 @@ class SumoTrafficSimulation(Provider):
     def _base_sumo_load_params(self):
         load_params = [
             "--num-clients=%d" % self._num_clients,
-            "--net-file=%s" % self._scenario.net_filepath,
+            "--net-file=%s" % self._scenario.road_network.net_file,
             "--quit-on-end",
             "--log=%s" % self._log_file,
             "--error-log=%s" % self._log_file,
@@ -593,10 +593,11 @@ class SumoTrafficSimulation(Provider):
             speed = sumo_vehicle[tc.VAR_SPEED]
             vehicle_type = sumo_vehicle[tc.VAR_VEHICLECLASS]
             dimensions = VEHICLE_CONFIGS[vehicle_type].dimensions
-            # adjust sumo vehicle location with map location offset
-            assert len(self._scenario.mapLocationOffset) == 2
-            front_bumper_pos[0] += self._scenario.mapLocationOffset[0]
-            front_bumper_pos[1] += self._scenario.mapLocationOffset[1]
+            # adjust sumo vehicle location if we shifted the map
+            map_offset = self._scenario.road_network.net_offset
+            assert len(map_offset) == 2
+            front_bumper_pos[0] += map_offset[0]
+            front_bumper_pos[1] += map_offset[1]
             provider_vehicles.append(
                 VehicleState(
                     # XXX: In the case of the SUMO traffic provider, the vehicle ID is

--- a/smarts/core/traffic_history_provider.py
+++ b/smarts/core/traffic_history_provider.py
@@ -42,7 +42,7 @@ class TrafficHistoryProvider(Provider):
     def setup(self, scenario) -> ProviderState:
         self._is_setup = True
         self._traffic_history_service = scenario._traffic_history_service
-        self._map_location_offset = scenario.mapLocationOffset
+        self._map_location_offset = scenario.road_network.net_offset
         return ProviderState()
 
     def set_replaced_ids(self, vehicle_ids: list):

--- a/smarts/core/utils/traffic_history_service.py
+++ b/smarts/core/utils/traffic_history_service.py
@@ -169,7 +169,7 @@ class Traffic_history_service:
 
     @staticmethod
     def fetch_agent_missions(
-        history_file_path: str, scenario_root_path: str, mapLocationOffset
+        history_file_path: str, scenario_root_path: str, map_offset
     ):
         assert os.path.isdir(scenario_root_path)
         history_mission_filepath = os.path.join(
@@ -195,7 +195,7 @@ class Traffic_history_service:
                         start=scenario.Start(
                             Traffic_history_service.apply_map_location_offset(
                                 vehicles_state[vehicle_id]["position"],
-                                mapLocationOffset,
+                                map_offset,
                             ),
                             scenario.Heading(vehicles_state[vehicle_id]["heading"]),
                         ),


### PR DESCRIPTION
Use possibly-shifted road network file when starting Sumo.  Note that we now keep around the shifted net file as `shifted_map-AUTOGEN.net.xml` in the same folder where `map.net.xml` was.  
This PR assumes that `sumo` (or `sumo-gui`) are started by SMARTS (within `sumo_traffic_simulation.py`).  There may still be problems if an external simulator uses the original (unshifted) `map.net.xml` directly, either when it starts Sumo or otherwise.  (But this risk may be mitigated if/when we refactor the sumo bridge to be controlled by SMARTS.)
Closes #716.

Also some snake_case variable_name style fixes along the way.
