### PR TITLE
make done_creteria independent from events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Added `sanity-test` script and asked new users to run `sanity-test` instead of `make test` to ease the setup
 process
 - Added `on_shoulder` as part of events in observation returned from each step of simulation
+### Fixed
+- Fixed the bug of events such as off_road not registering in observation when off_road is set to false in DoneCriteria
 
 ## [0.4.15] - 2021-03-18
 ### Added

--- a/smarts/core/sensors.py
+++ b/smarts/core/sensors.py
@@ -323,22 +323,10 @@ class Sensors:
         interface = sim.agent_manager.agent_interface_for_agent_id(agent_id)
         done_criteria = interface.done_criteria
 
-        collided = (
-            sim.vehicle_did_collide(vehicle.id) if done_criteria.collision else False
-        )
-        is_off_road = (
-            cls._vehicle_is_off_road(sim, vehicle) if done_criteria.off_road else False
-        )
-        is_on_shoulder = (
-            cls._vehicle_is_on_shoulder(sim, vehicle)
-            if done_criteria.on_shoulder
-            else False
-        )
-        is_not_moving = (
-            cls._vehicle_is_not_moving(sim, vehicle)
-            if done_criteria.not_moving
-            else False
-        )
+        collided = sim.vehicle_did_collide(vehicle.id)
+        is_off_road = cls._vehicle_is_off_road(sim, vehicle)
+        is_on_shoulder = cls._vehicle_is_on_shoulder(sim, vehicle)
+        is_not_moving = cls._vehicle_is_not_moving(sim, vehicle)
         reached_goal = cls._agent_reached_goal(sim, vehicle)
         reached_max_episode_steps = sensor_state.reached_max_episode_steps
         is_off_route, is_wrong_way = cls._vehicle_is_off_route_and_wrong_way(
@@ -346,12 +334,12 @@ class Sensors:
         )
 
         done = (
-            is_off_road
+            (is_off_road and done_criteria.off_road)
             or reached_goal
             or reached_max_episode_steps
-            or is_on_shoulder
-            or collided
-            or is_not_moving
+            or (is_on_shoulder and done_criteria.on_shoulder)
+            or (collided and done_criteria.collision)
+            or (is_not_moving and done_criteria.not_moving)
             or (is_off_route and done_criteria.off_route)
             or (is_wrong_way and done_criteria.wrong_way)
         )


### PR DESCRIPTION
This pr is to address the following: 
Previously when setting off_road in DoneCreteria to False, off_road events will also be False in observation when going off road. However, when users set DoneCreteria.offroad to False, they might still want to use off_road event  in observations.
