### PR TITLE
Extra ULTRA scenarios for debugging social-vehicle encoders

### DIFF
--- a/ultra/tests/scenarios/task00-multiagent/config.yaml
+++ b/ultra/tests/scenarios/task00-multiagent/config.yaml
@@ -13,6 +13,7 @@ levels:
         2lane_t:
            percent: 1
            specs: [[70kmh,p-test,1]]
+           stops: null
     test:
       total: 1
       ego_missions:
@@ -22,6 +23,7 @@ levels:
         2lane_t:
            percent: 1
            specs: [[70kmh,p-test,1]]
+           stops: null
   no-traffic:
     train:
       total: 1
@@ -36,6 +38,7 @@ levels:
         2lane_t:
            percent: 1
            specs: [[70kmh,no-traffic,1]]
+           stops: null
     test:
       total: 1
       ego_missions:
@@ -45,6 +48,7 @@ levels:
         2lane_t:
            percent: 1
            specs: [[70kmh,no-traffic,1]]
+           stops: null
   # Used in evaluation test
   eval_test:
     train:
@@ -63,18 +67,21 @@ levels:
                   [50kmh,mid-density,0.11],[70kmh,mid-density,0.11],[100kmh,mid-density,0.11], #33%,
                   [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                   [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
+          stops: null
         2lane_curvy_t:
           percent: 0.4
           specs: [[50kmh,low-density,0.21],[70kmh,low-density,0.20],[100kmh,low-density,0.20], #61%
                   [50kmh,mid-density,0.11],[70kmh,mid-density,0.11],[100kmh,mid-density,0.11], #33%
                   [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                   [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
+          stops: null
         3lane_t:
           percent: 0.4
           specs: [[50kmh,low-density,0.21],[70kmh,low-density,0.20],[100kmh,low-density,0.20], #61%
                   [50kmh,mid-density,0.11],[70kmh,mid-density,0.11],[100kmh,mid-density,0.11], #33%
                   [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                   [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
+          stops: null
     test:
       total: 2
       ego_missions:
@@ -87,9 +94,11 @@ levels:
                   [50kmh,mid-density,0.11],[70kmh,mid-density,0.11],[100kmh,mid-density,0.11], #33%
                   [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                   [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
+          stops: null
         3lane_c:
           percent: 0.5
           specs: [[50kmh,low-density,0.21],[70kmh,low-density,0.20],[100kmh,low-density,0.20], #61%
                   [50kmh,mid-density,0.11],[70kmh,mid-density,0.11],[100kmh,mid-density,0.11], #33%
                   [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                   [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
+          stops: null

--- a/ultra/tests/scenarios/task00/config.yaml
+++ b/ultra/tests/scenarios/task00/config.yaml
@@ -10,6 +10,7 @@ levels:
         2lane_t:
            percent: 1
            specs: [[70kmh,p-test,1]]
+           stops: null
     test:
       total: 1
       ego_missions:
@@ -20,6 +21,7 @@ levels:
         2lane_t:
            percent: 1
            specs: [[70kmh,p-test,1]]
+           stops: null
   no-traffic:
     train:
       total: 1
@@ -31,6 +33,7 @@ levels:
         2lane_t:
            percent: 1
            specs: [[70kmh,no-traffic,1]]
+           stops: null
     test:
       total: 1
       ego_missions:
@@ -41,6 +44,7 @@ levels:
         2lane_t:
            percent: 1
            specs: [[70kmh,no-traffic,1]]
+           stops: null
   # Used in evaluation test
   eval_test:
     train:
@@ -56,18 +60,21 @@ levels:
                   [50kmh,mid-density,0.11],[70kmh,mid-density,0.11],[100kmh,mid-density,0.11], #33%,
                   [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                   [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
+          stops: null
         2lane_curvy_t:
           percent: 0.4
           specs: [[50kmh,low-density,0.21],[70kmh,low-density,0.20],[100kmh,low-density,0.20], #61%
                   [50kmh,mid-density,0.11],[70kmh,mid-density,0.11],[100kmh,mid-density,0.11], #33%
                   [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                   [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
+          stops: null
         3lane_t:
           percent: 0.4
           specs: [[50kmh,low-density,0.21],[70kmh,low-density,0.20],[100kmh,low-density,0.20], #61%
                   [50kmh,mid-density,0.11],[70kmh,mid-density,0.11],[100kmh,mid-density,0.11], #33%
                   [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                   [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
+          stops: null
     test:
       total: 2
       ego_missions:
@@ -81,12 +88,14 @@ levels:
                   [50kmh,mid-density,0.11],[70kmh,mid-density,0.11],[100kmh,mid-density,0.11], #33%
                   [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                   [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
+          stops: null
         3lane_c:
           percent: 0.5
           specs: [[50kmh,low-density,0.21],[70kmh,low-density,0.20],[100kmh,low-density,0.20], #61%
                   [50kmh,mid-density,0.11],[70kmh,mid-density,0.11],[100kmh,mid-density,0.11], #33%
                   [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                   [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
+          stops: null
   offset_test:
     train:
       total: 10
@@ -99,6 +108,7 @@ levels:
         2lane_t:
            percent: 1
            specs: [[70kmh,p-test,1]]
+           stops: null
     test:
       total: 1
       ego_missions:
@@ -110,3 +120,4 @@ levels:
         2lane_t:
            percent: 1
            specs: [[70kmh,p-test,1]]
+           stops: null

--- a/ultra/ultra/config.yaml
+++ b/ultra/ultra/config.yaml
@@ -13,6 +13,10 @@ tasks:
     eval_test:
       train: "../tests/task/eval_test_multiagent/eval*"
       test:  "../tests/task/eval_test_multiagent/eval*"
+  taskX:
+    road-blocks:
+      train: "scenarios/taskX/train_road-blocks*"
+      test:  "scenarios/taskX/test_road-blocks*"
   task0:
     no-traffic:
       train: "scenarios/task1/train_no-traffic*"

--- a/ultra/ultra/config.yaml
+++ b/ultra/ultra/config.yaml
@@ -11,8 +11,8 @@ tasks:
       train: "../tests/task/train_multiagent_mock*"
       test:  "../tests/task/test_multiagent_mock*"
     eval_test:
-      train: "../tests/task/eval_test_multiagent/eval*"
-      test:  "../tests/task/eval_test_multiagent/eval*"
+      train: "../tests/task/eval_test_multiagent/train_*"
+      test:  "../tests/task/eval_test_multiagent/test_*"
   taskX:
     road-blocks:
       train: "scenarios/taskX/train_road-blocks*"

--- a/ultra/ultra/scenarios/common/distributions.py
+++ b/ultra/ultra/scenarios/common/distributions.py
@@ -111,7 +111,7 @@ t_patterns = {
                 "has_turn": True,
                 "deadlock_optimization": True,
             },
-            "east-south": None
+            "east-south": None,
         },
         "ego_hijacking_params": {
             "zone_range": [5, 10],
@@ -500,7 +500,7 @@ cross_patterns = {
             "east-south": None,
             "north-east": None,
             "north-west": None,
-            "north-south": None
+            "north-south": None,
         },
         "ego_hijacking_params": {
             "zone_range": [5, 10],

--- a/ultra/ultra/scenarios/common/distributions.py
+++ b/ultra/ultra/scenarios/common/distributions.py
@@ -88,7 +88,7 @@ t_patterns = {
             "south-north": None,
             "south-east": None,
             "south-west": {
-                "vehicles": 5,
+                "vehicles": 10,
                 "start_end_on_different_lanes_probability": 0.0,
                 "distribution": behavior_distribution,
                 "begin_time_init": {
@@ -100,7 +100,17 @@ t_patterns = {
             },
             "west-east": None,
             "west-south": None,
-            "east-west": None,
+            "east-west": {
+                "vehicles": 10,
+                "start_end_on_different_lanes_probability": 0.0,
+                "distribution": behavior_distribution,
+                "begin_time_init": {
+                    "func": basic_begin_time_init_func,
+                    "params": {"probability": prob_easy},
+                },
+                "has_turn": True,
+                "deadlock_optimization": True,
+            },
             "east-south": None
         },
         "ego_hijacking_params": {
@@ -457,12 +467,12 @@ cross_patterns = {
         },
         # t-intersection has no north route
     },
-    "blocks": {  # t-intersection
+    "blocks": {  # c-intersection
         "routes": {
             "south-west": None,
             "south-east": None,
             "south-north": {
-                "vehicles": 5,
+                "vehicles": 10,
                 "start_end_on_different_lanes_probability": 0.0,
                 "distribution": behavior_distribution,
                 "begin_time_init": {
@@ -475,7 +485,17 @@ cross_patterns = {
             "west-east": None,
             "west-north": None,  # blocking
             "west-south": None,
-            "east-west": None,
+            "east-west": {
+                "vehicles": 10,
+                "start_end_on_different_lanes_probability": 0.0,
+                "distribution": behavior_distribution,
+                "begin_time_init": {
+                    "func": basic_begin_time_init_func,
+                    "params": {"probability": prob_easy},
+                },
+                "has_turn": True,
+                "deadlock_optimization": True,
+            },
             "east-north": None,
             "east-south": None,
             "north-east": None,

--- a/ultra/ultra/scenarios/common/distributions.py
+++ b/ultra/ultra/scenarios/common/distributions.py
@@ -52,7 +52,7 @@ t_patterns = {
     "no-traffic": {  # t-intersection
         "routes": {
             "south-west": {
-                "vehicles": 2,
+                "vehicles": 5,
                 "start_end_on_different_lanes_probability": 0.0,
                 "distribution": behavior_distribution,
                 "begin_time_init": {
@@ -80,6 +80,33 @@ t_patterns = {
                 "has_turn": True,
                 "deadlock_optimization": True,
             },
+        },
+        # t-intersection has no north route
+    },
+    "blocks": {  # t-intersection
+        "routes": {
+            "south-north": None,
+            "south-east": None,
+            "south-west": {
+                "vehicles": 5,
+                "start_end_on_different_lanes_probability": 0.0,
+                "distribution": behavior_distribution,
+                "begin_time_init": {
+                    "func": basic_begin_time_init_func,
+                    "params": {"probability": prob_easy},
+                },
+                "has_turn": True,
+                "deadlock_optimization": True,
+            },
+            "west-east": None,
+            "west-south": None,
+            "east-west": None,
+            "east-south": None
+        },
+        "ego_hijacking_params": {
+            "zone_range": [5, 10],
+            "wait_to_hijack_limit_s": 10,
+            "start_time": "default",  # any value or default for LANE_LENGTH / speed_m_per_s
         },
         # t-intersection has no north route
     },
@@ -427,6 +454,38 @@ cross_patterns = {
             "north-south": None,
             "north-east": None,
             "north-west": None,
+        },
+        # t-intersection has no north route
+    },
+    "blocks": {  # t-intersection
+        "routes": {
+            "south-west": None,
+            "south-east": None,
+            "south-north": {
+                "vehicles": 5,
+                "start_end_on_different_lanes_probability": 0.0,
+                "distribution": behavior_distribution,
+                "begin_time_init": {
+                    "func": basic_begin_time_init_func,
+                    "params": {"probability": prob_easy},
+                },
+                "has_turn": True,
+                "deadlock_optimization": True,
+            },
+            "west-east": None,
+            "west-north": None,  # blocking
+            "west-south": None,
+            "east-west": None,
+            "east-north": None,
+            "east-south": None,
+            "north-east": None,
+            "north-west": None,
+            "north-south": None
+        },
+        "ego_hijacking_params": {
+            "zone_range": [5, 10],
+            "wait_to_hijack_limit_s": 10,
+            "start_time": "default",  # any value or default for LANE_LENGTH / speed_m_per_s
         },
         # t-intersection has no north route
     },

--- a/ultra/ultra/scenarios/generate_scenarios.py
+++ b/ultra/ultra/scenarios/generate_scenarios.py
@@ -306,8 +306,9 @@ def generate_left_turn_missions(
                                 "endPos": stop_position,
                                 "duration": "1000",
                             }
-                            vehicle.setAttribute("departPos", stop_position)
                             vehicle.setAttribute("depart", 0)
+                            vehicle.setAttribute("departPos", stop_position)
+                            vehicle.setAttribute("departSpeed", 0)
                             vehicle.setAttribute("departLane", stop_lane)
                             vehicle.addChild("stop", attrs=stop_attributes)
                             stops.pop(0)

--- a/ultra/ultra/scenarios/generate_scenarios.py
+++ b/ultra/ultra/scenarios/generate_scenarios.py
@@ -504,6 +504,10 @@ def scenario_worker(
     for i, seed in enumerate(seeds):
         if not dynamic_pattern_func is None:
             route_distributions = dynamic_pattern_func(route_distributions, i)
+        if stops is not None:
+            # Stops is modified during generation. Copy stops so parallel processes
+            # don't pop elements from the same list reference.
+            stops = stops.copy()
         generate_left_turn_missions(
             missions=ego_missions,
             route_lanes=route_lanes,
@@ -515,7 +519,7 @@ def scenario_worker(
             stopwatcher_behavior=stopwatcher_behavior,
             stopwatcher_route=stopwatcher_route,
             seed=seed,
-            stops=stops.copy(),  # We modify stops, copy so it can be used in parallel.
+            stops=stops,
             traffic_density=traffic_density,
             intersection_name=intersection_type,
         )

--- a/ultra/ultra/scenarios/generate_scenarios.py
+++ b/ultra/ultra/scenarios/generate_scenarios.py
@@ -293,7 +293,7 @@ def generate_left_turn_missions(
 
             # Add stops (if applicable) to vehicles in the existing all.rou.xml file.
             for vehicle in sumolib.output.parse(route_file_path, "vehicle"):
-                if stops:
+                if len(stops) > 0:
                     vehicle_edges = vehicle.route[0].edges.split()
                     start_edge = map_file.getEdge(vehicle_edges[0])
 
@@ -504,10 +504,11 @@ def scenario_worker(
     for i, seed in enumerate(seeds):
         if not dynamic_pattern_func is None:
             route_distributions = dynamic_pattern_func(route_distributions, i)
-        if stops is not None:
-            # Stops is modified during generation. Copy stops so parallel processes
-            # don't pop elements from the same list reference.
-            stops = stops.copy()
+
+        # Stops is modified during generation. Copy stops so parallel processes don't
+        # pop elements from the same list reference.
+        stops_copy = None if stops is None else stops.copy()
+
         generate_left_turn_missions(
             missions=ego_missions,
             route_lanes=route_lanes,
@@ -519,7 +520,7 @@ def scenario_worker(
             stopwatcher_behavior=stopwatcher_behavior,
             stopwatcher_route=stopwatcher_route,
             seed=seed,
-            stops=stops,
+            stops=stops_copy,
             traffic_density=traffic_density,
             intersection_name=intersection_type,
         )

--- a/ultra/ultra/scenarios/generate_scenarios.py
+++ b/ultra/ultra/scenarios/generate_scenarios.py
@@ -32,6 +32,7 @@ from collections import Counter, defaultdict
 from dataclasses import replace
 from multiprocessing import Manager, Process
 from shutil import copyfile
+
 import numpy as np
 import yaml
 
@@ -327,9 +328,9 @@ def generate_left_turn_missions(
 
                 route_file.write(
                     "<routes xmlns:xsi="
-                    "\"http://www.w3.org/2001/XMLSchema-instance\" "
+                    '"http://www.w3.org/2001/XMLSchema-instance" '
                     "xsi:noNamespaceSchemaLocation="
-                    "\"http://sumo.dlr.de/xsd/routes_file.xsd\">\n"
+                    '"http://sumo.dlr.de/xsd/routes_file.xsd">\n'
                 )
 
                 for vehicle_type in vehicle_types:
@@ -573,7 +574,11 @@ def build_scenarios(
         intersection_types = level_config[mode]["intersection_types"]
         intersections = sorted(
             [
-                [_type, intersection_types[_type]["percent"], intersection_types[_type]["stops"]]
+                [
+                    _type,
+                    intersection_types[_type]["percent"],
+                    intersection_types[_type]["stops"],
+                ]
                 for _type in intersection_types
             ],
             key=lambda x: x[1],
@@ -611,7 +616,6 @@ def build_scenarios(
                     temp_save_dir = task_dir + "/" + "_".join(name_additions)
                 else:
                     temp_save_dir = save_dir
-
 
                 sub_proc = Process(
                     target=scenario_worker,

--- a/ultra/ultra/scenarios/task1/config.yaml
+++ b/ultra/ultra/scenarios/task1/config.yaml
@@ -10,6 +10,7 @@ levels:
         2lane_t:
            percent: 1
            specs: [[70kmh,p-test,1]]
+           stops: null
     test:
       total: 10
       ego_missions:
@@ -20,6 +21,7 @@ levels:
         2lane_t:
            percent: 1
            specs: [[70kmh,p-test,1]]
+           stops: null
   no-traffic:
     train:
       total: 10000
@@ -31,9 +33,11 @@ levels:
         2lane_t:
            percent: 0.5
            specs: [[50kmh,no-traffic,0.34],[70kmh,no-traffic,0.33],[100kmh,no-traffic,0.33]]
+           stops: null
         3lane_t:
            percent: 0.5
            specs: [[50kmh,no-traffic,0.34],[70kmh,no-traffic,0.33],[100kmh,no-traffic,0.33]]
+           stops: null
     test:
       total: 200
       ego_missions:
@@ -44,9 +48,11 @@ levels:
         2lane_c:
            percent: 0.5
            specs: [[50kmh,no-traffic,0.34],[70kmh,no-traffic,0.33],[100kmh,no-traffic,0.33]]
+           stops: null
         3lane_c:
            percent: 0.5
            specs: [[50kmh,no-traffic,0.34],[70kmh,no-traffic,0.33],[100kmh,no-traffic,0.33]]
+           stops: null
   easy:
     train:
       total: 10000
@@ -61,18 +67,21 @@ levels:
                    [50kmh,mid-density,0.11],[70kmh,mid-density,0.11],[100kmh,mid-density,0.11], #33%,
                    [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                    [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
+           stops: null
         2lane_curvy_t:
            percent: 0.4
            specs: [[50kmh,low-density,0.21],[70kmh,low-density,0.20],[100kmh,low-density,0.20], #61%
                    [50kmh,mid-density,0.11],[70kmh,mid-density,0.11],[100kmh,mid-density,0.11], #33%
                    [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                    [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
+           stops: null
         3lane_t:
            percent: 0.4
            specs: [[50kmh,low-density,0.21],[70kmh,low-density,0.20],[100kmh,low-density,0.20], #61%
                    [50kmh,mid-density,0.11],[70kmh,mid-density,0.11],[100kmh,mid-density,0.11], #33%
                    [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                    [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
+           stops: null
     test:
       total: 200
       ego_missions:
@@ -86,12 +95,14 @@ levels:
                    [50kmh,mid-density,0.11],[70kmh,mid-density,0.11],[100kmh,mid-density,0.11], #33%
                    [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                    [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
+           stops: null
         3lane_c:
            percent: 0.5
            specs: [[50kmh,low-density,0.21],[70kmh,low-density,0.20],[100kmh,low-density,0.20], #61%
                    [50kmh,mid-density,0.11],[70kmh,mid-density,0.11],[100kmh,mid-density,0.11], #33%
                    [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                    [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
+           stops: null
   hard:
     train:
       total: 10000
@@ -106,6 +117,7 @@ levels:
                    [50kmh,mid-density,0.11],[70kmh,mid-density,0.11],[100kmh,mid-density,0.11], #33%
                    [50kmh,low-density,0.01],[70kmh,low-density,0.01],[100kmh,low-density,0.01], # 3%
                    [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01]] #3%
+           stops: null
 
         2lane_curvy_t:
            percent: 0.4
@@ -113,12 +125,14 @@ levels:
                    [50kmh,mid-density,0.11],[70kmh,mid-density,0.11],[100kmh,mid-density,0.11],
                    [50kmh,low-density,0.01],[70kmh,low-density,0.01],[100kmh,low-density,0.01], # 3%
                    [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01]] #3%
+           stops: null
         3lane_t:
            percent: 0.4
            specs: [[50kmh,high-density,0.21],[70kmh,high-density,0.2],[100kmh,high-density,0.2], # 61%
                   [50kmh,mid-density,0.11],[70kmh,mid-density,0.11],[100kmh,mid-density,0.11], # 33%
                   [50kmh,low-density,0.01],[70kmh,low-density,0.01],[100kmh,low-density,0.01], # 3%
                   [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01]] #3%
+           stops: null
     test:
       total: 200
       ego_missions:
@@ -131,8 +145,10 @@ levels:
            specs: [[50kmh,high-density,0.21],[70kmh,high-density,0.2],[100kmh,high-density,0.2], #61%
                    [50kmh,mid-density,0.12],[70kmh,mid-density,0.12],[100kmh,mid-density,0.12], #36%
                    [50kmh,low-density,0.01],[70kmh,low-density,0.01],[100kmh,low-density,0.01]] # 3%]
+           stops: null
         3lane_c:
            percent: 0.5
            specs: [[50kmh,high-density,0.21],[70kmh,high-density,0.2],[100kmh,high-density,0.2], #61%,
                    [50kmh,mid-density,0.12],[70kmh,mid-density,0.12],[100kmh,mid-density,0.12], #36%
                    [50kmh,low-density,0.01],[70kmh,low-density,0.01],[100kmh,low-density,0.01]] # 3%
+           stops: null

--- a/ultra/ultra/scenarios/task2/config.yaml
+++ b/ultra/ultra/scenarios/task2/config.yaml
@@ -12,11 +12,13 @@ levels:
            specs: [[50kmh,low-density,0.21],[70kmh,low-density,0.20],[100kmh,low-density,0.20], #61%
                    [50kmh,mid-density,0.12],[70kmh,mid-density,0.12],[100kmh,mid-density,0.12], #36%
                    [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
+           stops: null
         3lane_t:
            percent: 0.5
            specs: [[50kmh,low-density,0.21],[70kmh,low-density,0.20],[100kmh,low-density,0.20], #61%
                    [50kmh,mid-density,0.12],[70kmh,mid-density,0.12],[100kmh,mid-density,0.12], #36%
                    [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
+           stops: null
     test:
       total: 200
       ego_missions:
@@ -29,11 +31,13 @@ levels:
            specs: [[50kmh,high-density,0.21],[70kmh,high-density,0.20],[100kmh,high-density,0.20], #61%
                    [50kmh,mid-density,0.12],[70kmh,mid-density,0.12],[100kmh,mid-density,0.12], #36%
                    [50kmh,low-density,0.01],[70kmh,low-density,0.01],[100kmh,low-density,0.01]] # 3%
+           stops: null
         3lane_t:
            percent: 0.5
            specs: [[50kmh,high-density,0.21],[70kmh,high-density,0.20],[100kmh,high-density,0.20], #61%
                    [50kmh,mid-density,0.12],[70kmh,mid-density,0.12],[100kmh,mid-density,0.12], #36%
                    [50kmh,low-density,0.01],[70kmh,low-density,0.01],[100kmh,low-density,0.01]] # 3%
+           stops: null
   hi-low:
     train:
       total: 800
@@ -47,11 +51,13 @@ levels:
            specs: [[50kmh,high-density,0.21],[70kmh,high-density,0.20],[100kmh,high-density,0.20], #61%
                    [50kmh,mid-density,0.12],[70kmh,mid-density,0.12],[100kmh,mid-density,0.12], #36%
                    [50kmh,low-density,0.01],[70kmh,low-density,0.01],[100kmh,low-density,0.01]] # 3%
+           stops: null
         3lane_t:
            percent: 0.5
            specs: [[50kmh,high-density,0.21],[70kmh,high-density,0.20],[100kmh,high-density,0.20], #61%
                    [50kmh,mid-density,0.12],[70kmh,mid-density,0.12],[100kmh,mid-density,0.12], #36%
                    [50kmh,low-density,0.01],[70kmh,low-density,0.01],[100kmh,low-density,0.01]] # 3%
+           stops: null
     test:
       total: 200
       ego_missions:
@@ -64,8 +70,10 @@ levels:
            specs: [[50kmh,low-density,0.21],[70kmh,low-density,0.20],[100kmh,low-density,0.20], #61%
                    [50kmh,mid-density,0.12],[70kmh,mid-density,0.12],[100kmh,mid-density,0.12], #36%
                    [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
+           stops: null
         3lane_t:
            percent: 0.5
            specs: [[50kmh,low-density,0.21],[70kmh,low-density,0.20],[100kmh,low-density,0.20], #61%
                    [50kmh,mid-density,0.12],[70kmh,mid-density,0.12],[100kmh,mid-density,0.12], #36%
                    [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
+           stops: null

--- a/ultra/ultra/scenarios/taskX/config.yaml
+++ b/ultra/ultra/scenarios/taskX/config.yaml
@@ -10,11 +10,11 @@ levels:
         3lane_t:
            percent: 0.5
            specs: [[50kmh,blocks,0.34],[70kmh,blocks,0.33],[100kmh,blocks,0.33]]
-           stops: [[south-SN,1,80],[south-SN,0,120]]
+           stops: [[south-SN,0,120]]
         4lane_t:
            percent: 0.5
            specs: [[50kmh,blocks,0.34],[70kmh,blocks,0.33],[100kmh,blocks,0.33]]
-           stops: [[south-SN,1,70],[south-SN,0,120]]
+           stops: [[south-SN,1,120],[south-SN,0,120]]
     test:
       total: 10
       ego_missions:
@@ -25,8 +25,8 @@ levels:
         3lane_c:
            percent: 0.5
            specs: [[50kmh,blocks,0.34],[70kmh,blocks,0.33],[100kmh,blocks,0.33]]
-           stops: [[south-SN,0,80]]
+           stops: [[south-SN,0,120]]
         4lane_c:
            percent: 0.5
            specs: [[50kmh,blocks,0.34],[70kmh,blocks,0.33],[100kmh,blocks,0.33]]
-           stops: [[south-SN,1,80]]
+           stops: [[south-SN,1,120],[south-SN,0,120]]

--- a/ultra/ultra/scenarios/taskX/config.yaml
+++ b/ultra/ultra/scenarios/taskX/config.yaml
@@ -1,20 +1,20 @@
 levels:
   road-blocks:
     train:
-      total: 5
+      total: 10
       ego_missions:
         # left turn from south to west
       - start: south-SN
         end:   west-EW
       intersection_types:
-        2lane_t:
-           percent: 0.5
-           specs: [[50kmh,blocks,0.34],[70kmh,blocks,0.33],[100kmh,blocks,0.33]]
-           stops: [[south-SN,0,80]]
         3lane_t:
            percent: 0.5
            specs: [[50kmh,blocks,0.34],[70kmh,blocks,0.33],[100kmh,blocks,0.33]]
-           stops: [[south-SN,0,100]]
+           stops: [[south-SN,1,80],[south-SN,0,120]]
+        4lane_t:
+           percent: 0.5
+           specs: [[50kmh,blocks,0.34],[70kmh,blocks,0.33],[100kmh,blocks,0.33]]
+           stops: [[south-SN,1,70],[south-SN,0,120]]
     test:
       total: 10
       ego_missions:
@@ -22,11 +22,11 @@ levels:
       - start: south-SN
         end:   west-EW
       intersection_types:
-        2lane_c:
-           percent: 0.5
-           specs: [[50kmh,blocks,0.34],[70kmh,blocks,0.33],[100kmh,blocks,0.33]]
-           stops: [[south-SN,0,80]]
         3lane_c:
            percent: 0.5
            specs: [[50kmh,blocks,0.34],[70kmh,blocks,0.33],[100kmh,blocks,0.33]]
            stops: [[south-SN,0,80]]
+        4lane_c:
+           percent: 0.5
+           specs: [[50kmh,blocks,0.34],[70kmh,blocks,0.33],[100kmh,blocks,0.33]]
+           stops: [[south-SN,1,80]]

--- a/ultra/ultra/scenarios/taskX/config.yaml
+++ b/ultra/ultra/scenarios/taskX/config.yaml
@@ -1,0 +1,32 @@
+levels:
+  road-blocks:
+    train:
+      total: 5
+      ego_missions:
+        # left turn from south to west
+      - start: south-SN
+        end:   west-EW
+      intersection_types:
+        2lane_t:
+           percent: 0.5
+           specs: [[50kmh,blocks,0.34],[70kmh,blocks,0.33],[100kmh,blocks,0.33]]
+           stops: [[south-SN,0,80]]
+        3lane_t:
+           percent: 0.5
+           specs: [[50kmh,blocks,0.34],[70kmh,blocks,0.33],[100kmh,blocks,0.33]]
+           stops: [[south-SN,0,100]]
+    test:
+      total: 10
+      ego_missions:
+        # left turn from south to west
+      - start: south-SN
+        end:   west-EW
+      intersection_types:
+        2lane_c:
+           percent: 0.5
+           specs: [[50kmh,blocks,0.34],[70kmh,blocks,0.33],[100kmh,blocks,0.33]]
+           stops: [[south-SN,0,80]]
+        3lane_c:
+           percent: 0.5
+           specs: [[50kmh,blocks,0.34],[70kmh,blocks,0.33],[100kmh,blocks,0.33]]
+           stops: [[south-SN,0,80]]


### PR DESCRIPTION
Adding a new feature to maps for adding stopped vehicles on the south route

- for adding stops we need to specify the number of vehicles we need + their positions and lane
- this change requires some minor modifications to the other distributions/config files related to scenarios
- we can have other social vehicles moving as well or keep it simple by just have a few blocks on the road

@AlexLewandowski @JenishPatel99 @christianjans this is the draft for stopped vehicles, please don't push changes to this code for now and lets finalize the idea on our next meeting

TODO:
- [x] Overwrite `traffic/all.rou.xml` file with new vehicles
- [x] Add `stops` to the other task configs
- [x] Ensure ego vehicles do not hijack stopped vehicles
- [x] Address issue in some scenarios not including stopped vehicles when it should