### PR TITLE
Add image observations for ULTRA baseline agents

### DIFF
--- a/ultra/ultra/baselines/adapter.py
+++ b/ultra/ultra/baselines/adapter.py
@@ -70,10 +70,15 @@ class BaselineAdapter:
 
         self.social_vehicle_encoder = self.social_vehicle_config["encoder"]
 
+        self.rgb_info = (
+            self.policy_params["rgb"] if "rgb" in self.policy_params else None
+        )
+
         self.state_preprocessor = BaselineStatePreprocessor(
             social_vehicle_config=self.social_vehicle_config,
             observation_waypoints_lookahead=self.observation_num_lookahead,
             action_size=2,
+            rgb_info=self.rgb_info,
         )
 
         self.social_feature_encoder_class = self.social_vehicle_encoder[
@@ -112,6 +117,13 @@ class BaselineAdapter:
                     low=-1e10,
                     high=1e10,
                     shape=(self.social_capacity, self.num_social_features),
+                    dtype=torch.Tensor,
+                ),
+                # ULTRA RLlib does not support image observations now.
+                "images": gym.spaces.Box(
+                    low=0,
+                    high=255,
+                    shape=(1,),
                     dtype=torch.Tensor,
                 ),
             }

--- a/ultra/ultra/baselines/agent_spec.py
+++ b/ultra/ultra/baselines/agent_spec.py
@@ -33,6 +33,7 @@ from smarts.core.agent_interface import (
 
 from ultra.baselines.common.yaml_loader import load_yaml
 from smarts.core.agent import AgentSpec
+from smarts.core.agent_interface import RGB
 from ultra.baselines.adapter import BaselineAdapter
 
 
@@ -96,12 +97,23 @@ class BaselineAgentSpec(AgentSpec):
             assert agent_name != None
 
             adapter = BaselineAdapter(agent_name)
+
+            if "rgb" in adapter.policy_params:
+                rgb_info = adapter.policy_params["rgb"]
+                rgb = RGB(
+                    width=rgb_info["width"],
+                    height=rgb_info["height"],
+                    resolution=rgb_info["resolution"],
+                )
+            else:
+                rgb = False
+
             spec = AgentSpec(
                 interface=AgentInterface(
                     waypoints=Waypoints(lookahead=20),
                     neighborhood_vehicles=NeighborhoodVehicles(200),
                     action=action_type,
-                    rgb=False,
+                    rgb=rgb,
                     max_episode_steps=max_episode_steps,
                     debug=True,
                 ),

--- a/ultra/ultra/baselines/bdqn/bdqn/params.yaml
+++ b/ultra/ultra/baselines/bdqn/bdqn/params.yaml
@@ -20,3 +20,9 @@ social_vehicles:
     social_capacity: 5
     num_social_features: 4
     seed: 2
+# Uncomment to use RGB + low_dim_states as observation.
+rgb:
+    stack_size: 3
+    width: 64
+    height: 64
+    resolution: 0.78125  # = 50 / 64

--- a/ultra/ultra/baselines/common/baseline_state_preprocessor.py
+++ b/ultra/ultra/baselines/common/baseline_state_preprocessor.py
@@ -59,7 +59,7 @@ class BaselineStatePreprocessor(StatePreprocessor):
             self._images_stack = collections.deque(
                 [
                     np.zeros(
-                        (1, rgb_info["height"], rgb_info["width"]), dtype=np.float32
+                        (rgb_info["height"], rgb_info["width"]), dtype=np.float32
                     )
                     for _ in range(rgb_info["stack_size"])
                 ],
@@ -160,10 +160,9 @@ class BaselineStatePreprocessor(StatePreprocessor):
             image = state["rgb"]
             image = np.dot(image, (0.2125, 0.7154, 0.0721))  # Convert to grayscale.
             image = np.divide(image, 255.0)  # Normalize.
-            image = np.expand_dims(image, axis=0)  # Expand to Rank 3 tensor.
             self._images_stack.appendleft(image.astype(np.float32))
         stacked_images = (
-            np.concatenate(self._images_stack, axis=0)
+            np.stack(self._images_stack, axis=0)
             if len(self._images_stack) > 0
             else np.array([], dtype=np.float32)
         )

--- a/ultra/ultra/baselines/common/replay_buffer.py
+++ b/ultra/ultra/baselines/common/replay_buffer.py
@@ -85,6 +85,7 @@ class ReplayBufferDataset(Dataset):
         state["social_vehicles"] = torch.from_numpy(state["social_vehicles"]).to(
             self.device
         )
+        state["images"] = torch.from_numpy(state["images"]).to(self.device)
 
         next_state["low_dim_states"] = np.float32(
             np.append(next_state["low_dim_states"], action)
@@ -95,6 +96,7 @@ class ReplayBufferDataset(Dataset):
         next_state["low_dim_states"] = torch.from_numpy(
             next_state["low_dim_states"]
         ).to(self.device)
+        next_state["images"] = torch.from_numpy(next_state["images"]).to(self.device)
 
         action = np.asarray([action]) if not isinstance(action, Iterable) else action
         action = torch.from_numpy(action).float()
@@ -142,12 +144,6 @@ class ReplayBuffer:
         return self.replay_buffer_dataset[idx]
 
     def make_state_from_dict(self, states, device):
-        # image_keys = states[0]["images"].keys()
-        # images = {}
-        # for k in image_keys:
-        #     _images = torch.cat([e[k] for e in states], dim=0).float().to(device)
-        #     _images = normalize_im(_images)
-        #     images[k] = _images
         low_dim_states = (
             torch.cat([e["low_dim_states"] for e in states], dim=0).float().to(device)
         )
@@ -157,10 +153,13 @@ class ReplayBuffer:
             ]
         else:
             social_vehicles = False
+        images = (
+            torch.cat([state["images"] for state in states], dim=0).float().to(device)
+        )
         out = {
-            # "images": images,
             "low_dim_states": low_dim_states,
             "social_vehicles": social_vehicles,
+            "images": images,
         }
         return out
 

--- a/ultra/ultra/baselines/dqn/dqn/network.py
+++ b/ultra/ultra/baselines/dqn/dqn/network.py
@@ -69,9 +69,12 @@ class DQNCNN(nn.Module):
             # nn.init.normal_(q_out[-1].weight.data, 0.0, 1e-2)
             nn.init.constant_(q_out[-1].bias.data, 0.0)
 
-    def forward(self, image, state_size):
-        im_feature = self.im_feature(image)
-        x = torch.cat([im_feature, state_size], dim=-1)
+    def forward(self, state):
+        image = state["images"]
+        low_dim_states = state["low_dim_states"]
+
+        image_features = self.im_feature(image)
+        x = torch.cat([image_features, low_dim_states], dim=-1)
         x = [e(x) for e in self.q_outs]
         return x
 

--- a/ultra/ultra/baselines/dqn/dqn/network.py
+++ b/ultra/ultra/baselines/dqn/dqn/network.py
@@ -69,14 +69,19 @@ class DQNCNN(nn.Module):
             # nn.init.normal_(q_out[-1].weight.data, 0.0, 1e-2)
             nn.init.constant_(q_out[-1].bias.data, 0.0)
 
-    def forward(self, state):
+    def forward(self, state, training=False):
         image = state["images"]
         low_dim_states = state["low_dim_states"]
 
         image_features = self.im_feature(image)
         x = torch.cat([image_features, low_dim_states], dim=-1)
         x = [e(x) for e in self.q_outs]
-        return x
+
+        if training:
+            aux_losses = {}
+            return x, aux_losses
+        else:
+            return x
 
 
 class DQNFC(nn.Module):

--- a/ultra/ultra/baselines/dqn/dqn/params.yaml
+++ b/ultra/ultra/baselines/dqn/dqn/params.yaml
@@ -20,3 +20,9 @@ social_vehicles:
     social_capacity: 5
     num_social_features: 4
     seed: 2
+# Uncomment to use RGB + low_dim_states as observation.
+# rgb:
+#     stack_size: 4
+#     width: 64
+#     height: 64
+#     resolution: 0.78125  # = 50 / 64

--- a/ultra/ultra/baselines/dqn/dqn/policy.py
+++ b/ultra/ultra/baselines/dqn/dqn/policy.py
@@ -239,8 +239,7 @@ class DQNPolicy(Agent):
 
     def _act(self, state, explore=True):
         epsilon = self.epsilon_obj.get_epsilon()
-        # if not explore or np.random.rand() > epsilon:
-        if True:
+        if not explore or np.random.rand() > epsilon:
             state = copy.deepcopy(state)
             state["low_dim_states"] = np.float32(
                 np.append(state["low_dim_states"], self.prev_action)

--- a/ultra/ultra/baselines/dqn/dqn/policy.py
+++ b/ultra/ultra/baselines/dqn/dqn/policy.py
@@ -166,9 +166,7 @@ class DQNPolicy(Agent):
             network_params = {
                 "n_in_channels": rgb_info["stack_size"],
                 "image_dim": (rgb_info["height"], rgb_info["width"]),
-                # TODO: Make this part of the state_size calculation.
-                "state_size": sum(self.state_description["low_dim_states"].values())
-                + self.action_size,
+                "state_size": self.state_size,
                 "num_actions": self.num_actions,
             }
             network_class = DQNCNN
@@ -204,15 +202,16 @@ class DQNPolicy(Agent):
 
     @property
     def state_size(self):
-        # Adjusting state_size based on number of features (ego+social)
+        # Adjusting state_size based on type of features (ego + social or ego).
         size = sum(self.state_description["low_dim_states"].values())
-        if self.social_feature_encoder_class:
-            size += self.social_feature_encoder_class(
-                **self.social_feature_encoder_params
-            ).output_dim
-        else:
-            size += self.social_capacity * self.num_social_features
-        # adding the previous action
+        if self.rgb_info is None:
+            if self.social_feature_encoder_class:
+                size += self.social_feature_encoder_class(
+                    **self.social_feature_encoder_params
+                ).output_dim
+            else:
+                size += self.social_capacity * self.num_social_features
+        # Add the previous action size.
         size += self.action_size
         return size
 

--- a/ultra/ultra/baselines/td3/td3/cnn_models.py
+++ b/ultra/ultra/baselines/td3/td3/cnn_models.py
@@ -23,6 +23,7 @@
 #  1- https://github.com/udacity/deep-reinforcement-learning
 #  2- https://github.com/sfujim/TD3/blob/master/TD3.py
 #
+import math
 
 import numpy as np
 import torch
@@ -35,10 +36,35 @@ def hidden_init(layer):
     return (-lim, lim)
 
 
+def conv2d_output_size(input_dimensions, output_channels, kernel_sizes, stride_sizes):
+    """Calculate the output size of convolutional layers based on square kernel sizes
+    and square stride sizes. Does not take into account padding or dilation.
+
+        H_out = \floor((H_in - kernel_size) / stride_size + 1)
+        W_out = \floor((W_in - kernel_size) / stride_size + 1)
+    """
+    assert len(output_channels) == len(kernel_sizes) == len(stride_sizes)
+    assert len(input_dimensions) == 2
+
+    input_height = input_dimensions[0]
+    input_width = input_dimensions[1]
+
+    for kernel_size, stride_size in zip(kernel_sizes, stride_sizes):
+        input_height = math.floor((input_height - kernel_size) / stride_size + 1)
+        input_width = math.floor((input_width - kernel_size) / stride_size + 1)
+
+    return input_height * input_width * output_channels[-1]
+
+
 class ActorNetwork(torch.nn.Module):
+    CONV_OUTPUT_CHANNELS = [32, 64, 64]
+    CONV_KERNEL_SIZES = [8, 4, 3]
+    CONV_STRIDE_SIZES = [4, 2, 1]
+
     def __init__(
         self,
         input_channels,
+        input_dimension,
         low_dim_state_size,
         action_space,
         seed,
@@ -50,11 +76,30 @@ class ActorNetwork(torch.nn.Module):
         self.seed = torch.manual_seed(seed)
 
         self.conv1 = torch.nn.Conv2d(
-            input_channels, 32, 8, stride=4
-        )  # 84-8+4/4 -> 20x20x32
-        self.conv2 = torch.nn.Conv2d(32, 64, 4, stride=2)  # 24-3+2/2 -> 9x9x64
-        self.conv3 = torch.nn.Conv2d(64, 64, 3, stride=1)  # 9-3+1/1 -> 7x7x64
-        self.fc1 = torch.nn.Linear(7 * 7 * 64 + low_dim_state_size, hidden_dim)
+            input_channels,
+            ActorNetwork.CONV_OUTPUT_CHANNELS[0],
+            ActorNetwork.CONV_KERNEL_SIZES[0],
+            stride=ActorNetwork.CONV_STRIDE_SIZES[0],
+        )
+        self.conv2 = torch.nn.Conv2d(
+            ActorNetwork.CONV_OUTPUT_CHANNELS[0],
+            ActorNetwork.CONV_OUTPUT_CHANNELS[1],
+            ActorNetwork.CONV_KERNEL_SIZES[1],
+            stride=ActorNetwork.CONV_STRIDE_SIZES[1],
+        )
+        self.conv3 = torch.nn.Conv2d(
+            ActorNetwork.CONV_OUTPUT_CHANNELS[1],
+            ActorNetwork.CONV_OUTPUT_CHANNELS[2],
+            ActorNetwork.CONV_KERNEL_SIZES[2],
+            stride=ActorNetwork.CONV_STRIDE_SIZES[2],
+        )
+        conv_output_size = conv2d_output_size(
+            input_dimension,
+            ActorNetwork.CONV_OUTPUT_CHANNELS,
+            ActorNetwork.CONV_KERNEL_SIZES,
+            ActorNetwork.CONV_STRIDE_SIZES,
+        )
+        self.fc1 = torch.nn.Linear(conv_output_size + low_dim_state_size, hidden_dim)
         self.fc2 = torch.nn.Linear(hidden_dim, action_space)
         self.reset_parameters()
 
@@ -65,7 +110,11 @@ class ActorNetwork(torch.nn.Module):
         self.fc1.weight.data.uniform_(*hidden_init(self.fc1))
         self.fc2.weight.data.uniform_(-1e-3, 1e-3)
 
-    def forward(self, image, low_dim_state):
+    # def forward(self, image, low_dim_state):
+    def forward(self, state, training=False):
+        image = state["images"]
+        low_dim_state = state["low_dim_states"]
+
         output = F.relu(self.conv1(image))
         output = F.relu(self.conv2(output))
         output = F.relu(self.conv3(output))
@@ -76,9 +125,14 @@ class ActorNetwork(torch.nn.Module):
 
 
 class CriticNetwork(torch.nn.Module):
+    CONV_OUTPUT_CHANNELS = [32, 64, 64]
+    CONV_KERNEL_SIZES = [8, 4, 3]
+    CONV_STRIDE_SIZES = [4, 2, 1]
+
     def __init__(
         self,
         input_channels,
+        input_dimension,
         low_dim_state_size,
         action_space,
         seed,
@@ -90,13 +144,30 @@ class CriticNetwork(torch.nn.Module):
         self.action_space = action_space
 
         self.conv1 = torch.nn.Conv2d(
-            input_channels, 32, 8, stride=4
-        )  # 100-8+4/4 -> 24x24x32
-        self.conv2 = torch.nn.Conv2d(32, 64, 4, stride=2)  # 24-3+2/2 -> 11x11x64
-        self.conv3 = torch.nn.Conv2d(64, 64, 3, stride=1)  # 9-3+1/1 -> 9x9x64
-        self.fc1 = torch.nn.Linear(
-            7 * 7 * 64 + low_dim_state_size + action_space, hidden_dim
+            input_channels,
+            CriticNetwork.CONV_OUTPUT_CHANNELS[0],
+            CriticNetwork.CONV_KERNEL_SIZES[0],
+            stride=CriticNetwork.CONV_STRIDE_SIZES[0],
         )
+        self.conv2 = torch.nn.Conv2d(
+            CriticNetwork.CONV_OUTPUT_CHANNELS[0],
+            CriticNetwork.CONV_OUTPUT_CHANNELS[1],
+            CriticNetwork.CONV_KERNEL_SIZES[1],
+            stride=CriticNetwork.CONV_STRIDE_SIZES[1],
+        )
+        self.conv3 = torch.nn.Conv2d(
+            CriticNetwork.CONV_OUTPUT_CHANNELS[1],
+            CriticNetwork.CONV_OUTPUT_CHANNELS[2],
+            CriticNetwork.CONV_KERNEL_SIZES[2],
+            stride=CriticNetwork.CONV_STRIDE_SIZES[2],
+        )
+        conv_output_size = conv2d_output_size(
+            input_dimension,
+            CriticNetwork.CONV_OUTPUT_CHANNELS,
+            CriticNetwork.CONV_KERNEL_SIZES,
+            CriticNetwork.CONV_STRIDE_SIZES,
+        )
+        self.fc1 = torch.nn.Linear(conv_output_size + low_dim_state_size, hidden_dim)
         self.fc2 = torch.nn.Linear(hidden_dim, 1)
 
     def reset_parameters(self):
@@ -106,7 +177,14 @@ class CriticNetwork(torch.nn.Module):
         self.fc1.weight.data.uniform_(*hidden_init(self.fc1))
         self.fc2.weight.data.uniform_(-1e-3, 1e-3)
 
-    def forward(self, image, low_dim_state, action):
+    # def forward(self, image, low_dim_state, action):
+    def forward(self, state, action, training=False):
+        image = state["images"]
+        low_dim_state = state["low_dim_state"]
+
+        print("image:", image)
+        print("low_dim_state:", low_dim_state)
+
         output = F.relu(self.conv1(image))
         output = F.relu(self.conv2(output))
         output = F.relu(self.conv3(output))

--- a/ultra/ultra/baselines/td3/td3/params.yaml
+++ b/ultra/ultra/baselines/td3/td3/params.yaml
@@ -27,3 +27,9 @@ social_vehicles:
     social_capacity: 10
     num_social_features: 4
     seed: 2
+# Uncomment to use RGB + low_dim_states as observation.
+# rgb:
+#     stack_size: 3
+#     width: 64
+#     height: 64
+#     resolution: 0.78125  # = 50 / 64

--- a/ultra/ultra/baselines/td3/td3/policy.py
+++ b/ultra/ultra/baselines/td3/td3/policy.py
@@ -133,15 +133,16 @@ class TD3Policy(Agent):
 
     @property
     def state_size(self):
-        # Adjusting state_size based on number of features (ego+social)
+        # Adjusting state_size based on type of features (ego + social or ego).
         size = sum(self.state_description["low_dim_states"].values())
-        if self.social_feature_encoder_class:
-            size += self.social_feature_encoder_class(
-                **self.social_feature_encoder_params
-            ).output_dim
-        else:
-            size += self.social_capacity * self.num_social_features
-        # adding the previous action
+        if self.rgb_info is None:
+            if self.social_feature_encoder_class:
+                size += self.social_feature_encoder_class(
+                    **self.social_feature_encoder_params
+                ).output_dim
+            else:
+                size += self.social_capacity * self.num_social_features
+        # Add the previous action size.
         size += self.action_size
         return size
 
@@ -151,11 +152,7 @@ class TD3Policy(Agent):
             network_params = {
                 "input_channels": rgb_info["stack_size"],
                 "input_dimension": (rgb_info["height"], rgb_info["width"]),
-                # TODO: Make this part of the state_size calculation.
-                "low_dim_state_size": sum(
-                    self.state_description["low_dim_states"].values()
-                )
-                + self.action_size,
+                "low_dim_state_size": self.state_size,
                 "action_space": self.action_size,
                 "seed": self.seed,
                 "hidden_dim": 512,


### PR DESCRIPTION
Allows ULTRA baseline agents to use image observations.

TODO:
- [x] Fix error encountered when undergoing learning
- [x] Clean up how state size is calculated for non-image states
- [x] Store image observation stacks more efficiently in replay buffer
- [ ] Clean up how RLlib will handle the new image observation option