### PR TITLE
traffic history fix

### DIFF
--- a/smarts/sstudio/genhistories.py
+++ b/smarts/sstudio/genhistories.py
@@ -164,6 +164,13 @@ class _TrajectoryDataset:
         itcur.close()
         dbconxn.commit()
 
+        # ensure that sim_time always starts at 0:
+        self._log.debug("shifting sim_times..")
+        mcur = dbconxn.cursor()
+        mcur.execute("UPDATE Trajectory SET sim_time = sim_time - (SELECT min(sim_time) FROM Trajectory)")
+        mcur.close()
+        dbconxn.commit()
+
         self._log.debug("creating indices..")
         icur = dbconxn.cursor()
         icur.execute("CREATE INDEX Trajectory_Time ON Trajectory (sim_time)")

--- a/smarts/sstudio/genhistories.py
+++ b/smarts/sstudio/genhistories.py
@@ -167,7 +167,9 @@ class _TrajectoryDataset:
         # ensure that sim_time always starts at 0:
         self._log.debug("shifting sim_times..")
         mcur = dbconxn.cursor()
-        mcur.execute("UPDATE Trajectory SET sim_time = sim_time - (SELECT min(sim_time) FROM Trajectory)")
+        mcur.execute(
+            "UPDATE Trajectory SET sim_time = sim_time - (SELECT min(sim_time) FROM Trajectory)"
+        )
         mcur.close()
         dbconxn.commit()
 


### PR DESCRIPTION
Simple fix to ensure that traffic history data always starts at sim_time = 0 (even if the data file being imported does not).

Closes #762.