### PR TITLE
traffic history issues

### DIFF
--- a/smarts/core/traffic_history_provider.py
+++ b/smarts/core/traffic_history_provider.py
@@ -122,7 +122,7 @@ class TrafficHistoryProvider(Provider):
             default_dims = VEHICLE_CONFIGS[vehicle_type].dimensions
             vehicles.append(
                 VehicleState(
-                    vehicle_id=v_id,
+                    vehicle_id=f"social-agent-history-{v_id}",
                     vehicle_type=vehicle_type,
                     pose=Pose.from_center(
                         [

--- a/smarts/sstudio/genhistories.py
+++ b/smarts/sstudio/genhistories.py
@@ -168,7 +168,7 @@ class _TrajectoryDataset:
         self._log.debug("shifting sim_times..")
         mcur = dbconxn.cursor()
         mcur.execute(
-            "UPDATE Trajectory SET sim_time = sim_time - (SELECT min(sim_time) FROM Trajectory)"
+            "UPDATE Trajectory SET sim_time = round(sim_time - (SELECT min(sim_time) FROM Trajectory), 3)"
         )
         mcur.close()
         dbconxn.commit()


### PR DESCRIPTION
Main thing here is a fix for a bug introduced by PR #765:  the update to `sim_time` caused some times to be imprecise, meaning that the "between" query done in the `traffic_history_provider.py` sometimes misses.

Also a miscellaneous update to give traffic history vehicles an id that will allow them to be colored as social agents (as opposed to ego agents) in Sumo, allowing for the 1 ego agent used by the history replacement script to stand out as red.