### PR TITLE
Ignore SMARTS CI base tests on ULTRA branches

### DIFF
--- a/.github/workflows/ci-base-tests.yml
+++ b/.github/workflows/ci-base-tests.yml
@@ -1,6 +1,12 @@
 name: SMARTS CI Base Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - ultra[-_/]**
+  pull_request:
+    branches-ignore:
+      - ultra[-_/]**
 
 jobs:
   test:


### PR DESCRIPTION
Move toward a more independent ULTRA by only running SMARTS CI base tests on SMARTS branches. ULTRA branches (those beginning with `ultra-`, `ultra_`, or `ultra/`) will not run the SMARTS CI base tests. However, they will still run the header and formatting tests from SMARTS.

Tagging @adreena, @AlexLewandowski, @JenishPatel99 to let everyone know of these changes, and the need for ULTRA branches to begin with the above prefixes if you want to avoid SMARTS base tests. Let me know of thoughts/edits if you have any.

Will close #772.