### PR TITLE
Disable ultra test on smarts

### DIFF
--- a/.github/workflows/ci-smarts-run-ultra-tests.yml
+++ b/.github/workflows/ci-smarts-run-ultra-tests.yml
@@ -2,7 +2,7 @@ name: SMARTS scheduled run of ULTRA tests
 
 on:
   schedule:
-    - cron: '25 6 * * 7'
+    - cron: '40 6 * * 6'
       # Time is in UTC
       # Runs at 11.00pm, UTC  , every Wednesday
       # Runs at  6.00pm, UTC-4, every Wednesday

--- a/.github/workflows/ci-smarts-run-ultra-tests.yml
+++ b/.github/workflows/ci-smarts-run-ultra-tests.yml
@@ -2,7 +2,7 @@ name: SMARTS scheduled run of ULTRA tests
 
 on:
   schedule:
-    - cron: '40 6 * * 6'
+    - cron: '0 11 * * 2'
       # Time is in UTC
       # Runs at 11.00pm, UTC  , every Wednesday
       # Runs at  6.00pm, UTC-4, every Wednesday

--- a/.github/workflows/ci-smarts-run-ultra-tests.yml
+++ b/.github/workflows/ci-smarts-run-ultra-tests.yml
@@ -2,16 +2,15 @@ name: SMARTS scheduled run of ULTRA tests
 
 on:
   schedule:
-    - cron: '0 23 * * 3'
+    - cron: '25 6 * * 7'
       # Time is in UTC
       # Runs at 11.00pm, UTC  , every Wednesday
-      # Runs at  6.00pm, UTC-5, every Wednesday
+      # Runs at  6.00pm, UTC-4, every Wednesday
   workflow_dispatch:
 
 jobs:
   test-base:
     runs-on: ubuntu-18.04
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     container: huaweinoah/smarts:v0.4.13-minimal
     steps:
       - name: Checkout

--- a/.github/workflows/ci-smarts-run-ultra-tests.yml
+++ b/.github/workflows/ci-smarts-run-ultra-tests.yml
@@ -1,12 +1,12 @@
-name: ULTRA CI Base Tests
+name: SMARTS scheduled run of ULTRA tests
 
-on: 
-  push:
-    branches:
-      - ultra[-_/]**
-  pull_request:
-    branches:
-      - ultra[-_/]**
+on:
+  schedule:
+    - cron: '0 23 * * 3'
+      # Time is in UTC
+      # Runs at 11.00pm, UTC  , every Wednesday
+      # Runs at  6.00pm, UTC-5, every Wednesday
+  workflow_dispatch:
 
 jobs:
   test-base:
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: develop
       - name: Setup X11
         run: |
           /usr/bin/Xorg \
@@ -105,31 +107,3 @@ jobs:
           . .venv/bin/activate
           scl scenario build-all ultra/scenarios/pool
           pytest -v ./tests/test_ultra_package.py
-  # test-package-via-pypi:
-  #   runs-on: ubuntu-18.04
-  #   if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-  #   container: huaweinoah/smarts:v0.4.13-minimal
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
-  #     - name: Setup X11
-  #       run: |
-  #         /usr/bin/Xorg \
-  #           -noreset \
-  #           +extension GLX \
-  #           +extension RANDR \
-  #           +extension RENDER \
-  #           -logfile ./xdummy.log \
-  #           -config /etc/X11/xorg.conf :1 &
-  #     - name: Install ultra-rl via setup.py
-  #       run: |
-  #         cd ultra
-  #         python3.7 -m venv .venv
-  #         . .venv/bin/activate
-  #         pip install ultra-rl
-  #     - name: Run test
-  #       run: |
-  #         cd ultra
-  #         . .venv/bin/activate
-  #         scl scenario build-all ultra/scenarios/pool
-  #         pytest -v ./tests/test_ultra_package.py

--- a/.github/workflows/ci-test-learning.yml
+++ b/.github/workflows/ci-test-learning.yml
@@ -2,7 +2,7 @@ name: SMARTS CI Learning
 
 on:
   schedule:
-    - cron: '0 23 * * 2'
+    - cron: '0 23 * * 1'
       # Time is in UTC
       # Runs at 11.00pm, UTC  , every Tuesday
       # Runs at  6.00pm, UTC-4, every Tuesday

--- a/.github/workflows/ci-test-learning.yml
+++ b/.github/workflows/ci-test-learning.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 23 * * 2'
       # Time is in UTC
       # Runs at 11.00pm, UTC  , every Tuesday
-      # Runs at  6.00pm, UTC-5, every Tuesday
+      # Runs at  6.00pm, UTC-4, every Tuesday
   workflow_dispatch:
 
 env:

--- a/.github/workflows/ci-test-long-determinism.yml
+++ b/.github/workflows/ci-test-long-determinism.yml
@@ -2,7 +2,7 @@ name: SMARTS CI Long Determinism
 
 on:
   schedule:
-    - cron: '0 23 * * 6'
+    - cron: '0 23 * * 5'
       # Time is in UTC
       # Runs at 11.00pm, UTC  , every Saturday
       # Runs at  6.00pm, UTC-4, every Saturday

--- a/.github/workflows/ci-test-long-determinism.yml
+++ b/.github/workflows/ci-test-long-determinism.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 23 * * 6'
       # Time is in UTC
       # Runs at 11.00pm, UTC  , every Saturday
-      # Runs at  6.00pm, UTC-5, every Saturday
+      # Runs at  6.00pm, UTC-4, every Saturday
   workflow_dispatch:
 
 env:

--- a/.github/workflows/ci-test-memory-growth.yml
+++ b/.github/workflows/ci-test-memory-growth.yml
@@ -2,7 +2,7 @@ name: SMARTS CI Memory
 
 on:
   schedule:
-    - cron: '0 23 * * 4'
+    - cron: '0 23 * * 3'
       # Time is in UTC
       # Runs at 11.00pm, UTC  , every Thursday
       # Runs at  6.00pm, UTC-4, every Thursday

--- a/.github/workflows/ci-test-memory-growth.yml
+++ b/.github/workflows/ci-test-memory-growth.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 23 * * 4'
       # Time is in UTC
       # Runs at 11.00pm, UTC  , every Thursday
-      # Runs at  6.00pm, UTC-5, every Thursday
+      # Runs at  6.00pm, UTC-4, every Thursday
   workflow_dispatch:
 
 env:

--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -3,10 +3,12 @@ name: ULTRA CI Base Tests
 on: 
   push:
     branches:
-      - 'ultra[-_]**'
+      - ultra-**
+      - ultra_**
   pull_request:
     branches:
-      - 'ultra[-_]**'
+      - ultra-**
+      - ultra_**
 
 jobs:
   test-base:

--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -3,10 +3,10 @@ name: ULTRA CI Base Tests
 on: 
   push:
     branches:
-      - 'ultra[-_/]**'
+      - 'ultra[-_]**'
   pull_request:
     branches:
-      - 'ultra[-_/]**'
+      - 'ultra[-_]**'
 
 jobs:
   test-base:

--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -3,7 +3,7 @@ name: ULTRA CI Base Tests
 on: 
   push:
     branches:
-     - 'ultra[-_/]**'
+      - 'ultra[-_/]**'
   pull_request:
     branches:
       - 'ultra[-_/]**'

--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -3,10 +3,10 @@ name: ULTRA CI Base Tests
 on: 
   push:
     branches:
-      - ultra[-_/]**
+     - 'ultra[-_/]**'
   pull_request:
     branches:
-      - ultra[-_/]**
+      - 'ultra[-_/]**'
 
 jobs:
   test-base:


### PR DESCRIPTION
-disabled ultra base tests on smarts branches (branches that don't start with ultra- or ultra_)
-scheduled ultra test to run on develop on every wednesday
-fixed comments in actions since the days in a week is from 0 to 6