### PR TITLE
Fix ignore ULTRA branch pattern in SMARTS CI base tests

### DIFF
--- a/.github/workflows/ci-base-tests.yml
+++ b/.github/workflows/ci-base-tests.yml
@@ -3,10 +3,14 @@ name: SMARTS CI Base Tests
 on:
   push:
     branches-ignore:
-      - ultra[-_/]**
+      - ultra-**
+      - ultra_**
+      - ultra/**
   pull_request:
     branches-ignore:
-      - ultra[-_/]**
+      - ultra-**
+      - ultra_**
+      - ultra/**
 
 jobs:
   test:


### PR DESCRIPTION
The original branch pattern was ignoring SMARTS CI base tests for branches that did not begin with `ultra-`, `ultra_`, or `ultra/`. These changes should make it so that only branches that begin with `ultra-`, `ultra_`, or `ultra/` ignore the SMARTS CI base tests.

https://github.com/huawei-noah/SMARTS/tree/smarts-ultra-test-ignore-ci was used to verify other branches are still running the SMARTS CI base tests.