### PR TITLE
Add social vehicles controlled by custom policy through bubbles

### DIFF
--- a/ultra/tests/scenarios/task00-multiagent/config.yaml
+++ b/ultra/tests/scenarios/task00-multiagent/config.yaml
@@ -14,6 +14,7 @@ levels:
            percent: 1
            specs: [[70kmh,p-test,1]]
            stops: null
+           bubbles: null
     test:
       total: 1
       ego_missions:
@@ -24,6 +25,7 @@ levels:
            percent: 1
            specs: [[70kmh,p-test,1]]
            stops: null
+           bubbles: null
   no-traffic:
     train:
       total: 1
@@ -39,6 +41,7 @@ levels:
            percent: 1
            specs: [[70kmh,no-traffic,1]]
            stops: null
+           bubbles: null
     test:
       total: 1
       ego_missions:
@@ -49,6 +52,7 @@ levels:
            percent: 1
            specs: [[70kmh,no-traffic,1]]
            stops: null
+           bubbles: null
   # Used in evaluation test
   eval_test:
     train:
@@ -68,6 +72,7 @@ levels:
                   [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                   [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
           stops: null
+          bubbles: null
         2lane_curvy_t:
           percent: 0.4
           specs: [[50kmh,low-density,0.21],[70kmh,low-density,0.20],[100kmh,low-density,0.20], #61%
@@ -75,6 +80,7 @@ levels:
                   [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                   [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
           stops: null
+          bubbles: null
         3lane_t:
           percent: 0.4
           specs: [[50kmh,low-density,0.21],[70kmh,low-density,0.20],[100kmh,low-density,0.20], #61%
@@ -82,6 +88,7 @@ levels:
                   [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                   [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
           stops: null
+          bubbles: null
     test:
       total: 2
       ego_missions:
@@ -95,6 +102,7 @@ levels:
                   [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                   [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
           stops: null
+          bubbles: null
         3lane_c:
           percent: 0.5
           specs: [[50kmh,low-density,0.21],[70kmh,low-density,0.20],[100kmh,low-density,0.20], #61%
@@ -102,3 +110,4 @@ levels:
                   [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                   [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
           stops: null
+          bubbles: null

--- a/ultra/tests/scenarios/task00/config.yaml
+++ b/ultra/tests/scenarios/task00/config.yaml
@@ -132,3 +132,26 @@ levels:
            specs: [[70kmh,p-test,1]]
            stops: null
            bubbles: null
+  stops_test:
+    train:
+      total: 10
+      ego_missions:
+      - start: south-SN
+        end:   west-EW
+      intersection_types:
+        4lane_t:
+          percent: 1
+          specs: [[70kmh,p-test,1]]
+          stops: [[south-SN,1,120],[south-SN,0,100],[south-SN,1,80]]
+          bubbles: null
+    test:
+      total: 10
+      ego_missions:
+      - start: south-SN
+        end:   west-EW
+      intersection_types:
+        4lane_t:
+          percent: 1
+          specs: [[70kmh,p-test,1]]
+          stops: [[south-SN,0,120],[south-SN,1,100],[south-SN,0,80]]
+          bubbles: null

--- a/ultra/tests/scenarios/task00/config.yaml
+++ b/ultra/tests/scenarios/task00/config.yaml
@@ -11,6 +11,7 @@ levels:
            percent: 1
            specs: [[70kmh,p-test,1]]
            stops: null
+           bubbles: null
     test:
       total: 1
       ego_missions:
@@ -22,6 +23,7 @@ levels:
            percent: 1
            specs: [[70kmh,p-test,1]]
            stops: null
+           bubbles: null
   no-traffic:
     train:
       total: 1
@@ -34,6 +36,7 @@ levels:
            percent: 1
            specs: [[70kmh,no-traffic,1]]
            stops: null
+           bubbles: null
     test:
       total: 1
       ego_missions:
@@ -45,6 +48,7 @@ levels:
            percent: 1
            specs: [[70kmh,no-traffic,1]]
            stops: null
+           bubbles: null
   # Used in evaluation test
   eval_test:
     train:
@@ -61,6 +65,7 @@ levels:
                   [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                   [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
           stops: null
+          bubbles: null
         2lane_curvy_t:
           percent: 0.4
           specs: [[50kmh,low-density,0.21],[70kmh,low-density,0.20],[100kmh,low-density,0.20], #61%
@@ -68,6 +73,7 @@ levels:
                   [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                   [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
           stops: null
+          bubbles: null
         3lane_t:
           percent: 0.4
           specs: [[50kmh,low-density,0.21],[70kmh,low-density,0.20],[100kmh,low-density,0.20], #61%
@@ -75,6 +81,7 @@ levels:
                   [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                   [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
           stops: null
+          bubbles: null
     test:
       total: 2
       ego_missions:
@@ -89,6 +96,7 @@ levels:
                   [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                   [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
           stops: null
+          bubbles: null
         3lane_c:
           percent: 0.5
           specs: [[50kmh,low-density,0.21],[70kmh,low-density,0.20],[100kmh,low-density,0.20], #61%
@@ -96,6 +104,7 @@ levels:
                   [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                   [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
           stops: null
+          bubbles: null
   offset_test:
     train:
       total: 10
@@ -109,6 +118,7 @@ levels:
            percent: 1
            specs: [[70kmh,p-test,1]]
            stops: null
+           bubbles: null
     test:
       total: 1
       ego_missions:
@@ -121,3 +131,4 @@ levels:
            percent: 1
            specs: [[70kmh,p-test,1]]
            stops: null
+           bubbles: null

--- a/ultra/tests/scenarios/task00/config.yaml
+++ b/ultra/tests/scenarios/task00/config.yaml
@@ -49,7 +49,7 @@ levels:
            specs: [[70kmh,no-traffic,1]]
            stops: null
            bubbles: null
-  # Used in evaluation test
+  # Used in evaluation test.
   eval_test:
     train:
       total: 5
@@ -105,6 +105,7 @@ levels:
                   [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
           stops: null
           bubbles: null
+  # Used in scenarios test.
   offset_test:
     train:
       total: 10
@@ -132,6 +133,7 @@ levels:
            specs: [[70kmh,p-test,1]]
            stops: null
            bubbles: null
+  # Used in scenarios test.
   stops_test:
     train:
       total: 10
@@ -155,3 +157,43 @@ levels:
           specs: [[70kmh,p-test,1]]
           stops: [[south-SN,0,120],[south-SN,1,100],[south-SN,0,80]]
           bubbles: null
+  # Used in scenarios test.
+  bubbles_test:
+    train:
+      total: 10
+      ego_missions:
+      - start: south-SN
+        end:   west-EW
+      intersection_types:
+        4lane_t:
+          percent: 1
+          specs: [[70kmh,p-test,1]]
+          stops: null
+          bubbles:
+          - location: [intersection,40,40]  # [location, length, width]
+            actor_name: "intersection-actor"
+            agent_locator: "intersection_test_agent:test-agent-v0"
+            agent_params: {}
+          - location: [south-SN,0,30,50,2]  # [lane, lane_index, offset, length, num_lanes]
+            actor_name: "lane-actor"
+            agent_locator: "lane_test_agent:test-agent-v0"
+            agent_params: {speed: 30}
+    test:
+      total: 10
+      ego_missions:
+      - start: south-SN
+        end:   west-EW
+      intersection_types:
+        4lane_t:
+          percent: 1
+          specs: [[70kmh,p-test,1]]
+          stops: null
+          bubbles:
+          - location: [intersection,40,40]  # [location, length, width]
+            actor_name: "intersection-actor"
+            agent_locator: "intersection_test_agent:test-agent-v0"
+            agent_params: {}
+          - location: [south-SN,0,30,50,2]  # [lane, lane_index, offset, length, num_lanes]
+            actor_name: "lane-actor"
+            agent_locator: "lane_test_agent:test-agent-v0"
+            agent_params: {speed: 30}

--- a/ultra/ultra/config.yaml
+++ b/ultra/ultra/config.yaml
@@ -17,6 +17,9 @@ tasks:
     road-blocks:
       train: "scenarios/taskX/train_road-blocks*"
       test:  "scenarios/taskX/test_road-blocks*"
+    bubbles:
+      train: "scenarios/taskX/train_bubbles*"
+      test:  "scenarios/taskX/test_bubbles*"
   task0:
     no-traffic:
       train: "scenarios/task1/train_no-traffic*"

--- a/ultra/ultra/scenarios/task1/config.yaml
+++ b/ultra/ultra/scenarios/task1/config.yaml
@@ -11,6 +11,7 @@ levels:
            percent: 1
            specs: [[70kmh,p-test,1]]
            stops: null
+           bubbles: null
     test:
       total: 10
       ego_missions:
@@ -22,6 +23,7 @@ levels:
            percent: 1
            specs: [[70kmh,p-test,1]]
            stops: null
+           bubbles: null
   no-traffic:
     train:
       total: 10000
@@ -34,10 +36,12 @@ levels:
            percent: 0.5
            specs: [[50kmh,no-traffic,0.34],[70kmh,no-traffic,0.33],[100kmh,no-traffic,0.33]]
            stops: null
+           bubbles: null
         3lane_t:
            percent: 0.5
            specs: [[50kmh,no-traffic,0.34],[70kmh,no-traffic,0.33],[100kmh,no-traffic,0.33]]
            stops: null
+           bubbles: null
     test:
       total: 200
       ego_missions:
@@ -49,10 +53,12 @@ levels:
            percent: 0.5
            specs: [[50kmh,no-traffic,0.34],[70kmh,no-traffic,0.33],[100kmh,no-traffic,0.33]]
            stops: null
+           bubbles: null
         3lane_c:
            percent: 0.5
            specs: [[50kmh,no-traffic,0.34],[70kmh,no-traffic,0.33],[100kmh,no-traffic,0.33]]
            stops: null
+           bubbles: null
   easy:
     train:
       total: 10000
@@ -68,6 +74,7 @@ levels:
                    [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                    [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
            stops: null
+           bubbles: null
         2lane_curvy_t:
            percent: 0.4
            specs: [[50kmh,low-density,0.21],[70kmh,low-density,0.20],[100kmh,low-density,0.20], #61%
@@ -75,6 +82,7 @@ levels:
                    [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                    [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
            stops: null
+           bubbles: null
         3lane_t:
            percent: 0.4
            specs: [[50kmh,low-density,0.21],[70kmh,low-density,0.20],[100kmh,low-density,0.20], #61%
@@ -82,6 +90,7 @@ levels:
                    [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                    [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
            stops: null
+           bubbles: null
     test:
       total: 200
       ego_missions:
@@ -96,6 +105,7 @@ levels:
                    [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                    [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
            stops: null
+           bubbles: null
         3lane_c:
            percent: 0.5
            specs: [[50kmh,low-density,0.21],[70kmh,low-density,0.20],[100kmh,low-density,0.20], #61%
@@ -103,6 +113,7 @@ levels:
                    [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01], #3%
                    [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
            stops: null
+           bubbles: null
   hard:
     train:
       total: 10000
@@ -118,7 +129,7 @@ levels:
                    [50kmh,low-density,0.01],[70kmh,low-density,0.01],[100kmh,low-density,0.01], # 3%
                    [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01]] #3%
            stops: null
-
+           bubbles: null
         2lane_curvy_t:
            percent: 0.4
            specs: [[50kmh,high-density,0.21],[70kmh,high-density,0.2],[100kmh,high-density,0.2], #61%
@@ -126,6 +137,7 @@ levels:
                    [50kmh,low-density,0.01],[70kmh,low-density,0.01],[100kmh,low-density,0.01], # 3%
                    [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01]] #3%
            stops: null
+           bubbles: null
         3lane_t:
            percent: 0.4
            specs: [[50kmh,high-density,0.21],[70kmh,high-density,0.2],[100kmh,high-density,0.2], # 61%
@@ -133,6 +145,7 @@ levels:
                   [50kmh,low-density,0.01],[70kmh,low-density,0.01],[100kmh,low-density,0.01], # 3%
                   [50kmh,no-traffic,0.01],[70kmh,no-traffic,0.01],[100kmh,no-traffic,0.01]] #3%
            stops: null
+           bubbles: null
     test:
       total: 200
       ego_missions:
@@ -146,9 +159,11 @@ levels:
                    [50kmh,mid-density,0.12],[70kmh,mid-density,0.12],[100kmh,mid-density,0.12], #36%
                    [50kmh,low-density,0.01],[70kmh,low-density,0.01],[100kmh,low-density,0.01]] # 3%]
            stops: null
+           bubbles: null
         3lane_c:
            percent: 0.5
            specs: [[50kmh,high-density,0.21],[70kmh,high-density,0.2],[100kmh,high-density,0.2], #61%,
                    [50kmh,mid-density,0.12],[70kmh,mid-density,0.12],[100kmh,mid-density,0.12], #36%
                    [50kmh,low-density,0.01],[70kmh,low-density,0.01],[100kmh,low-density,0.01]] # 3%
            stops: null
+           bubbles: null

--- a/ultra/ultra/scenarios/task2/config.yaml
+++ b/ultra/ultra/scenarios/task2/config.yaml
@@ -13,12 +13,14 @@ levels:
                    [50kmh,mid-density,0.12],[70kmh,mid-density,0.12],[100kmh,mid-density,0.12], #36%
                    [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
            stops: null
+           bubbles: null
         3lane_t:
            percent: 0.5
            specs: [[50kmh,low-density,0.21],[70kmh,low-density,0.20],[100kmh,low-density,0.20], #61%
                    [50kmh,mid-density,0.12],[70kmh,mid-density,0.12],[100kmh,mid-density,0.12], #36%
                    [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
            stops: null
+           bubbles: null
     test:
       total: 200
       ego_missions:
@@ -32,12 +34,14 @@ levels:
                    [50kmh,mid-density,0.12],[70kmh,mid-density,0.12],[100kmh,mid-density,0.12], #36%
                    [50kmh,low-density,0.01],[70kmh,low-density,0.01],[100kmh,low-density,0.01]] # 3%
            stops: null
+           bubbles: null
         3lane_t:
            percent: 0.5
            specs: [[50kmh,high-density,0.21],[70kmh,high-density,0.20],[100kmh,high-density,0.20], #61%
                    [50kmh,mid-density,0.12],[70kmh,mid-density,0.12],[100kmh,mid-density,0.12], #36%
                    [50kmh,low-density,0.01],[70kmh,low-density,0.01],[100kmh,low-density,0.01]] # 3%
            stops: null
+           bubbles: null
   hi-low:
     train:
       total: 800
@@ -52,12 +56,14 @@ levels:
                    [50kmh,mid-density,0.12],[70kmh,mid-density,0.12],[100kmh,mid-density,0.12], #36%
                    [50kmh,low-density,0.01],[70kmh,low-density,0.01],[100kmh,low-density,0.01]] # 3%
            stops: null
+           bubbles: null
         3lane_t:
            percent: 0.5
            specs: [[50kmh,high-density,0.21],[70kmh,high-density,0.20],[100kmh,high-density,0.20], #61%
                    [50kmh,mid-density,0.12],[70kmh,mid-density,0.12],[100kmh,mid-density,0.12], #36%
                    [50kmh,low-density,0.01],[70kmh,low-density,0.01],[100kmh,low-density,0.01]] # 3%
            stops: null
+           bubbles: null
     test:
       total: 200
       ego_missions:
@@ -71,9 +77,11 @@ levels:
                    [50kmh,mid-density,0.12],[70kmh,mid-density,0.12],[100kmh,mid-density,0.12], #36%
                    [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
            stops: null
+           bubbles: null
         3lane_t:
            percent: 0.5
            specs: [[50kmh,low-density,0.21],[70kmh,low-density,0.20],[100kmh,low-density,0.20], #61%
                    [50kmh,mid-density,0.12],[70kmh,mid-density,0.12],[100kmh,mid-density,0.12], #36%
                    [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
            stops: null
+           bubbles: null

--- a/ultra/ultra/scenarios/taskX/config.yaml
+++ b/ultra/ultra/scenarios/taskX/config.yaml
@@ -30,3 +30,44 @@ levels:
            percent: 0.5
            specs: [[50kmh,blocks,0.34],[70kmh,blocks,0.33],[100kmh,blocks,0.33]]
            stops: [[south-SN,1,120],[south-SN,0,120]]
+  # Running the 'bubbles' level requries <path-to-SMARTS>/zoo/policies/open-agent/ and
+  # <path-to-SMARTS>/zoo/ in your PYTHONPATH.
+  bubbles:
+    train:
+      total: 1
+      ego_missions:
+      - start: south-SN
+        end:   west-EW
+      intersection_types:
+        4lane_t:
+          percent: 1.0
+          specs: [[50kmh,high-density,1.0]]
+          stops: [[south-SN,1,60]]
+          bubbles:
+          - location: [intersection,40,40]  # [location, length, width]
+            actor_name: "intersection-actor"
+            agent_locator: "open_agent:open_agent-v0"
+            agent_params: {}
+          - location: [south-SN,0,30,50,2]  # [lane, lane_index, offset, length, num_lanes]
+            actor_name: "lane-actor"
+            agent_locator: "policies.non_interactive_agent:non-interactive-agent-v0"
+            agent_params: {speed: 30}
+    test:
+      total: 1
+      ego_missions:
+      - start: south-SN
+        end:   west-EW
+      intersection_types:
+        4lane_t:
+          percent: 1.0
+          specs: [[50kmh,high-density,1.0]]
+          stops: [[south-SN,1,60]]
+          bubbles:
+          - location: [intersection,40,40]  # [location, length, width]
+            actor_name: "intersection-actor"
+            agent_locator: "open_agent:open_agent-v0"
+            agent_params: {}
+          - location: [south-SN,0,30,50,2]  # [lane, lane_index, offset, length, num_lanes]
+            actor_name: "lane-actor"
+            agent_locator: "policies.non_interactive_agent:non-interactive-agent-v0"
+            agent_params: {speed: 30}

--- a/ultra/ultra/scenarios/taskX/config.yaml
+++ b/ultra/ultra/scenarios/taskX/config.yaml
@@ -11,10 +11,12 @@ levels:
            percent: 0.5
            specs: [[50kmh,blocks,0.34],[70kmh,blocks,0.33],[100kmh,blocks,0.33]]
            stops: [[south-SN,0,120]]
+           bubbles: null
         4lane_t:
            percent: 0.5
            specs: [[50kmh,blocks,0.34],[70kmh,blocks,0.33],[100kmh,blocks,0.33]]
            stops: [[south-SN,1,120],[south-SN,0,120]]
+           bubbles: null
     test:
       total: 10
       ego_missions:
@@ -26,10 +28,12 @@ levels:
            percent: 0.5
            specs: [[50kmh,blocks,0.34],[70kmh,blocks,0.33],[100kmh,blocks,0.33]]
            stops: [[south-SN,0,120]]
+           bubbles: null
         4lane_c:
            percent: 0.5
            specs: [[50kmh,blocks,0.34],[70kmh,blocks,0.33],[100kmh,blocks,0.33]]
            stops: [[south-SN,1,120],[south-SN,0,120]]
+           bubbles: null
   # Running the 'bubbles' level requries <path-to-SMARTS>/zoo/policies/open-agent/ and
   # <path-to-SMARTS>/zoo/ in your PYTHONPATH.
   bubbles:


### PR DESCRIPTION
Allows for social vehicles to be controlled in certain locations of an ULTRA map, determined by wherever the bubbles are placed.