### PR TITLE
trigger ego vehicle to be done based on other agent's alive/done situation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ process
 - Added reference to SMARTS paper in front page of docs
 - Only create `Renderer` on demand if vehicles are using camera-based sensors. See issue #725.
 - Added glb models for pedestrians and motorcycles
+<<<<<<< HEAD
 - Added `--allow-offset-map` option for `scl scenario build` to prevent auto-shifting of Sumo road networks
+=======
+- Added options in DoneCreteria to trigger ego agent to be done based on other agent's done situation
+>>>>>>> added done creteria based on number of agents alive
 ### Changed
 - Refactored SMARTS class to not inherit from Panda3D's ShowBase; it's aggregated instead. See issue #597.
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,8 @@ process
 - Added reference to SMARTS paper in front page of docs
 - Only create `Renderer` on demand if vehicles are using camera-based sensors. See issue #725.
 - Added glb models for pedestrians and motorcycles
-<<<<<<< HEAD
 - Added `--allow-offset-map` option for `scl scenario build` to prevent auto-shifting of Sumo road networks
-=======
 - Added options in DoneCreteria to trigger ego agent to be done based on other agent's done situation
->>>>>>> added done creteria based on number of agents alive
 ### Changed
 - Refactored SMARTS class to not inherit from Panda3D's ShowBase; it's aggregated instead. See issue #597.
 ### Fixed

--- a/smarts/core/agent_interface.py
+++ b/smarts/core/agent_interface.py
@@ -19,7 +19,7 @@
 # THE SOFTWARE.
 from dataclasses import dataclass, field, replace
 from enum import IntEnum
-from typing import Optional, Union
+from typing import Optional, Union, List, Tuple
 
 from .controllers import ActionSpaceType
 from .lidar_sensor_params import BasicLidar
@@ -130,6 +130,31 @@ class AgentType(IntEnum):
 
 
 @dataclass(frozen=True)
+class AgentsListAlive:
+    agents_list: List[str]
+    """The list of agents to check whether they are alive"""
+    minimum_agents_alive_in_list: int
+    """Triggers the agent to be done if the number of alive agents in agents_list falls below the given value"""
+
+
+@dataclass(frozen=True)
+class AgentsAliveDoneCriteria:
+    minimum_ego_agents_alive: Optional[int] = None
+    """If set, triggers the agent to be done if the total number of alive ego agents falls below the given value."""
+    minimum_total_agents_alive: Optional[int] = None
+    """If set, triggers the agent to be done if total number of alive agents falls below the given value."""
+    agent_lists_alive: Optional[List[AgentsListAlive]] = None
+    """A termination criteria based on the ids of agents. If set, triggers the agent to be done if any list of agents fails 
+    to meet its specified minimum number of alive agents.
+    Example: [
+        (['agent1', 'agent2'], 1),
+        (['agent3'], 1)
+    ]
+    This agent's done event would be triggered if both 'agent1' and 'agent2' is done *or* 'agent3' is done.
+    """
+
+
+@dataclass(frozen=True)
 class DoneCriteria:
     """Toggleable conditions on which to trigger episode end."""
 
@@ -149,6 +174,8 @@ class DoneCriteria:
     """End the episode when the agent is not moving for 60 seconds or more. To account
     for controller noise not moving means <= 1 meter of displacement within 60 seconds.
     """
+    agents_alive: Optional[AgentsAliveDoneCriteria] = None
+    """If set, triggers the ego agent to be done based on the number of active agents for multi-agent purposes."""
 
 
 @dataclass

--- a/smarts/core/agent_interface.py
+++ b/smarts/core/agent_interface.py
@@ -148,10 +148,10 @@ class AgentsAliveDoneCriteria:
     to meet its specified minimum number of alive agents.
     Example: [
         AgentsListAlive(
-            agents_list=[AGENT1, AGENT2], minimum_agents_alive_in_list=1
+            agents_list=['agent1','agent2'], minimum_agents_alive_in_list=1
         ),
         AgentsListAlive(
-            agents_list=[AGENT3], minimum_agents_alive_in_list=1
+            agents_list=['agent3'], minimum_agents_alive_in_list=1
         ),
     ]
     This agent's done event would be triggered if both 'agent1' and 'agent2' is done *or* 'agent3' is done.

--- a/smarts/core/agent_interface.py
+++ b/smarts/core/agent_interface.py
@@ -147,8 +147,12 @@ class AgentsAliveDoneCriteria:
     """A termination criteria based on the ids of agents. If set, triggers the agent to be done if any list of agents fails 
     to meet its specified minimum number of alive agents.
     Example: [
-        (['agent1', 'agent2'], 1),
-        (['agent3'], 1)
+        AgentsListAlive(
+            agents_list=[AGENT1, AGENT2], minimum_agents_alive_in_list=1
+        ),
+        AgentsListAlive(
+            agents_list=[AGENT3], minimum_agents_alive_in_list=1
+        ),
     ]
     This agent's done event would be triggered if both 'agent1' and 'agent2' is done *or* 'agent3' is done.
     """

--- a/smarts/core/events.py
+++ b/smarts/core/events.py
@@ -29,3 +29,4 @@ class Events(NamedTuple):
     not_moving: bool
     reached_goal: bool
     reached_max_episode_steps: bool
+    agents_alive_done: bool

--- a/smarts/core/sensors.py
+++ b/smarts/core/sensors.py
@@ -26,6 +26,7 @@ from typing import Dict, Iterable, List, NamedTuple, Set, Tuple
 
 import numpy as np
 
+from smarts.core.agent_interface import AgentsAliveDoneCriteria
 from smarts.core.mission_planner import MissionPlanner
 from smarts.core.utils.math import squared_dist, vec_2d
 from smarts.sstudio.types import CutIn, UTurn
@@ -319,6 +320,46 @@ class Sensors:
         return sensor_state.step()
 
     @classmethod
+    def _agents_alive_done_check(
+        cls, agent_manager, agents_alive: AgentsAliveDoneCriteria
+    ):
+        if not agents_alive:
+            return False
+
+        if (
+            agents_alive.minimum_ego_agents_alive
+            and len(agent_manager.ego_agent_ids) < agents_alive.minimum_ego_agents_alive
+        ):
+            return True
+        if (
+            agents_alive.minimum_total_agents_alive
+            and len(agent_manager.agent_ids) < agents_alive.minimum_total_agents_alive
+        ):
+            return True
+        if agents_alive.agent_lists_alive:
+            for agents_list_alive in agents_alive.agent_lists_alive:
+                assert isinstance(
+                    agents_list_alive.agents_list, (List, Set, Tuple)
+                ), "Please specify a list of agent ids to watch"
+                assert isinstance(
+                    agents_list_alive.minimum_agents_alive_in_list, int
+                ), "Please specify an int for minimum number of alive agents in the list"
+                assert (
+                    agents_list_alive.minimum_agents_alive_in_list >= 0
+                ), "minimum_agents_alive_in_list should not be negative"
+                agents_alive_check = [
+                    1 if id in agent_manager.agent_ids else 0
+                    for id in agents_list_alive.agents_list
+                ]
+                if (
+                    agents_alive_check.count(1)
+                    < agents_list_alive.minimum_agents_alive_in_list
+                ):
+                    return True
+
+        return False
+
+    @classmethod
     def _is_done_with_events(cls, sim, agent_id, vehicle, sensor_state):
         interface = sim.agent_manager.agent_interface_for_agent_id(agent_id)
         done_criteria = interface.done_criteria
@@ -332,6 +373,9 @@ class Sensors:
         is_off_route, is_wrong_way = cls._vehicle_is_off_route_and_wrong_way(
             sim, vehicle
         )
+        agents_alive_done = cls._agents_alive_done_check(
+            sim.agent_manager, done_criteria.agents_alive
+        )
 
         done = (
             (is_off_road and done_criteria.off_road)
@@ -342,6 +386,7 @@ class Sensors:
             or (is_not_moving and done_criteria.not_moving)
             or (is_off_route and done_criteria.off_route)
             or (is_wrong_way and done_criteria.wrong_way)
+            or agents_alive_done
         )
 
         events = Events(
@@ -353,6 +398,7 @@ class Sensors:
             on_shoulder=is_on_shoulder,
             wrong_way=is_wrong_way,
             not_moving=is_not_moving,
+            agents_alive_done=agents_alive_done,
         )
 
         return done, events

--- a/smarts/core/tests/test_done_creteria.py
+++ b/smarts/core/tests/test_done_creteria.py
@@ -1,0 +1,116 @@
+# MIT License
+#
+# Copyright (C) 2021. Huawei Technologies Co., Ltd. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+import pytest
+
+from smarts.core.agent_interface import (
+    AgentInterface,
+    DoneCriteria,
+    AgentsAliveDoneCriteria,
+    AgentsListAlive,
+)
+from smarts.core.smarts import SMARTS
+from smarts.core.sumo_traffic_simulation import SumoTrafficSimulation
+from smarts.core.scenario import Scenario
+from smarts.core.sensors import Sensors
+
+AGENT1 = "agent1"
+AGENT2 = "agent2"
+AGENT3 = "agent3"
+
+
+@pytest.fixture
+def scenario():
+    scenario = Scenario(
+        scenario_root="scenarios/loop",
+        route="basic.rou.xml",
+    )
+    return scenario
+
+
+ego_alive_test = AgentsAliveDoneCriteria(
+    minimum_ego_agents_alive=2,
+)
+
+custom_agent_list_test = AgentsAliveDoneCriteria(
+    agent_lists_alive=[
+        AgentsListAlive(
+            agents_list=[AGENT1, AGENT2], minimum_agents_alive_in_list=1
+        ),  # requires 1 of AGENT1 and AGENT2 to be alive
+        AgentsListAlive(
+            agents_list=[AGENT3], minimum_agents_alive_in_list=1
+        ),  # requires AGENT3 to be alive
+    ]
+)
+
+total_alive_test = AgentsAliveDoneCriteria(
+    minimum_total_agents_alive=2,
+)
+
+
+@pytest.fixture(
+    scope="module", params=[ego_alive_test, custom_agent_list_test, total_alive_test]
+)
+def sim(request):
+    shared_interface = AgentInterface(
+        done_criteria=DoneCriteria(agents_alive=request.param)
+    )
+    agents = {
+        AGENT1: shared_interface,
+        AGENT2: shared_interface,
+        AGENT3: shared_interface,
+    }
+    smarts = SMARTS(
+        agents,
+        traffic_sim=SumoTrafficSimulation(headless=True),
+        envision=None,
+    )
+
+    yield smarts
+    smarts.destroy()
+
+
+def test_agents_alive_done_check(sim, scenario):
+    sim.setup(scenario)
+    interface = sim.agent_manager.agent_interface_for_agent_id(AGENT1)
+    done_criteria = interface.done_criteria
+    # 3 agents available, done requires 2 to be alive
+    assert not Sensors._agents_alive_done_check(
+        sim.agent_manager, done_criteria.agents_alive
+    )
+
+    sim.agent_manager.teardown_ego_agents({AGENT2})
+    # 2 agents available, done requires 2 to be alive
+    assert not Sensors._agents_alive_done_check(
+        sim.agent_manager, done_criteria.agents_alive
+    )
+
+    sim.agent_manager.teardown_ego_agents({AGENT3})
+    # 1 agents available, done requires 2 to be alive
+    assert Sensors._agents_alive_done_check(
+        sim.agent_manager, done_criteria.agents_alive
+    )
+
+    sim.agent_manager.teardown_ego_agents({AGENT1})
+    # 1 agents available, done requires 2 to be alive
+    assert Sensors._agents_alive_done_check(
+        sim.agent_manager, done_criteria.agents_alive
+    )


### PR DESCRIPTION
resolves #715 

This change is needed in situation of multi-agent training. For example, to make prey vehicles done when there are no more predator vehicles so that prey vehicles don't run alone in the simulation, which creates noise in the training. 

will add unit tests if this change in DoneCreteria makes sense