### PR TITLE
Allow sumo traffic_sim to be None if not needed.

### DIFF
--- a/examples/history_vehicles_replacement_for_imitation_learning.py
+++ b/examples/history_vehicles_replacement_for_imitation_learning.py
@@ -25,8 +25,8 @@ def main(scenarios, headless, seed):
     scenarios_iterator = Scenario.scenario_variations(scenarios, [])
     smarts = SMARTS(
         agent_interfaces={},
-        traffic_sim=SumoTrafficSimulation(headless=headless, auto_start=True),
-        envision=Envision(),
+        traffic_sim=None,
+        envision=None if headless else Envision(),
     )
     for _ in scenarios:
         scenario = next(scenarios_iterator)

--- a/smarts/core/smarts.py
+++ b/smarts/core/smarts.py
@@ -87,10 +87,11 @@ class SMARTS:
         self._motion_planner_provider = MotionPlannerProvider()
         self._traffic_history_provider = TrafficHistoryProvider()
         self._providers = [
-            self._traffic_sim,
             self._motion_planner_provider,
             self._traffic_history_provider,
         ]
+        if self._traffic_sim:
+            self._providers.insert(0, self._traffic_sim)
 
         # We buffer provider state between steps to compensate for TRACI's timestep delay
         self._last_provider_state = None


### PR DESCRIPTION
When using traffic history, we don't really need to generate nor track traffic with Sumo.  Since Sumo is sometimes crashing (Issue #803), allow this to be bypassed if desired.