### PR TITLE
Consistent level names for Task 2 in ULTRA

### DIFF
--- a/ultra/ultra/config.yaml
+++ b/ultra/ultra/config.yaml
@@ -44,9 +44,9 @@ tasks:
       train: "scenarios/task1/train_hard*"
       test:  "scenarios/task1/test_hard*"
   task2:
-    lo-hi:
-      train: "scenarios/task2/train_lo-hi*"
-      test:  "scenarios/task2/test_lo-hi*"
-    hi-lo:
-      train: "scenarios/task2/train_hi-lo*"
-      test:  "scenarios/task2/test_hi-lo*"
+    low-high:
+      train: "scenarios/task2/train_low-high*"
+      test:  "scenarios/task2/test_low-high*"
+    high-low:
+      train: "scenarios/task2/train_high-low*"
+      test:  "scenarios/task2/test_high-low*"

--- a/ultra/ultra/scenarios/generate_scenarios.py
+++ b/ultra/ultra/scenarios/generate_scenarios.py
@@ -667,7 +667,7 @@ def build_scenarios(
 if __name__ == "__main__":
     parser = argparse.ArgumentParser("generate scenarios")
     parser.add_argument("--task", help="type a task id [0, 1, 2, 3, X]", type=str)
-    parser.add_argument("--level", help="easy/medium/hard, lo-hi/hi-lo", type=str)
+    parser.add_argument("--level", help="easy/medium/hard, low-high/high-low", type=str)
     parser.add_argument(
         "--stopwatcher",
         help="all/aggressive/default/slow/blocker/crusher south-west",

--- a/ultra/ultra/scenarios/task2/config.yaml
+++ b/ultra/ultra/scenarios/task2/config.yaml
@@ -1,5 +1,5 @@
 levels:
-  lo-hi:
+  low-high:
     train:
       total: 800
       ego_missions:
@@ -38,7 +38,7 @@ levels:
                    [50kmh,mid-density,0.12],[70kmh,mid-density,0.12],[100kmh,mid-density,0.12], #36%
                    [50kmh,low-density,0.01],[70kmh,low-density,0.01],[100kmh,low-density,0.01]] # 3%
            stops: null
-  hi-low:
+  high-low:
     train:
       total: 800
       ego_missions:


### PR DESCRIPTION
Previously, Task 2 had inconsistent level naming, particularly in the "high-low" level. For example, one could generate the "high-low" level by setting **hi-low** as the level argument:
```sh
(.venv) $ python ultra/scenarios/interface generate --task 2 --level hi-low
```
But, to then train an agent on the "high-low" level of Task 2, one would need to pass **hi-lo** as the level argument:
```sh
(.venv) $ python ultra/train.py --task 2 --level hi-lo --policy bdqn
```
Fix this inconsistency by using the full words: "high" and "low", when naming Task 2 levels.