### PR TITLE
Run ULTRA Tune CI tests only once

### DIFF
--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -42,6 +42,7 @@ jobs:
           --ignore=./tests/test_scenarios.py \
           --ignore=./tests/test_social_vehicles.py \
           --ignore=./tests/test_rllib_train.py \
+          --ignore=./tests/test_tune.py \
 
   test-light-base-tests:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
ULTRA's Tune CI test was being run twice (in both the heavy and light CI tests). Thoughts on if it should be run as a heavy test vs. a light test? Currently, it is ignored in the heavy tests, so it runs as a light CI test.