### PR TITLE
Zoo manager spawned as a subprocess

### DIFF
--- a/smarts/core/remote_agent_buffer.py
+++ b/smarts/core/remote_agent_buffer.py
@@ -26,7 +26,6 @@ import subprocess
 import sys
 import time
 from concurrent import futures
-from multiprocessing import Process
 from typing import List, Tuple
 
 import grpc

--- a/smarts/core/remote_agent_buffer.py
+++ b/smarts/core/remote_agent_buffer.py
@@ -20,7 +20,10 @@
 
 import atexit
 import logging
+import pathlib
 import random
+import subprocess
+import sys
 import time
 from concurrent import futures
 from multiprocessing import Process
@@ -111,7 +114,7 @@ class RemoteAgentBuffer:
         if self._local_zoo_manager:
             self._zoo_manager_conns[0]["channel"].close()
             self._zoo_manager_conns[0]["process"].terminate()
-            self._zoo_manager_conns[0]["process"].join()
+            self._zoo_manager_conns[0]["process"].wait()
 
     def _build_remote_agent(self, zoo_manager_conns):
         # Get a random zoo manager connection.
@@ -185,9 +188,22 @@ class RemoteAgentBuffer:
 
 
 def spawn_local_zoo_manager(port):
-    manager = Process(target=zoo_manager.serve, args=(port,))
-    manager.start()
-    return manager
+    cmd = [
+        sys.executable,  # Path to the current Python binary.
+        str(
+            (pathlib.Path(__file__).parent.parent / "zoo" / "manager.py")
+            .absolute()
+            .resolve()
+        ),
+        "--port",
+        str(port),
+    ]
+
+    manager = subprocess.Popen(cmd)
+    if manager.poll() == None:
+        return manager
+
+    raise RuntimeError("Zoo manager subprocess is not running.")
 
 
 def get_manager_channel_stub(addr):


### PR DESCRIPTION
Changed `multiprocess` to `subprocess` in spawning zoo manager to avoid `daemonic processes are not allowed to have children` error while running SMARTS with XingTian.