### PR TITLE
Proper shutdown of RemoteAgentBuffer after code crash

### DIFF
--- a/examples/single_agent.py
+++ b/examples/single_agent.py
@@ -59,11 +59,17 @@ def main(scenarios, sim_name, headless, num_episodes, seed, max_episode_steps=No
         episode.record_scenario(env.scenario_log)
 
         dones = {"__all__": False}
+        counter = 0
         while not dones["__all__"]:
+            counter += 1
             agent_obs = observations[AGENT_ID]
             agent_action = agent.act(agent_obs)
             observations, rewards, dones, infos = env.step({AGENT_ID: agent_action})
             episode.record_step(observations, rewards, dones, infos)
+
+            if counter > 10:
+                f = 0 / 0
+                g = f * 2
 
     env.close()
 

--- a/examples/single_agent.py
+++ b/examples/single_agent.py
@@ -59,17 +59,11 @@ def main(scenarios, sim_name, headless, num_episodes, seed, max_episode_steps=No
         episode.record_scenario(env.scenario_log)
 
         dones = {"__all__": False}
-        counter = 0
         while not dones["__all__"]:
-            counter += 1
             agent_obs = observations[AGENT_ID]
             agent_action = agent.act(agent_obs)
             observations, rewards, dones, infos = env.step({AGENT_ID: agent_action})
             episode.record_step(observations, rewards, dones, infos)
-
-            if counter > 10:
-                f = 0 / 0
-                g = f * 2
 
     env.close()
 

--- a/smarts/core/remote_agent.py
+++ b/smarts/core/remote_agent.py
@@ -77,9 +77,6 @@ class RemoteAgent:
         if (self._act_future is not None) and (not self._act_future.done()):
             self._act_future.cancel()
 
-        # Close worker channel
-        self._worker_channel.close()
-
         # Stop the remote worker process
         response = self._manager_stub.stop_worker(
             manager_pb2.Port(num=self._worker_address[1])

--- a/smarts/core/remote_agent_buffer.py
+++ b/smarts/core/remote_agent_buffer.py
@@ -92,12 +92,7 @@ class RemoteAgentBuffer:
             self._remote_agent_future() for _ in range(self._buffer_size)
         ]
 
-        atexit.register(self.destroy)
-
     def destroy(self):
-        if atexit:
-            atexit.unregister(self.destroy)
-
         # Teardown any remaining remote agents.
         for remote_agent_future in self._agent_buffer:
             try:


### PR DESCRIPTION
When SMARTS crashes due to non-grpc related errors, incorrect attempts to close processes which are already closed throws unwanted grpc error messages. This is now rectified.

To verify try:
```
$ git checkout 2d6caf6f
$ python3.7 ./examples/single_agent.py ./scenarios/intersections/6lane --headless
``` 
The above test commit should crash without producing unwanted grpc error messages.