### PR TITLE
fixed backwards polarity on dones check

### DIFF
--- a/examples/history_vehicles_replacement_for_imitation_learning.py
+++ b/examples/history_vehicles_replacement_for_imitation_learning.py
@@ -60,7 +60,7 @@ def main(scenarios, headless, seed):
             observations = smarts.reset(scenario)
 
             dones = {agent_id: False}
-            while not dones.get(agent_id, False):
+            while not dones.get(agent_id, True):
                 agent_obs = observations[agent_id]
                 agent_action = agent.act(agent_obs)
 


### PR DESCRIPTION
I recently changed the `dones` check in this script to not crash when the `agent_id` is not found, but I got the default value backwards.  If the `agent_id` isn't found, it's not still running, and hence it's "done".
(pointed out by @zbzhu99)
