### PR TITLE
simulation clock rounding fix

### DIFF
--- a/smarts/core/smarts.py
+++ b/smarts/core/smarts.py
@@ -230,7 +230,7 @@ class SMARTS:
 
         # 8. Advance the simulation clock.
         # round due to FP precision issues, but need to allow arbitrarily-small dt's
-        dec_digits = int(1 - math.log10(dt % 1))
+        dec_digits = len("{}".format(self._timestep_sec)) - 2
         self._elapsed_sim_time = round(self._elapsed_sim_time + dt, dec_digits)
 
         return observations, rewards, dones, extras


### PR DESCRIPTION
Minor change to the rounding of the simulation clock to ensure we always keep enough digits, no matter what `timestep_sec` is set to.  For example, this will work correctly with `timestep_sec = 0.00123` whereas the previous line would not.  (Rounding is necessary here due to FP precision errors that affect the use of the timestamp in SQL queries in the traffic history provider, among other places.)