### PR TITLE
Bugfix remove unused `make` pview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Copy and pasting the git commit messages is __NOT__ enough.
 
 ## [Unreleased]
 
+## Removed
+- Removed `pview` from `make` as it refers to `.egg` file artifacts that we no longer keep around.
+
 ## [0.4.16] - 2021-05-11
 ### Added 
 - Added `sanity-test` script and asked new users to run `sanity-test` instead of `make test` to ease the setup

--- a/Makefile
+++ b/Makefile
@@ -92,12 +92,6 @@ $(scenario)/flamegraph-perf.log: build-scenario $(script) smarts/core/* smarts/e
 	# pip install git+https://github.com/asokoloski/python-flamegraph.git
 	python -m flamegraph -i 0.001 -o $(scenario)/flamegraph-perf.log $(script) $(scenario)
 
-.PHONY: pview
-pview: $(scenario)/map.egg
-	# !!! READ THE pview MANUAL !!!
-	# https://www.panda3d.org/manual/?title=Previewing_3D_Models_in_Pview
-	pview -c -l $(scenario)/map.egg
-
 .PHONY: sumo-gui
 sumo-gui: $(scenario)/map.net.xml
 	sumo-gui \


### PR DESCRIPTION
`pview` is no longer usable since we do not keep around `.egg` files (nor would we add them back.) This is just a small clean-up removing the `pview` option from `make`.