### PR TITLE
ULTRA Make max total steps an argument

### DIFF
--- a/ultra/tests/test_train.py
+++ b/ultra/tests/test_train.py
@@ -83,6 +83,7 @@ class TrainTest(unittest.TestCase):
                 policy_classes=policy_classes,
                 num_episodes=1,
                 max_episode_steps=2,
+                max_steps=5,
                 eval_info={
                     "eval_rate": 1000,
                     "eval_episodes": 2,
@@ -119,6 +120,7 @@ class TrainTest(unittest.TestCase):
                 policy_classes=policy_classes,
                 num_episodes=1,
                 max_episode_steps=2,
+                max_steps=5,
                 eval_info={
                     "eval_rate": 1000,
                     "eval_episodes": 2,

--- a/ultra/tests/test_ultra_package.py
+++ b/ultra/tests/test_ultra_package.py
@@ -62,6 +62,7 @@ class UltraPackageTest(unittest.TestCase):
                 policy_classes=[policy_class],
                 num_episodes=1,
                 max_episode_steps=2,
+                max_steps=5,
                 eval_info={
                     "eval_rate": 1000,
                     "eval_episodes": 2,

--- a/ultra/ultra/train.py
+++ b/ultra/ultra/train.py
@@ -50,6 +50,7 @@ def train(
     num_episodes,
     policy_classes,
     max_episode_steps,
+    max_steps,
     eval_info,
     timestep_sec,
     headless,
@@ -148,8 +149,8 @@ def train(
         collect_evaluations(evaluation_task_ids=evaluation_task_ids)
 
         while not dones["__all__"]:
-            # Break if any of the agent's step counts is 1000000 or greater.
-            if any([episode.get_itr(agent_id) >= 1000000 for agent_id in agents]):
+            # Break if any of the agent's step counts is max_steps (default is 1000000) or greater.
+            if any([episode.get_itr(agent_id) >= max_steps for agent_id in agents]):
                 finished = True
                 break
             # Request and perform actions on each agent that received an observation.
@@ -227,6 +228,12 @@ if __name__ == "__main__":
         default=200,
     )
     parser.add_argument(
+        "--max-steps",
+        help="Maximum total number of training steps",
+        type=int,
+        default=1000000,
+    )
+    parser.add_argument(
         "--timestep", help="Environment timestep (sec)", type=float, default=0.1
     )
     parser.add_argument(
@@ -277,6 +284,7 @@ if __name__ == "__main__":
         scenario_info=(args.task, args.level),
         num_episodes=int(args.episodes),
         max_episode_steps=int(args.max_episode_steps),
+        max_steps=int(args.max_steps),
         eval_info={
             "eval_rate": float(args.eval_rate),
             "eval_episodes": int(args.eval_episodes),


### PR DESCRIPTION
We used 1 Million steps as a termination condition during training. However, that value was hardcoded into the train script. We have encountered training performance changing after 1M steps, thus we need to extend the limit