### PR TITLE
ULTRA Save scenarios to respective task dirs

### DIFF
--- a/ultra/ultra/config.yaml
+++ b/ultra/ultra/config.yaml
@@ -56,6 +56,9 @@ tasks:
     no-traffic:
       train: "scenarios/task1/train_no-traffic*"
       test:  "scenarios/task1/test_no-traffic*"
+    simple:
+      train: "scenarios/task1/train_simple*"
+      test:  "scenarios/task1/test_simple*"
     easy:
       train: "scenarios/task1/train_easy*"
       test:  "scenarios/task1/test_easy*"
@@ -65,6 +68,15 @@ tasks:
     hard:
       train: "scenarios/task1/train_hard*"
       test:  "scenarios/task1/test_hard*"
+    low-interaction:
+      train: "scenarios/task1/train_low-interaction*"
+      test:  "scenarios/task1/test_low-interaction*"
+    mid-interaction:
+      train: "scenarios/task1/train_mid-interaction*"
+      test:  "scenarios/task1/test_mid-interaction*"
+    high-interaction:
+      train: "scenarios/task1/train_high-interaction*"
+      test:  "scenarios/task1/test_high-interaction*"
   task2:
     lo-hi:
       train: "scenarios/task2/train_lo-hi*"

--- a/ultra/ultra/config.yaml
+++ b/ultra/ultra/config.yaml
@@ -56,9 +56,6 @@ tasks:
     no-traffic:
       train: "scenarios/task1/train_no-traffic*"
       test:  "scenarios/task1/test_no-traffic*"
-    simple:
-      train: "scenarios/task1/train_simple*"
-      test:  "scenarios/task1/test_simple*"
     easy:
       train: "scenarios/task1/train_easy*"
       test:  "scenarios/task1/test_easy*"
@@ -68,15 +65,6 @@ tasks:
     hard:
       train: "scenarios/task1/train_hard*"
       test:  "scenarios/task1/test_hard*"
-    low-interaction:
-      train: "scenarios/task1/train_low-interaction*"
-      test:  "scenarios/task1/test_low-interaction*"
-    mid-interaction:
-      train: "scenarios/task1/train_mid-interaction*"
-      test:  "scenarios/task1/test_mid-interaction*"
-    high-interaction:
-      train: "scenarios/task1/train_high-interaction*"
-      test:  "scenarios/task1/test_high-interaction*"
   task2:
     lo-hi:
       train: "scenarios/task2/train_lo-hi*"

--- a/ultra/ultra/train.py
+++ b/ultra/ultra/train.py
@@ -538,7 +538,7 @@ if __name__ == "__main__":
         "--curriculum-scenarios-save-dir",
         help="Save the scenarios in specified directory",
         type=str,
-        default="ultra/scenarios/taskgb/",
+        default=None,
     )
 
     base_dir = os.path.dirname(__file__)


### PR DESCRIPTION
When creating a static curriculum, users have the options to build all scenarios that will be needed for the grades. Ideally, we want the scenarios to be in their respective task directories. A small fix: To default the save directory flag (`--curriculum-save-dir`) to `None`, which will cause the `generate_scenarios.py` to automatically save them in their task dirs. If someone wants to explicitly save their scenarios in a specific folder then they can use the flag.

Note: For some unit tests, we would need to initialize the save directory because the environment is programmed to scan for scenarios under `ultra/scenarios` and not `tests/scenarios`