### PR TITLE
only observe cars for imitation learning

### DIFF
--- a/examples/observation_collection_for_imitation_learning.py
+++ b/examples/observation_collection_for_imitation_learning.py
@@ -31,9 +31,14 @@ def main(scenarios: Sequence[str], headless: bool, seed: int):
 
     smarts.reset(next(scenarios_iterator))
 
+    # could also include "motorcycle" or "truck" in this set if desired
+    vehicle_types = frozenset({"car"})
+
     for _ in range(5000):
         smarts.step({})
-        current_vehicles = smarts.vehicle_index.social_vehicle_ids()
+        current_vehicles = smarts.vehicle_index.social_vehicle_ids(
+            vehicle_types=vehicle_types
+        )
         smarts.attach_sensors_to_vehicles(agent_spec, current_vehicles)
         obs, _, _, dones = smarts.observe_from(current_vehicles)
         # TODO: save observations for imitation learning

--- a/smarts/core/vehicle_index.py
+++ b/smarts/core/vehicle_index.py
@@ -164,11 +164,15 @@ class VehicleIndex:
         return set(vehicle_ids)
 
     @cache
-    def social_vehicle_ids(self):
+    def social_vehicle_ids(self, vehicle_types=None):
         vehicle_ids = self._controlled_by[
             self._controlled_by["actor_type"] == _ActorType.Social
         ]["vehicle_id"]
-        vehicle_ids = [self._2id_to_id[id_] for id_ in vehicle_ids]
+        vehicle_ids = [
+            self._2id_to_id[id_]
+            for id_ in vehicle_ids
+            if not vehicle_types or self._vehicles[id_].vehicle_type in vehicle_types
+        ]
         return set(vehicle_ids)
 
     @cache

--- a/smarts/core/vehicle_index.py
+++ b/smarts/core/vehicle_index.py
@@ -21,7 +21,7 @@ import logging
 from copy import copy, deepcopy
 from enum import IntEnum
 from io import StringIO
-from typing import NamedTuple
+from typing import FrozenSet, NamedTuple
 
 import numpy as np
 import tableprint as tp
@@ -164,7 +164,7 @@ class VehicleIndex:
         return set(vehicle_ids)
 
     @cache
-    def social_vehicle_ids(self, vehicle_types=None):
+    def social_vehicle_ids(self, vehicle_types: FrozenSet[str] = None):
         vehicle_ids = self._controlled_by[
             self._controlled_by["actor_type"] == _ActorType.Social
         ]["vehicle_id"]


### PR DESCRIPTION
As requested by @zbzhu99, this updates our data collection script for imitation learning to only attach sensors to cars (not motorcycles or trucks).  