### PR TITLE
ULTRA add `--durations` flag to ULTRA CI tests

### DIFF
--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -154,31 +154,31 @@ jobs:
           --durations=0 \
           ./tests/test_ultra_package.py \
 
-  # test-package-via-pypi:
-  #   runs-on: ubuntu-18.04
-  #   if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-  #   container: huaweinoah/smarts:v0.4.13-minimal
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
-  #     - name: Setup X11
-  #       run: |
-  #         /usr/bin/Xorg \
-  #           -noreset \
-  #           +extension GLX \
-  #           +extension RANDR \
-  #           +extension RENDER \
-  #           -logfile ./xdummy.log \
-  #           -config /etc/X11/xorg.conf :1 &
-  #     - name: Install ultra-rl via setup.py
-  #       run: |
-  #         cd ultra
-  #         python3.7 -m venv .venv
-  #         . .venv/bin/activate
-  #         pip install ultra-rl
-  #     - name: Run test
-  #       run: |
-  #         cd ultra
-  #         . .venv/bin/activate
-  #         scl scenario build-all ultra/scenarios/pool
-  #         pytest -v ./tests/test_ultra_package.py
+  test-package-via-pypi:
+    runs-on: ubuntu-18.04
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    container: huaweinoah/smarts:v0.4.13-minimal
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup X11
+        run: |
+          /usr/bin/Xorg \
+            -noreset \
+            +extension GLX \
+            +extension RANDR \
+            +extension RENDER \
+            -logfile ./xdummy.log \
+            -config /etc/X11/xorg.conf :1 &
+      - name: Install ultra-rl via setup.py
+        run: |
+          cd ultra
+          python3.7 -m venv .venv
+          . .venv/bin/activate
+          pip install ultra-rl
+      - name: Run test
+        run: |
+          cd ultra
+          . .venv/bin/activate
+          scl scenario build-all ultra/scenarios/pool
+          pytest -v ./tests/test_ultra_package.py

--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -170,7 +170,7 @@ jobs:
             +extension RENDER \
             -logfile ./xdummy.log \
             -config /etc/X11/xorg.conf :1 &
-      - name: Install ultra-rl via setup.py
+      - name: Install ultra-rl via pypi
         run: |
           cd ultra
           python3.7 -m venv .venv

--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -35,6 +35,7 @@ jobs:
           scl scenario build-all ultra/scenarios/pool
           pytest -v \
           ./tests/ \
+          --durations=0 \
           --ignore=./tests/test_ultra_package.py \
           --ignore=./tests/test_adapter.py \
           --ignore=./tests/test_env.py \
@@ -76,6 +77,7 @@ jobs:
           scl scenario build-all ultra/scenarios/pool
           pytest -v \
           ./tests/ \
+          --durations=0 \
           --ignore=./tests/test_ultra_package.py \
           --ignore=./tests/test_train.py \
           --ignore=./tests/test_evaluate.py \
@@ -110,7 +112,9 @@ jobs:
           cd ultra
           . .venv/bin/activate
           scl scenario build-all ultra/scenarios/pool
-          pytest -v ./tests/test_ultra_package.py
+          pytest -v \
+          --durations=0 \
+          ./tests/test_ultra_package.py \
 
   test-package-via-wheel:
     runs-on: ubuntu-18.04
@@ -146,7 +150,9 @@ jobs:
           cd ultra
           . .venv/bin/activate
           scl scenario build-all ultra/scenarios/pool
-          pytest -v ./tests/test_ultra_package.py
+          pytest -v \
+          --durations=0 \
+          ./tests/test_ultra_package.py \
 
   # test-package-via-pypi:
   #   runs-on: ubuntu-18.04


### PR DESCRIPTION
Motive: To analyze the duration of ULTRA tests

Side task:
- [x] Activate PyPI ULTRA CI test