### PR TITLE
history agent vehicle sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - `history_vehicles_replacement_for_imitation_learning.py` now uses new Imitation action space.  See Issue #844.
 - Vehicles with a `BoxChassis` can now use an `AccelerometerSensor` too.
 - When importing NGSIM history data, vehicle speeds are recomputed.
+- Allow custom sizes for agent vehicles in history traffic missions.
 ### Fixed
 - Allow for non-dynamic action spaces to have action controllers.  See PR #854.
 - Fixed a minor bug in `sensors.py` which triggered `wrong_way` event when the vehicle goes into an intersection. See Issue #846.

--- a/examples/history_vehicles_replacement_for_imitation_learning.py
+++ b/examples/history_vehicles_replacement_for_imitation_learning.py
@@ -52,17 +52,17 @@ class ReplayCheckerAgent(Agent):
         assert math.isclose(
             cur_state.heading, exp["heading"], abs_tol=1e-09
         ), f'vid={self._vehicle_id}: {cur_state.heading} != {exp["heading"]} @ {obs_time}'
-        # Note: the speed check can't be as tight b/c we lose some accuracy (due to angular acceleration)
+        # Note: the other checks can't be as tight b/c we lose some accuracy (due to angular acceleration)
         # by converting the acceleration vector to a scalar in the observation script,
         # which compounds over time throughout the simulation.
         assert math.isclose(
             cur_state.speed, exp["speed"], abs_tol=0.1
         ), f'vid={self._vehicle_id}: {cur_state.speed} != {exp["speed"]} @ {obs_time}'
         assert math.isclose(
-            cur_state.position[0], exp["ego_pos"][0], rel_tol=0.01
+            cur_state.position[0], exp["ego_pos"][0], abs_tol=2
         ), f'vid={self._vehicle_id}: {cur_state.position[0]} != {exp["ego_pos"][0]} @ {obs_time}'
         assert math.isclose(
-            cur_state.position[1], exp["ego_pos"][1], rel_tol=0.01
+            cur_state.position[1], exp["ego_pos"][1], abs_tol=2
         ), f'vid={self._vehicle_id}: {cur_state.position[1]} != {exp["ego_pos"][1]} @ {obs_time}'
 
         # Then get and return the next set of control inputs

--- a/smarts/core/controllers/__init__.py
+++ b/smarts/core/controllers/__init__.py
@@ -26,7 +26,10 @@ from smarts.core.controllers.actuator_dynamic_controller import (
     ActuatorDynamicController,
     ActuatorDynamicControllerState,
 )
-from smarts.core.controllers.imitation_controller import ImitationController
+from smarts.core.controllers.imitation_controller import (
+    ImitationController,
+    ImitationControllerState,
+)
 from smarts.core.controllers.lane_following_controller import (
     LaneFollowingController,
     LaneFollowingControllerState,
@@ -119,7 +122,9 @@ class Controllers:
             elif action == "change_lane_right":
                 perform_lane_following(target_speed=12.5, lane_change=-1)
         elif action_space == ActionSpaceType.Imitation:
-            ImitationController.perform_action(sim.timestep_sec, vehicle, action)
+            ImitationController.perform_action(
+                sim.timestep_sec, vehicle, action, controller_state
+            )
         else:
             # Note: TargetPose and MultiTargetPose use a MotionPlannerProvider directly
             raise ValueError(
@@ -153,6 +158,9 @@ class ControllerState:
 
         if action_space == ActionSpaceType.MPC:
             return TrajectoryTrackingControllerState()
+
+        if action_space == ActionSpaceType.Imitation:
+            return ImitationControllerState(0.0)
 
         # Other action spaces do not need a controller state object
         return None

--- a/smarts/core/controllers/__init__.py
+++ b/smarts/core/controllers/__init__.py
@@ -26,10 +26,7 @@ from smarts.core.controllers.actuator_dynamic_controller import (
     ActuatorDynamicController,
     ActuatorDynamicControllerState,
 )
-from smarts.core.controllers.imitation_controller import (
-    ImitationController,
-    ImitationControllerState,
-)
+from smarts.core.controllers.imitation_controller import ImitationController
 from smarts.core.controllers.lane_following_controller import (
     LaneFollowingController,
     LaneFollowingControllerState,
@@ -122,9 +119,7 @@ class Controllers:
             elif action == "change_lane_right":
                 perform_lane_following(target_speed=12.5, lane_change=-1)
         elif action_space == ActionSpaceType.Imitation:
-            ImitationController.perform_action(
-                sim.timestep_sec, vehicle, action, controller_state
-            )
+            ImitationController.perform_action(sim.timestep_sec, vehicle, action)
         else:
             # Note: TargetPose and MultiTargetPose use a MotionPlannerProvider directly
             raise ValueError(
@@ -158,9 +153,6 @@ class ControllerState:
 
         if action_space == ActionSpaceType.MPC:
             return TrajectoryTrackingControllerState()
-
-        if action_space == ActionSpaceType.Imitation:
-            return ImitationControllerState(0.0)
 
         # Other action spaces do not need a controller state object
         return None

--- a/smarts/core/controllers/imitation_controller.py
+++ b/smarts/core/controllers/imitation_controller.py
@@ -53,7 +53,9 @@ class ImitationController:
         target_heading = (vehicle.heading + angular_velocity * dt) % (2 * math.pi)
 
         if isinstance(chassis, BoxChassis):
-            dpos = radians_to_vec(vehicle.heading) * vehicle.speed * dt
+            heading_vec = radians_to_vec(vehicle.heading)
+            ortho_vec = radians_to_vec(vehicle.heading + math.pi / 2)
+            dpos = (heading_vec * vehicle.speed + ortho_vec * angular_velocity) * dt
             new_pose = Pose(
                 position=vehicle.position + np.append(dpos, 0.0),
                 orientation=fast_quaternion_from_angle(target_heading),

--- a/smarts/core/controllers/imitation_controller.py
+++ b/smarts/core/controllers/imitation_controller.py
@@ -56,7 +56,7 @@ class ImitationController:
             dpos = radians_to_vec(vehicle.heading) * vehicle.speed * dt
             new_pose = Pose(
                 position=vehicle.position + np.append(dpos, 0.0),
-                orientation=fast_quaternion_from_angle(vehicle.heading),
+                orientation=fast_quaternion_from_angle(target_heading),
             )
             target_speed = vehicle.speed + acceleration * dt
             vehicle.control(new_pose, target_speed, dt)

--- a/smarts/core/controllers/imitation_controller.py
+++ b/smarts/core/controllers/imitation_controller.py
@@ -53,19 +53,12 @@ class ImitationController:
         target_heading = (vehicle.heading + angular_velocity * dt) % (2 * math.pi)
 
         if isinstance(chassis, BoxChassis):
-            speed_x, speed_y = radians_to_vec(vehicle.heading) * vehicle.speed
-            new_position = np.array(
-                (
-                    vehicle.position[0] + dt * speed_x,
-                    vehicle.position[1] + dt * speed_y,
-                    vehicle.position[2],
-                )
+            dpos = radians_to_vec(vehicle.heading) * vehicle.speed * dt
+            new_pose = Pose(
+                position=vehicle.position + np.append(dpos, 0.0),
+                orientation=fast_quaternion_from_angle(vehicle.heading),
             )
             target_speed = vehicle.speed + acceleration * dt
-            new_pose = Pose(
-                orientation=fast_quaternion_from_angle(target_heading),
-                position=new_position,
-            )
             vehicle.control(new_pose, target_speed, dt)
 
         elif isinstance(chassis, AckermannChassis):

--- a/smarts/core/smarts.py
+++ b/smarts/core/smarts.py
@@ -292,7 +292,9 @@ class SMARTS:
 
         # Tell history provide to ignore vehicles if we have assigned mission to them
         self._traffic_history_provider.set_replaced_ids(
-            m.vehicle_id for m in scenario.missions.values() if m and m.vehicle_id
+            m.vehicle_spec.veh_id
+            for m in scenario.missions.values()
+            if m and m.vehicle_spec
         )
 
         self._total_sim_time += self._elapsed_sim_time

--- a/smarts/core/smarts.py
+++ b/smarts/core/smarts.py
@@ -610,10 +610,13 @@ class SMARTS:
 
         return provider_state
 
-    def _nondynamic_provider_step(self, agent_actions) -> ProviderState:
+    def _nondynamic_provider_step(
+        self, agent_actions, step_pybullet: bool
+    ) -> ProviderState:
         self._perform_agent_actions(agent_actions)
 
-        self._bullet_client.stepSimulation()
+        if step_pybullet:
+            self._bullet_client.stepSimulation()
 
         self._process_collisions()
 
@@ -720,7 +723,7 @@ class SMARTS:
             )
         if other_actions:
             accumulated_provider_state.merge(
-                self._nondynamic_provider_step(other_actions)
+                self._nondynamic_provider_step(other_actions, bool(pybullet_actions))
             )
 
         for provider in self.providers:

--- a/smarts/core/traffic_history_provider.py
+++ b/smarts/core/traffic_history_provider.py
@@ -17,7 +17,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-import logging
 import numpy as np
 import sqlite3
 from itertools import cycle
@@ -34,7 +33,6 @@ class TrafficHistoryProvider(Provider):
     def __init__(self):
         self._histories = None
         self._is_setup = False
-        self._log = logging.getLogger(self.__class__.__name__)
         self._map_location_offset = None
         self._replaced_vehicle_ids = set()
         self._last_step_vehicles = set()
@@ -87,23 +85,6 @@ class TrafficHistoryProvider(Provider):
         # Ignore other sim state
         pass
 
-    def _decode_vehicle_type(self, vehicle_type: int) -> str:
-        # Options from NGSIM and INTERACTION currently include:
-        #  1=motorcycle, 2=auto, 3=truck, 4=pedestrian/bicycle
-        if vehicle_type == 1:
-            return "motorcycle"
-        elif vehicle_type == 2:
-            return "passenger"
-        elif vehicle_type == 3:
-            return "truck"
-        elif vehicle_type == 4:
-            return "pedestrian"
-        else:
-            self._log.warning(
-                f"unsupported vehicle_type ({vehicle_type}) in history data."
-            )
-        return "passenger"
-
     def step(
         self, provider_actions, dt: float, elapsed_sim_time: float
     ) -> ProviderState:
@@ -120,7 +101,7 @@ class TrafficHistoryProvider(Provider):
             if v_id in vehicle_ids or v_id in self._replaced_vehicle_ids:
                 continue
             vehicle_ids.add(v_id)
-            vehicle_type = self._decode_vehicle_type(hr.vehicle_type)
+            vehicle_type = self._histories.decode_vehicle_type(hr.vehicle_type)
             default_dims = VEHICLE_CONFIGS[vehicle_type].dimensions
             pos_x = hr.position_x + self._map_location_offset[0]
             pos_y = hr.position_y + self._map_location_offset[1]

--- a/smarts/core/vehicle.py
+++ b/smarts/core/vehicle.py
@@ -307,15 +307,23 @@ class Vehicle:
         controller_filepath,
         initial_speed=None,
     ):
-        # Agents can currently only control passenger vehicles
-        vehicle_type = "passenger"
-        chassis_dims = VEHICLE_CONFIGS[vehicle_type].dimensions
+        mission = mission_planner.mission
 
-        if isinstance(mission_planner.mission.task, UTurn):
-            if mission_planner.mission.task.initial_speed:
-                initial_speed = mission_planner.mission.task.initial_speed
+        if mission.vehicle_spec:
+            # mission.vehicle_spec.veh_type will always be "passenger" for now,
+            # but we use that value here in case we ever expand our history functionality.
+            vehicle_type = mission.vehicle_spec.veh_type
+            chassis_dims = mission.vehicle_spec.dimensions
+        else:
+            # non-history agents can currently only control passenger vehicles.
+            vehicle_type = "passenger"
+            chassis_dims = VEHICLE_CONFIGS[vehicle_type].dimensions
 
-        start = mission_planner.mission.start
+        if isinstance(mission.task, UTurn):
+            if mission.task.initial_speed:
+                initial_speed = mission.task.initial_speed
+
+        start = mission.start
         start_pose = Pose.from_front_bumper(
             front_bumper_position=numpy.array(start.position),
             heading=start.heading,
@@ -349,7 +357,11 @@ class Vehicle:
 
         chassis = None
         # change this to dynamic_action_spaces later when pr merged
-        if agent_interface and agent_interface.action in sim.dynamic_action_spaces:
+        if (
+            agent_interface
+            and agent_interface.action in sim.dynamic_action_spaces
+            and not mission.vehicle_spec
+        ):
             chassis = AckermannChassis(
                 pose=start_pose,
                 bullet_client=sim.bc,

--- a/smarts/sstudio/genhistories.py
+++ b/smarts/sstudio/genhistories.py
@@ -268,8 +268,8 @@ class NGSIM(_TrajectoryDataset):
             avg = (c - p) / d1
         else:
             avg = ((n - c) / d2) + ((c - p) / d1)
-        r = math.atan2(avg[1], avg[0]) % (2 * math.pi)
-        self._prev_heading = r - math.pi / 2
+        r = math.atan2(avg[1], avg[0])
+        self._prev_heading = (r - math.pi / 2) % (2 * math.pi)
         return self._prev_heading
 
     def _cal_speed(self, window):


### PR DESCRIPTION
This PR allows agent vehicles' sizes to be set to match whatever was specified in the traffic history dataset for the vehicle being replaced.  This is necessary for accurate collision detection when training/testing imitation learning models.