### PR TITLE
ULTRA Remove start/end offsets

### DIFF
--- a/ultra/ultra/scenarios/task1/config.yaml
+++ b/ultra/ultra/scenarios/task1/config.yaml
@@ -66,8 +66,6 @@ levels:
         # left turn from south to west
       - start: south-SN
         end:   west-EW
-        start_offset: [110, 120]
-        end_offset:   [10, 10]
       intersection_types:
         2lane_t:
           percent: 0.2
@@ -93,8 +91,6 @@ levels:
         # left turn from south to west
       - start: south-SN
         end:   west-EW
-        start_offset: [110, 120]
-        end_offset:   [10, 10]
       intersection_types:
         2lane_c:
           percent: 0.5


### PR DESCRIPTION
Minor update: Remove ego vehicle's start and end offsets from the simple level. 

Note: By default levels from tasks 1 & 2 would be not be constrained by any destination/arrival positions (start/end offsets)