### PR TITLE
Add default info adapter to remove reward adapter's NeighborhoodVehicles dependency

### DIFF
--- a/ultra/docs/adapters.md
+++ b/ultra/docs/adapters.md
@@ -104,11 +104,11 @@ If there are more than 10 social vehicles, this adapter will truncate the social
 
 ## Reward Adapters
 
-A reward adapter takes an [observation](https://smarts.readthedocs.io/en/latest/sim/observations.html#id1) and the [environment reward](https://smarts.readthedocs.io/en/latest/sim/observations.html#rewards) as arguments from the environment and adapts them, acting as a custom reward function. ULTRA has one default reward adapter that uses elements from the agent's observation, as well as the environment reward to develop a custom reward.
+A reward adapter takes an [observation](https://smarts.readthedocs.io/en/latest/sim/observations.html#id1) and the [environment reward](https://smarts.readthedocs.io/en/latest/sim/observations.html#rewards) as arguments from the environment and adapts them, acting as a custom reward function. ULTRA has one default reward adapter that uses elements from the agent's observation, as well as the environment reward, to develop a custom reward.
 
 ### [ultra.adapters.default_reward_adapter](../ultra/adapters/default_reward_adapter.py)
 
-The default reward adapter requires that the SMARTS environment include the next 20 waypoints in front of the ego vehicle, and all neighborhood (social) vehicles within a radius of 200 meters around the ego vehicle. Therefore, when using this adapter, the [`AgentInterface`](../../smarts/core/agent_interface.py) of your agent needs its `waypoints` parameter to be `Waypoints(lookahead=20)` and its `neighborhood_vehicles` parameter to be `NeighborhoodVehicles(radius=200.0)`. This requirement is outlined in this module's `required_interface`.
+The default reward adapter requires that the SMARTS environment include the next 20 waypoints in front of the ego vehicle in the ego vehicle's observation. Therefore, when using this adapter, the [`AgentInterface`](../../smarts/core/agent_interface.py) of your agent needs its `waypoints` parameter to be `Waypoints(lookahead=20)`. This requirement is outlined in this module's `required_interface`.
 
 This default reward adapter combines elements of the agent's observation along with the environment reward to create a custom reward. This custom reward consists of multiple components:
 ```python

--- a/ultra/ultra/adapters/__init__.py
+++ b/ultra/ultra/adapters/__init__.py
@@ -26,6 +26,7 @@ import gym
 
 import ultra.adapters.default_action_continuous_adapter as default_action_continuous_adapter
 import ultra.adapters.default_action_discrete_adapter as default_action_discrete_adapter
+import ultra.adapters.default_info_adapter as default_info_adapter
 import ultra.adapters.default_observation_image_adapter as default_observation_image_adapter
 import ultra.adapters.default_observation_vector_adapter as default_observation_vector_adapter
 import ultra.adapters.default_reward_adapter as default_reward_adapter
@@ -35,6 +36,9 @@ class AdapterType(enum.Enum):
     # Action adapters.
     DefaultActionContinuous = enum.auto()
     DefaultActionDiscrete = enum.auto()
+
+    # Info adapters.
+    DefaultInfo = enum.auto()
 
     # Observation adapters.
     DefaultObservationVector = enum.auto()
@@ -47,6 +51,7 @@ class AdapterType(enum.Enum):
 _STRING_TO_TYPE = {
     "default_action_continuous": AdapterType.DefaultActionContinuous,
     "default_action_discrete": AdapterType.DefaultActionDiscrete,
+    "default_info": AdapterType.DefaultInfo,
     "default_observation_image": AdapterType.DefaultObservationImage,
     "default_observation_vector": AdapterType.DefaultObservationVector,
     "default_reward": AdapterType.DefaultReward,
@@ -60,6 +65,7 @@ _TYPE_TO_SPACE = {
 _TYPE_TO_ADAPTER = {
     AdapterType.DefaultActionContinuous: default_action_continuous_adapter.adapt,
     AdapterType.DefaultActionDiscrete: default_action_discrete_adapter.adapt,
+    AdapterType.DefaultInfo: default_info_adapter.adapt,
     AdapterType.DefaultObservationImage: default_observation_image_adapter.adapt,
     AdapterType.DefaultObservationVector: default_observation_vector_adapter.adapt,
     AdapterType.DefaultReward: default_reward_adapter.adapt,
@@ -67,6 +73,7 @@ _TYPE_TO_ADAPTER = {
 _TYPE_TO_REQUIRED_INTERFACE = {
     AdapterType.DefaultActionContinuous: default_action_continuous_adapter.required_interface,
     AdapterType.DefaultActionDiscrete: default_action_discrete_adapter.required_interface,
+    AdapterType.DefaultInfo: default_info_adapter.required_interface,
     AdapterType.DefaultObservationImage: default_observation_image_adapter.required_interface,
     AdapterType.DefaultObservationVector: default_observation_vector_adapter.required_interface,
     AdapterType.DefaultReward: default_reward_adapter.required_interface,

--- a/ultra/ultra/adapters/constants.py
+++ b/ultra/ultra/adapters/constants.py
@@ -1,0 +1,25 @@
+# MIT License
+#
+# Copyright (C) 2021. Huawei Technologies Co., Ltd. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+# Constants used by multiple default adapters.
+DEFAULT_WAYPOINTS = 20  # Number of waypoints ahead of the ego vehicle to include.
+DEFAULT_RADIUS = 200.0  # Include all vehicles within this radius of the ego vehicle.

--- a/ultra/ultra/adapters/default_info_adapter.py
+++ b/ultra/ultra/adapters/default_info_adapter.py
@@ -63,9 +63,7 @@ def adapt(
     ego_state = observation.ego_vehicle_state
     start = observation.ego_vehicle_state.mission.start
     goal = observation.ego_vehicle_state.mission.goal
-    path = get_path_to_goal(
-        goal=goal, paths=observation.waypoint_paths, start=start
-    )
+    path = get_path_to_goal(goal=goal, paths=observation.waypoint_paths, start=start)
     closest_wp, _ = get_closest_waypoint(
         num_lookahead=100,
         goal_path=path,
@@ -116,5 +114,3 @@ def adapt(
     )
 
     return info
-
-

--- a/ultra/ultra/adapters/default_info_adapter.py
+++ b/ultra/ultra/adapters/default_info_adapter.py
@@ -26,12 +26,13 @@ from scipy.spatial import distance
 
 from smarts.core.agent_interface import NeighborhoodVehicles, Waypoints
 from smarts.core.sensors import Observation
+from ultra.adapters.constants import DEFAULT_RADIUS, DEFAULT_WAYPOINTS
 import ultra.adapters.default_reward_adapter as default_reward_adapter
 from ultra.utils.common import ego_social_safety, get_closest_waypoint, get_path_to_goal
 
 
-_WAYPOINTS = 20
-_RADIUS = 200.0
+_WAYPOINTS = DEFAULT_WAYPOINTS
+_RADIUS = DEFAULT_RADIUS
 
 
 required_interface = {

--- a/ultra/ultra/adapters/default_info_adapter.py
+++ b/ultra/ultra/adapters/default_info_adapter.py
@@ -1,0 +1,120 @@
+# MIT License
+#
+# Copyright (C) 2021. Huawei Technologies Co., Ltd. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+from typing import Any, Dict
+
+import numpy as np
+from scipy.spatial import distance
+
+from smarts.core.agent_interface import NeighborhoodVehicles, Waypoints
+from smarts.core.sensors import Observation
+import ultra.adapters.default_reward_adapter as default_reward_adapter
+from ultra.utils.common import ego_social_safety, get_closest_waypoint, get_path_to_goal
+
+
+_WAYPOINTS = 20
+_RADIUS = 200.0
+
+
+required_interface = {
+    "waypoints": Waypoints(lookahead=_WAYPOINTS),
+    "neighborhood_vehicles": NeighborhoodVehicles(radius=_RADIUS),
+}
+
+
+def adapt(
+    observation: Observation, reward: float, info: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Adapts a raw environment observation, an environment reward, and info about the
+    agent from the environment into custom information about the agent.
+
+    The raw observation from the environment must include the ego vehicle's state,
+    events, waypoint paths, and neighborhood vehicles. See smarts.core.sensors for more
+    information on the Observation type.
+
+    Args:
+        observation (Observation): The raw environment observation received from SMARTS.
+        reward (float): The environment reward received from SMARTS.
+        info (dict): Information about the agent received from SMARTS.
+
+    Returns:
+        dict: The adapted information. A dictionary containing the same information as
+            the original info argument, but also including a "logs" key containing more
+            information about the agent.
+    """
+    ego_state = observation.ego_vehicle_state
+    start = observation.ego_vehicle_state.mission.start
+    goal = observation.ego_vehicle_state.mission.goal
+    path = get_path_to_goal(
+        goal=goal, paths=observation.waypoint_paths, start=start
+    )
+    closest_wp, _ = get_closest_waypoint(
+        num_lookahead=100,
+        goal_path=path,
+        ego_position=ego_state.position,
+        ego_heading=ego_state.heading,
+    )
+    signed_dist_from_center = closest_wp.signed_lateral_error(ego_state.position)
+    lane_width = closest_wp.lane_width * 0.5
+    ego_dist_center = signed_dist_from_center / lane_width
+
+    linear_jerk = np.linalg.norm(ego_state.linear_jerk)
+    angular_jerk = np.linalg.norm(ego_state.angular_jerk)
+
+    # Distance to goal
+    ego_2d_position = ego_state.position[0:2]
+    goal_dist = distance.euclidean(ego_2d_position, goal.position)
+
+    angle_error = closest_wp.relative_heading(
+        ego_state.heading
+    )  # relative heading radians [-pi, pi]
+
+    # number of violations
+    (ego_num_violations, social_num_violations,) = ego_social_safety(
+        observation,
+        d_min_ego=1.0,
+        t_c_ego=1.0,
+        d_min_social=1.0,
+        t_c_social=1.0,
+        ignore_vehicle_behind=True,
+    )
+
+    info["logs"] = dict(
+        position=ego_state.position,
+        speed=ego_state.speed,
+        steering=ego_state.steering,
+        heading=ego_state.heading,
+        dist_center=abs(ego_dist_center),
+        start=start,
+        goal=goal,
+        closest_wp=closest_wp,
+        events=observation.events,
+        ego_num_violations=ego_num_violations,
+        social_num_violations=social_num_violations,
+        goal_dist=goal_dist,
+        linear_jerk=np.linalg.norm(ego_state.linear_jerk),
+        angular_jerk=np.linalg.norm(ego_state.angular_jerk),
+        env_score=default_reward_adapter.adapt(observation, reward),
+    )
+
+    return info
+
+

--- a/ultra/ultra/adapters/default_observation_vector_adapter.py
+++ b/ultra/ultra/adapters/default_observation_vector_adapter.py
@@ -30,11 +30,12 @@ import numpy as np
 from smarts.core.coordinates import Heading
 from smarts.core.sensors import Observation, VehicleObservation
 from smarts.core.agent_interface import NeighborhoodVehicles, Waypoints
+from ultra.adapters.constants import DEFAULT_RADIUS, DEFAULT_WAYPOINTS
 from ultra.utils.common import get_closest_waypoint, get_path_to_goal, rotate2d_vector
 
 
-_WAYPOINTS = 20  # Number of waypoints on the path ahead of the ego vehicle.
-_RADIUS = 200.0  # Locate all social vehicles within this radius of the ego vehicle.
+_WAYPOINTS = DEFAULT_WAYPOINTS
+_RADIUS = DEFAULT_RADIUS
 _CAPACITY = 10  # Number of social vehicles we keep in the adapted observation.
 _FEATURES = 4  # Number of features for each social vehicle.
 _SIZE = (

--- a/ultra/ultra/adapters/default_reward_adapter.py
+++ b/ultra/ultra/adapters/default_reward_adapter.py
@@ -24,21 +24,17 @@ import math
 import numpy as np
 from scipy.spatial import distance
 
-from smarts.core.agent_interface import NeighborhoodVehicles, Waypoints
+from smarts.core.agent_interface import Waypoints
 from smarts.core.sensors import Observation
-from ultra.utils.common import ego_social_safety, get_closest_waypoint, get_path_to_goal
+from ultra.utils.common import get_closest_waypoint, get_path_to_goal
 
 
 _WAYPOINTS = 20  # Number of waypoints on the path ahead of the ego vehicle.
-_RADIUS = 200.0  # Locate all social vehicles within this radius of the ego vehicle.
 
 
-# This adapter requires SMARTS to pass the next _WAYPOINTS waypoints and all
-# neighborhood vehicles within a radius of _RADIUS meters in the agent's observation.
-required_interface = {
-    "waypoints": Waypoints(lookahead=_WAYPOINTS),
-    "neighborhood_vehicles": NeighborhoodVehicles(radius=_RADIUS),
-}
+# This adapter requires SMARTS to pass the next _WAYPOINTS waypoints in the agent's
+# observation.
+required_interface = {"waypoints": Waypoints(lookahead=_WAYPOINTS)}
 
 
 def adapt(observation: Observation, reward: float) -> float:
@@ -46,8 +42,8 @@ def adapt(observation: Observation, reward: float) -> float:
     of type float.
 
     The raw observation from the environment must include the ego vehicle's state,
-    events, waypoint paths, and neighborhood vehicles. See smarts.core.sensors for more
-    information on the Observation type.
+    events, and waypoint paths. See smarts.core.sensors for more information on the
+    Observation type.
 
     Args:
         observation (Observation): The raw environment observation received from SMARTS.
@@ -55,8 +51,8 @@ def adapt(observation: Observation, reward: float) -> float:
 
     Returns:
         float: The adapted, custom reward which includes aspects of the ego vehicle's
-            state, the ego vehicle's mission progress, and the and neighborhood vehicles
-            around the ego vehicle, in addition to the environment reward.
+            state and the ego vehicle's mission progress, in addition to the environment
+            reward.
     """
     env_reward = reward
     ego_events = observation.events
@@ -89,15 +85,16 @@ def adapt(observation: Observation, reward: float) -> float:
     lane_width = closest_wp.lane_width * 0.5
     ego_dist_center = signed_dist_from_center / lane_width
 
-    # number of violations
-    (ego_num_violations, social_num_violations,) = ego_social_safety(
-        observation,
-        d_min_ego=1.0,
-        t_c_ego=1.0,
-        d_min_social=1.0,
-        t_c_social=1.0,
-        ignore_vehicle_behind=True,
-    )
+    # NOTE: This requires the NeighborhoodVehicles interface.
+    # # number of violations
+    # (ego_num_violations, social_num_violations,) = ego_social_safety(
+    #     observation,
+    #     d_min_ego=1.0,
+    #     t_c_ego=1.0,
+    #     d_min_social=1.0,
+    #     t_c_social=1.0,
+    #     ignore_vehicle_behind=True,
+    # )
 
     speed_fraction = max(0, ego_observation.speed / closest_wp.speed_limit)
     ego_step_reward = 0.02 * min(speed_fraction, 1) * np.cos(angle_error)
@@ -114,8 +111,10 @@ def adapt(observation: Observation, reward: float) -> float:
     ego_dist_center_reward = -0.002 * min(1, abs(ego_dist_center))
     ego_angle_error_reward = -0.005 * max(0, np.cos(angle_error))
     ego_reached_goal = 1.0 if ego_events.reached_goal else 0.0
-    ego_safety_reward = -0.02 if ego_num_violations > 0 else 0
-    social_safety_reward = -0.02 if social_num_violations > 0 else 0
+    # NOTE: This requires the NeighborhoodVehicles interface.
+    # ego_safety_reward = -0.02 if ego_num_violations > 0 else 0
+    # NOTE: This requires the NeighborhoodVehicles interface.
+    # social_safety_reward = -0.02 if social_num_violations > 0 else 0
     ego_lat_speed = 0.0  # -0.1 * abs(long_lat_speed[1])
     ego_linear_jerk = -0.0001 * linear_jerk
     ego_angular_jerk = -0.0001 * angular_jerk * math.cos(angle_error)

--- a/ultra/ultra/adapters/default_reward_adapter.py
+++ b/ultra/ultra/adapters/default_reward_adapter.py
@@ -26,10 +26,11 @@ from scipy.spatial import distance
 
 from smarts.core.agent_interface import Waypoints
 from smarts.core.sensors import Observation
+from ultra.adapters.constants import DEFAULT_WAYPOINTS
 from ultra.utils.common import get_closest_waypoint, get_path_to_goal
 
 
-_WAYPOINTS = 20  # Number of waypoints on the path ahead of the ego vehicle.
+_WAYPOINTS = DEFAULT_WAYPOINTS
 
 
 # This adapter requires SMARTS to pass the next _WAYPOINTS waypoints in the agent's

--- a/ultra/ultra/baselines/agent_spec.py
+++ b/ultra/ultra/baselines/agent_spec.py
@@ -70,6 +70,7 @@ class BaselineAgentSpec(AgentSpec):
                     agent_builder=spec.policy_builder,
                     observation_adapter=spec.observation_adapter,
                     reward_adapter=spec.reward_adapter,
+                    info_adapter=spec.info_adapter,
                 )
 
                 spec = new_spec
@@ -94,15 +95,17 @@ class BaselineAgentSpec(AgentSpec):
             reward_type = adapters.type_from_string(
                 string_type=policy_params["reward_type"]
             )
+            info_type = adapters.AdapterType.DefaultInfo
 
             adapter_interface_requirements = adapters.required_interface_from_types(
-                action_type, observation_type, reward_type
+                action_type, observation_type, reward_type, info_type
             )
             action_adapter = adapters.adapter_from_type(adapter_type=action_type)
             observation_adapter = adapters.adapter_from_type(
                 adapter_type=observation_type
             )
             reward_adapter = adapters.adapter_from_type(adapter_type=reward_type)
+            info_adapter = adapters.adapter_from_type(adapter_type=info_type)
 
             spec = AgentSpec(
                 interface=AgentInterface(
@@ -117,6 +120,7 @@ class BaselineAgentSpec(AgentSpec):
                 action_adapter=action_adapter,
                 observation_adapter=observation_adapter,
                 reward_adapter=reward_adapter,
+                info_adapter=info_adapter,
             )
 
         return spec

--- a/ultra/ultra/env/ultra_env.py
+++ b/ultra/ultra/env/ultra_env.py
@@ -57,10 +57,6 @@ class UltraEnv(HiWayEnv):
         else:
             _scenarios = glob.glob(f"{self.scenarios['test']}")
 
-        self.ultra_scores = adapters.adapter_from_type(
-            adapter_type=adapters.AdapterType.DefaultReward
-        )
-
         super().__init__(
             scenarios=_scenarios,
             agent_specs=agent_specs,

--- a/ultra/ultra/env/ultra_env.py
+++ b/ultra/ultra/env/ultra_env.py
@@ -35,7 +35,6 @@ import ultra.adapters as adapters
 from ultra.baselines.common.yaml_loader import load_yaml
 
 path.append("./ultra")
-from ultra.utils.common import ego_social_safety, get_closest_waypoint, get_path_to_goal
 
 
 class UltraEnv(HiWayEnv):
@@ -87,63 +86,6 @@ class UltraEnv(HiWayEnv):
                 )
             )
 
-    def generate_logs(self, observation, highwayenv_score):
-        ego_state = observation.ego_vehicle_state
-        start = observation.ego_vehicle_state.mission.start
-        goal = observation.ego_vehicle_state.mission.goal
-        path = get_path_to_goal(
-            goal=goal, paths=observation.waypoint_paths, start=start
-        )
-        closest_wp, _ = get_closest_waypoint(
-            num_lookahead=100,
-            goal_path=path,
-            ego_position=ego_state.position,
-            ego_heading=ego_state.heading,
-        )
-        signed_dist_from_center = closest_wp.signed_lateral_error(ego_state.position)
-        lane_width = closest_wp.lane_width * 0.5
-        ego_dist_center = signed_dist_from_center / lane_width
-
-        linear_jerk = np.linalg.norm(ego_state.linear_jerk)
-        angular_jerk = np.linalg.norm(ego_state.angular_jerk)
-
-        # Distance to goal
-        ego_2d_position = ego_state.position[0:2]
-        goal_dist = distance.euclidean(ego_2d_position, goal.position)
-
-        angle_error = closest_wp.relative_heading(
-            ego_state.heading
-        )  # relative heading radians [-pi, pi]
-
-        # number of violations
-        (ego_num_violations, social_num_violations,) = ego_social_safety(
-            observation,
-            d_min_ego=1.0,
-            t_c_ego=1.0,
-            d_min_social=1.0,
-            t_c_social=1.0,
-            ignore_vehicle_behind=True,
-        )
-
-        info = dict(
-            position=ego_state.position,
-            speed=ego_state.speed,
-            steering=ego_state.steering,
-            heading=ego_state.heading,
-            dist_center=abs(ego_dist_center),
-            start=start,
-            goal=goal,
-            closest_wp=closest_wp,
-            events=observation.events,
-            ego_num_violations=ego_num_violations,
-            social_num_violations=social_num_violations,
-            goal_dist=goal_dist,
-            linear_jerk=np.linalg.norm(ego_state.linear_jerk),
-            angular_jerk=np.linalg.norm(ego_state.angular_jerk),
-            env_score=self.ultra_scores(observation, highwayenv_score),
-        )
-        return info
-
     def step(self, agent_actions):
         agent_actions = {
             agent_id: self._agent_specs[agent_id].action_adapter(action)
@@ -166,7 +108,6 @@ class UltraEnv(HiWayEnv):
             rewards[agent_id] = agent_spec.reward_adapter(observation, reward)
             observations[agent_id] = agent_spec.observation_adapter(observation)
             infos[agent_id] = agent_spec.info_adapter(observation, reward, info)
-            infos[agent_id]["logs"] = self.generate_logs(observation, reward)
 
         for done in agent_dones.values():
             self._dones_registered += 1 if done else 0


### PR DESCRIPTION
A possible solution to address removing the NeighborhoodVehicles from the default reward adapter's required interface.

This would of course require all ULTRA agents to use this info adapter, not only because it ensures that waypoints and neighborhood vehicles are provided in the observation, but also because the episodes object requires the info provided by this adapter when it records the data from each episode.

Will add tests and documentation for the info adapter later if we go with this solution.
Edit: Tests and documentation have been added for the info adapter.

There is a problem with this in that if we require all ULTRA ego agents to use this adapter, then we require them to use observations that contain neighborhood vehicles within 200 meters, and the next 20 waypoints... What if one wants to use neighborhood vehicles only within 50 meters? Or the next 40 waypoints? Etc.