### PR TITLE
Fix args count error caused by `websocket`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Patched a restart of SUMO every 50 resets to avoid rampant memory growth.
 - Fixed bugs in `AccelerometerSensor`.  See PR #878.
 - Ensure that `yaw_rate` is always a scalar in `EgoVehicleObservation`.
+- Fixed an args count error caused by `websocket.on_close()` sending a variable number of args.
 ## Removed
 - Removed `pview` from `make` as it refers to `.egg` file artifacts that we no longer keep around.
 

--- a/envision/client.py
+++ b/envision/client.py
@@ -178,7 +178,7 @@ class Client:
 
             ws.send(state)
 
-        def on_close(ws):
+        def on_close(ws, *args):
             self._log.debug("Connection to Envision closed")
 
         def on_error(ws, error):

--- a/envision/client.py
+++ b/envision/client.py
@@ -178,7 +178,7 @@ class Client:
 
             ws.send(state)
 
-        def on_close(ws, *args):
+        def on_close(ws, code=None, reason=None):
             self._log.debug("Connection to Envision closed")
 
         def on_error(ws, error):


### PR DESCRIPTION
Investigating `websocket.WebSocketApp` I found that it is possible for it to (oddly) provide a variable number of arguments of 1 or 3 total args.