### PR TITLE
Ensure agents have the required interface for the ULTRA environment

### DIFF
--- a/ultra/docs/adapters.md
+++ b/ultra/docs/adapters.md
@@ -196,17 +196,15 @@ A reward adapter takes an [observation](https://smarts.readthedocs.io/en/latest/
 and the [environment reward](https://smarts.readthedocs.io/en/latest/sim/observations.html#rewards)
 as arguments from the environment and adapts them, acting as a custom reward function.
 ULTRA has one default reward adapter that uses elements from the agent's observation, as
-well as the environment reward to develop a custom reward.
+well as the environment reward, to develop a custom reward.
 
 ### [ultra.adapters.default_reward_adapter](../ultra/adapters/default_reward_adapter.py)
 
 The default reward adapter requires that the SMARTS environment include the next 20
-waypoints in front of the ego vehicle, and all neighborhood (social) vehicles within a
-radius of 200 meters around the ego vehicle. Therefore, when using this adapter, the
-[`AgentInterface`](../../smarts/core/agent_interface.py) of your agent needs its
-`waypoints` parameter to be `Waypoints(lookahead=20)` and its `neighborhood_vehicles`
-parameter to be `NeighborhoodVehicles(radius=200.0)`. This requirement is outlined in
-this module's `required_interface`.
+waypoints in front of the ego vehicle in the ego vehicle's observation. Therefore, when
+using this adapter, the [`AgentInterface`](../../smarts/core/agent_interface.py) of your
+agent needs its `waypoints` parameter to be `Waypoints(lookahead=20)`. This requirement
+is outlined in this module's `required_interface`.
 
 This default reward adapter combines elements of the agent's observation along with the
 environment reward to create a custom reward. This custom reward consists of multiple

--- a/ultra/tests/test_adapter.py
+++ b/ultra/tests/test_adapter.py
@@ -26,7 +26,7 @@ import gym
 import numpy as np
 
 from smarts.core.agent import Agent, AgentSpec
-from smarts.core.agent_interface import AgentInterface
+from smarts.core.agent_interface import AgentInterface, NeighborhoodVehicles, Waypoints
 from smarts.core.sensors import Observation
 import ultra.adapters as adapters
 from ultra.env.ultra_env import UltraEnv
@@ -145,6 +145,11 @@ def prepare_test_agent_and_environment(
     required_interface = adapters.required_interface_from_types(
         action_type, observation_type, reward_type
     )
+
+    if "waypoints" not in required_interface:
+        required_interface["waypoints"] = Waypoints(lookahead=20)
+    if "neighborhood_vehicles" not in required_interface:
+        required_interface["neighborhood_vehicles"] = NeighborhoodVehicles(radius=200.0)
 
     agent_spec = AgentSpec(
         interface=AgentInterface(**required_interface),

--- a/ultra/ultra/adapters/default_reward_adapter.py
+++ b/ultra/ultra/adapters/default_reward_adapter.py
@@ -30,15 +30,11 @@ from ultra.utils.common import ego_social_safety, get_closest_waypoint, get_path
 
 
 _WAYPOINTS = 20  # Number of waypoints on the path ahead of the ego vehicle.
-_RADIUS = 200.0  # Locate all social vehicles within this radius of the ego vehicle.
 
 
-# This adapter requires SMARTS to pass the next _WAYPOINTS waypoints and all
-# neighborhood vehicles within a radius of _RADIUS meters in the agent's observation.
-required_interface = {
-    "waypoints": Waypoints(lookahead=_WAYPOINTS),
-    "neighborhood_vehicles": NeighborhoodVehicles(radius=_RADIUS),
-}
+# This adapter requires SMARTS to pass the next _WAYPOINTS waypoints in the agent's
+# observation.
+required_interface = {"waypoints": Waypoints(lookahead=_WAYPOINTS)}
 
 
 def adapt(observation: Observation, reward: float) -> float:
@@ -46,8 +42,8 @@ def adapt(observation: Observation, reward: float) -> float:
     of type float.
 
     The raw observation from the environment must include the ego vehicle's state,
-    events, waypoint paths, and neighborhood vehicles. See smarts.core.sensors for more
-    information on the Observation type.
+    events, and waypoint paths. See smarts.core.sensors for more information on the
+    Observation type.
 
     Args:
         observation (Observation): The raw environment observation received from SMARTS.
@@ -55,8 +51,8 @@ def adapt(observation: Observation, reward: float) -> float:
 
     Returns:
         float: The adapted, custom reward which includes aspects of the ego vehicle's
-            state, the ego vehicle's mission progress, and the and neighborhood vehicles
-            around the ego vehicle, in addition to the environment reward.
+            state and the ego vehicle's mission progress, in addition to the environment
+            reward.
     """
     env_reward = reward
     ego_events = observation.events
@@ -89,15 +85,16 @@ def adapt(observation: Observation, reward: float) -> float:
     lane_width = closest_wp.lane_width * 0.5
     ego_dist_center = signed_dist_from_center / lane_width
 
-    # number of violations
-    (ego_num_violations, social_num_violations,) = ego_social_safety(
-        observation,
-        d_min_ego=1.0,
-        t_c_ego=1.0,
-        d_min_social=1.0,
-        t_c_social=1.0,
-        ignore_vehicle_behind=True,
-    )
+    # NOTE: This requires the NeighborhoodVehicles interface.
+    # # number of violations
+    # (ego_num_violations, social_num_violations,) = ego_social_safety(
+    #     observation,
+    #     d_min_ego=1.0,
+    #     t_c_ego=1.0,
+    #     d_min_social=1.0,
+    #     t_c_social=1.0,
+    #     ignore_vehicle_behind=True,
+    # )
 
     speed_fraction = max(0, ego_observation.speed / closest_wp.speed_limit)
     ego_step_reward = 0.02 * min(speed_fraction, 1) * np.cos(angle_error)
@@ -114,8 +111,10 @@ def adapt(observation: Observation, reward: float) -> float:
     ego_dist_center_reward = -0.002 * min(1, abs(ego_dist_center))
     ego_angle_error_reward = -0.005 * max(0, np.cos(angle_error))
     ego_reached_goal = 1.0 if ego_events.reached_goal else 0.0
-    ego_safety_reward = -0.02 if ego_num_violations > 0 else 0
-    social_safety_reward = -0.02 if social_num_violations > 0 else 0
+    # NOTE: This requires the NeighborhoodVehicles interface.
+    # ego_safety_reward = -0.02 if ego_num_violations > 0 else 0
+    # NOTE: This requires the NeighborhoodVehicles interface.
+    # social_safety_reward = -0.02 if social_num_violations > 0 else 0
     ego_lat_speed = 0.0  # -0.1 * abs(long_lat_speed[1])
     ego_linear_jerk = -0.0001 * linear_jerk
     ego_angular_jerk = -0.0001 * angular_jerk * math.cos(angle_error)

--- a/ultra/ultra/baselines/agent_spec.py
+++ b/ultra/ultra/baselines/agent_spec.py
@@ -111,8 +111,6 @@ class BaselineAgentSpec(AgentSpec):
                     "neighborhood_vehicles"
                 ] = NeighborhoodVehicles(radius=200.0)
 
-            print("requirements:", adapter_interface_requirements)
-
             spec = AgentSpec(
                 interface=AgentInterface(
                     **adapter_interface_requirements,

--- a/ultra/ultra/baselines/agent_spec.py
+++ b/ultra/ultra/baselines/agent_spec.py
@@ -24,7 +24,7 @@ import numpy as np
 import torch, yaml, os, inspect, dill
 
 from smarts.core.agent import AgentSpec
-from smarts.core.agent_interface import AgentInterface
+from smarts.core.agent_interface import AgentInterface, NeighborhoodVehicles, Waypoints
 from ultra.baselines.common.yaml_loader import load_yaml
 import ultra.adapters as adapters
 
@@ -103,6 +103,15 @@ class BaselineAgentSpec(AgentSpec):
                 adapter_type=observation_type
             )
             reward_adapter = adapters.adapter_from_type(adapter_type=reward_type)
+
+            if "waypoints" not in adapter_interface_requirements:
+                adapter_interface_requirements["waypoints"] = Waypoints(lookahead=20)
+            if "neighborhood_vehicles" not in adapter_interface_requirements:
+                adapter_interface_requirements[
+                    "neighborhood_vehicles"
+                ] = NeighborhoodVehicles(radius=200.0)
+
+            print("requirements:", adapter_interface_requirements)
 
             spec = AgentSpec(
                 interface=AgentInterface(

--- a/ultra/ultra/env/rllib_ultra_env.py
+++ b/ultra/ultra/env/rllib_ultra_env.py
@@ -55,6 +55,18 @@ class RLlibUltraEnv(RLlibHiWayEnv):
             adapter_type=adapters.AdapterType.DefaultReward
         )
 
+        # The ULTRA environment requires every agent to have at least Waypoints and
+        # NeighborhoodVehicles as part of its interface.
+        for agent_id, agent_spec in config["agent_specs"].items():
+            if not agent_spec.interface.waypoints:
+                raise Exception(
+                    f"Waypoints is not set in the interface of '{agent_id}'."
+                )
+            if not agent_spec.interface.neighborhood_vehicles:
+                raise Exception(
+                    f"NeighborhoodVehicles is not set in the interface of '{agent_id}'."
+                )
+
         super().__init__(config=config)
 
         if config["ordered_scenarios"]:

--- a/ultra/ultra/env/ultra_env.py
+++ b/ultra/ultra/env/ultra_env.py
@@ -62,6 +62,18 @@ class UltraEnv(HiWayEnv):
             adapter_type=adapters.AdapterType.DefaultReward
         )
 
+        # The ULTRA environment requires every agent to have at least Waypoints and
+        # NeighborhoodVehicles as part of its interface.
+        for agent_id, agent_spec in agent_specs.items():
+            if not agent_spec.interface.waypoints:
+                raise Exception(
+                    f"Waypoints is not set in the interface of '{agent_id}'."
+                )
+            if not agent_spec.interface.neighborhood_vehicles:
+                raise Exception(
+                    f"NeighborhoodVehicles is not set in the interface of '{agent_id}'."
+                )
+
         super().__init__(
             scenarios=_scenarios,
             agent_specs=agent_specs,


### PR DESCRIPTION
A possible solution to address removing the NeighborhoodVehicles from the default reward adapter's required interface.