### PR TITLE
ULTRA Evaluate specific models

### DIFF
--- a/ultra/docs/getting_started.md
+++ b/ultra/docs/getting_started.md
@@ -78,20 +78,26 @@ After training your agent, your models should be saved under `logs/<timestamped_
 - Re-run the evaluation with `ultra/evaluation.py`. Available arguments include:
   - `--task`: The task number to run (default is 1).
   - `--level`: The level of the task (default is easy).
-  - `--models`: The path to the saved model (default is models/).
+  - `--agents`: The ids of agents that you wish to evaluate (default is None; all agents are subject to evaluation).
   - `--episodes`: The number of evaluation episodes (default is 200).
   - `--max-episode-steps`: The option to limit the number of steps per epsiodes (default is 200).
   - `--timestep`: The environment timestep in seconds (default is 0.1).
   - `--headless`: Provide this flag to run evaluation without Envision.
   - `--experiment-dir`: The path to the spec file that includes adapters and policy parameters.
   - `--log-dir`: The log directory location (default is logs/).
+  - `--models-to-evaluate`: Provide this flag if you wish to evaluate agent(s) at desired checkpoint(s)
 
   For example, let's re-run our DQN's evaluation with the following command:
   ```sh
-  $ python ultra/evaluate.py --task 1 --level easy --models logs/<timestamped_experiment_name>/models/ --experiment-dir logs/<timestamed_experiment_name>/ --episodes 5
+  $ python ultra/evaluate.py --task 1 --level easy --agents <agent_ids> --experiment-dir logs/<timestamed_experiment_name>/ --episodes 5
   ```
   > This will produce another experiment directory under `logs/` containing the results of the evaluation.
 
+  The `--models-to-evaluate` flag will provide you the functionality to evaluate agent(s) at specific checkpoint(s). The `--models-to-evaluate` flag takes a list of arguments in this format: <agent_id>/<model>. For example, if we want to evaluate an agent with id="000" at checkpoints 0, 33, 87, 120 (these values represent the steps at which the checkpoint was saved) we can run the following command:
+  ```sh
+  $ python ultra/evaluate.py --task 1 --level easy --agents 000 --experiment-dir logs/<timestamed_experiment_name>/ --episodes 5 --models-to-evaluate 000/0 000/33 000/87 000/120
+  ```
+  
 ## View Tensorboard Results
 
 To view the Tensorboard results of this experiment, run the command below:

--- a/ultra/docs/getting_started.md
+++ b/ultra/docs/getting_started.md
@@ -62,14 +62,14 @@ Implementations of baseline agents are available in `ultra/baselines/`. Notice, 
 
   Run the following command to train our DQN agent with a quick training session (if you started Envision in the previous section, refresh your browser to observe the training):
   ```sh
-  $ python ultra/train.py --task 1 --level easy --episodes 10 --eval-episodes 5 --eval-rate 100 --policy dqn
+  $ python ultra/train.py --task 1 --level easy --episodes 10 --eval-episodes 2 --eval-rate 5 --policy dqn
   ```
-  > This will train our DQN on 10 episodes and evaluate its performance every 100 observations. You will notice that it will switch between training episodes and evaluation episodes.
+  > This will train our DQN on 10 episodes and evaluate its performance every 5 episodes by running the agent in 2 evaluation episodes. You will notice that it will switch between training episodes and evaluation episodes.
 - During training, a folder `logs/<timestamped_experiment_name>` is produced. It contains:
   - A tensorboard log (`events.out.tfevents.<...>`)
-  - Models at different observation steps (`models/<observation_number>/online.pth`, `models/<observation_number>/target.pth`)
-  - A pickled specification of your agent (`spec.pkl`), and
-  - Pickled results from training and evaluation (`Evaluation/resuts.pkl` and `Train/results.pkl`).
+  - Models at different observation steps (`models/000/<observation_number>/online.pth`, `models/000/<observation_number>/target.pth`)
+  - Pickled metadata of your agent (`agent_metadata.pkl`), and
+  - Pickled results from training and evaluation (`pkls/Evaluation/resuts.pkl`, `pkls/Evaluation_Training/results.pkl`, and `pkls/Train/results.pkl`).
 
 ## Evaluating the Agent
 
@@ -78,18 +78,17 @@ After training your agent, your models should be saved under `logs/<timestamped_
 - Re-run the evaluation with `ultra/evaluation.py`. Available arguments include:
   - `--task`: The task number to run (default is 1).
   - `--level`: The level of the task (default is easy).
-  - `--policy`: A string tag on the evaluation experiment directory (default is TD3).
   - `--models`: The path to the saved model (default is models/).
   - `--episodes`: The number of evaluation episodes (default is 200).
   - `--max-episode-steps`: The option to limit the number of steps per epsiodes (default is 200).
   - `--timestep`: The environment timestep in seconds (default is 0.1).
   - `--headless`: Provide this flag to run evaluation without Envision.
   - `--experiment-dir`: The path to the spec file that includes adapters and policy parameters.
-  - `--policy`: The policy (agent) to evaluate (default is sac).
+  - `--log-dir`: The log directory location (default is logs/).
 
   For example, let's re-run our DQN's evaluation with the following command:
   ```sh
-  $ python ultra/evaluate.py --task 1 --level easy --models logs/<timestamped_experiment_name>/models/ --episodes 5 --policy dqn
+  $ python ultra/evaluate.py --task 1 --level easy --models logs/<timestamped_experiment_name>/models/ --experiment-dir logs/<timestamed_experiment_name>/ --episodes 5
   ```
   > This will produce another experiment directory under `logs/` containing the results of the evaluation.
 
@@ -102,4 +101,5 @@ $ tensorboard --logdir <abolute_path_to_ULTRA>/logs/<timestamped_experiment_name
 > View the result in your browser with the provided link.
 
 ## Running Task 2
+
 Now try generating Task 2's scenarios and training an agent on this task by slightly modifying the above instructions (note that Task 2's level names are different than Task 1's level names).

--- a/ultra/docs/getting_started.md
+++ b/ultra/docs/getting_started.md
@@ -67,7 +67,7 @@ Implementations of baseline agents are available in `ultra/baselines/`. Notice, 
   > This will train our DQN on 10 episodes and evaluate its performance every 5 episodes by running the agent in 2 evaluation episodes. You will notice that it will switch between training episodes and evaluation episodes.
 - During training, a folder `logs/<timestamped_experiment_name>` is produced. It contains:
   - A tensorboard log (`events.out.tfevents.<...>`)
-  - Models at different observation steps (`models/000/<observation_number>/online.pth`, `models/000/<observation_number>/target.pth`)
+  - Models at different observation episodes (`models/000/<observation_number>/online.pth`, `models/000/<observation_number>/target.pth`)
   - Pickled metadata of your agent (`agent_metadata.pkl`), and
   - Pickled results from training and evaluation (`pkls/Evaluation/resuts.pkl`, `pkls/Evaluation_Training/results.pkl`, and `pkls/Train/results.pkl`).
 
@@ -93,7 +93,7 @@ After training your agent, your models should be saved under `logs/<timestamped_
   ```
   > This will produce another experiment directory under `logs/` containing the results of the evaluation.
 
-  The `--models-to-evaluate` flag will provide you the functionality to evaluate agent(s) at specific checkpoint(s). The `--models-to-evaluate` flag takes a list of arguments in this format: <agent_id>/<model>. For example, if we want to evaluate an agent with id="000" at checkpoints 0, 33, 87, 120 (these values represent the steps at which the checkpoint was saved) we can run the following command:
+  The `--models-to-evaluate` flag will provide you the functionality to evaluate agent(s) at specific checkpoint(s). The `--models-to-evaluate` flag takes a list of arguments in this format: <agent_id>/<model>. For example, if we want to evaluate an agent with id="000" at checkpoints 0, 33, 87, 120 (these values represent the episodes at which the checkpoint was saved) we can run the following command:
   ```sh
   $ python ultra/evaluate.py --task 1 --level easy --agents 000 --experiment-dir logs/<timestamed_experiment_name>/ --episodes 5 --models-to-evaluate 000/0 000/33 000/87 000/120
   ```

--- a/ultra/tests/test_evaluate.py
+++ b/ultra/tests/test_evaluate.py
@@ -198,7 +198,7 @@ class EvaluateTest(unittest.TestCase):
         )[0]
         evaluate_command = (
             f"python ultra/evaluate.py "
-            f"--task 00-multiagent --level eval_test --experiment-dir {experiment_dir} "
+            f"--task 00-multiagent --level eval_test --agents 000 --experiment-dir {experiment_dir} "
             f"--episodes 1 --max-episode-steps 2 --log-dir {log_dir} --headless"
         )
 

--- a/ultra/tests/test_evaluate.py
+++ b/ultra/tests/test_evaluate.py
@@ -170,13 +170,11 @@ class EvaluateTest(unittest.TestCase):
         experiment_dir = glob.glob(
             os.path.join(EvaluateTest.OUTPUT_DIRECTORY, "sac_test_models/*")
         )[0]
-        models = " ".join(glob.glob(os.path.join(experiment_dir, "models/000/")))
         evaluate_command = (
             f"python ultra/evaluate.py "
-            f"--task 00 --level eval_test --models {models} --experiment-dir {experiment_dir} "
+            f"--task 00 --level eval_test --experiment-dir {experiment_dir} "
             f"--episodes 1 --max-episode-steps 2 --log-dir {log_dir} --headless"
         )
-
         ray.shutdown()
         try:
             os.system(evaluate_command)
@@ -198,10 +196,9 @@ class EvaluateTest(unittest.TestCase):
         experiment_dir = glob.glob(
             os.path.join(EvaluateTest.OUTPUT_DIRECTORY, "multiagent_test_models/*")
         )[0]
-        models = " ".join(glob.glob(os.path.join(experiment_dir, "models/000/")))
         evaluate_command = (
             f"python ultra/evaluate.py "
-            f"--task 00-multiagent --level eval_test --models {models} --experiment-dir {experiment_dir} "
+            f"--task 00-multiagent --level eval_test --experiment-dir {experiment_dir} "
             f"--episodes 1 --max-episode-steps 2 --log-dir {log_dir} --headless"
         )
 

--- a/ultra/ultra/evaluate.py
+++ b/ultra/ultra/evaluate.py
@@ -311,7 +311,7 @@ def evaluate_saved_models(
             agent_id = model.split("/")[0]
             if agent_id in agent_checkpoint_directories.keys():
                 for model_directory in agent_checkpoint_directories[agent_id]:
-                    if model.split("/")[-1] in model_directory.split("/")[-1]:
+                    if model.split("/")[-1] == model_directory.split("/")[-1]:
                         if agent_id in custom_checkpoint_directories:
                             custom_checkpoint_directories[agent_id].append(
                                 model_directory
@@ -387,8 +387,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "--agents",
         nargs="+",
-        default=None,
         help="Agents to evaluate",
+        default=None,
     )
     parser.add_argument(
         "--episodes", help="Number of training episodes", type=int, default=200

--- a/ultra/ultra/evaluate.py
+++ b/ultra/ultra/evaluate.py
@@ -309,15 +309,30 @@ def evaluate_saved_models(
         # Iterate through each model to be evaluated (models that do not exist will not be included)
         for model in models_to_evaluate:
             agent_id = model.split("/")[0]
+            model_observation_number = model.split("/")[-1]
             if agent_id in agent_checkpoint_directories.keys():
-                for model_directory in agent_checkpoint_directories[agent_id]:
-                    if model.split("/")[-1] == model_directory.split("/")[-1]:
-                        if agent_id in custom_checkpoint_directories:
-                            custom_checkpoint_directories[agent_id].append(
-                                model_directory
-                            )
-                        else:
-                            custom_checkpoint_directories[agent_id] = [model_directory]
+                model_directories = {
+                    model_directory.split("/")[-1]: model_directory
+                    for model_directory in agent_checkpoint_directories[agent_id]
+                }
+                if model_observation_number in model_directories:
+                    if agent_id in custom_checkpoint_directories:
+                        custom_checkpoint_directories[agent_id].append(
+                            model_directories[model_observation_number]
+                        )
+                    else:
+                        custom_checkpoint_directories[agent_id] = [
+                            model_directories[model_observation_number]
+                        ]
+                else:
+                    raise Exception(
+                        f"The agent with id: {agent_id} does not contain the provided observation number: {model_observation_number}"
+                    )
+            else:
+                raise Exception(
+                    f"The agent id: {agent_id} is not in the specified agent IDs"
+                )
+
         # Agent checkpoint directories contains the specified model directories for the
         # specified agents
         agent_checkpoint_directories = custom_checkpoint_directories

--- a/ultra/ultra/evaluate.py
+++ b/ultra/ultra/evaluate.py
@@ -322,19 +322,6 @@ def evaluate_saved_models(
         # specified agents
         agent_checkpoint_directories = custom_checkpoint_directories
 
-    # TODO : Discuss with ULTRA team if it is still necessary to assert the length of models
-    # of all agents with the new structure
-    # Assert each agent ID has the same number of checkpoints saved.
-    # directories_iterator = iter(agent_checkpoint_directories.values())
-    # number_of_checkpoints = len(next(directories_iterator))
-    # assert all(
-    #     len(checkpoint_directory) == number_of_checkpoints
-    #     for checkpoint_directory in directories_iterator
-    # ), "Not all agents have the same number of checkpoints saved"
-
-    # Define an 'etag' for this experiment's data directory based off policy_classes.
-    # E.g. From a {"000": "ultra.baselines.dqn:dqn-v0", "001": "ultra.baselines.ppo:ppo-v0"]
-    # policy_classes dict, transform it to an etag of "dqn-v0:ppo-v0-evaluation".
     etag = (
         ":".join([policy_classes[agent_id].split(":")[-1] for agent_id in agent_ids])
         + "-evaluation"

--- a/ultra/ultra/evaluate.py
+++ b/ultra/ultra/evaluate.py
@@ -392,7 +392,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--agents",
         nargs="+",
-        help="Agents to evaluate",
+        help="Agent IDs to evaluate",
         default=None,
     )
     parser.add_argument(

--- a/ultra/ultra/tune.py
+++ b/ultra/ultra/tune.py
@@ -241,9 +241,7 @@ def _perform_evaluation_on_best(
     evaluation_experiment_dir = glob.glob(
         os.path.join(best_log_dir, args.log_dir, "*/")
     )[0]
-    evaluation_models_dir = glob.glob(
-        os.path.join(evaluation_experiment_dir, "models/*/")
-    )
+    agents = os.listdir(os.path.join(evaluation_experiment_dir, "models"))
 
     print(f"Evaluating the best performing trial ({best_trial}).")
     evaluate_saved_models(
@@ -251,7 +249,7 @@ def _perform_evaluation_on_best(
         log_dir=evaluation_results_dir,
         headless=headless,
         max_episode_steps=max_episode_steps,
-        model_paths=evaluation_models_dir,
+        agents=agents,
         num_episodes=num_episodes,
         scenario_info=scenario_info,
         timestep=timestep,


### PR DESCRIPTION
Motive: Evaluate an explicit model rather than evaluating all possible models, as previously implemented inside of `evaluate.py`.

- [x] Remove the `models` flag which was previously used to check for compatibility of models and retrieving the agent ids
- [x] Use the `experiment-dir` flag instead to fulfil the purpose of the `models` flag
https://github.com/huawei-noah/SMARTS/blob/a5d204c2b3276a4ea7c3116c3d5e5fc3779f519b/ultra/ultra/evaluate.py#L257-L258
- [x] Add `agents` flag to state which agent(s) is/are to be evaluated. Currently only one agent is able to be evaluated at a time, more investigation is needed
- [x] Add `models-to-evaluate` flag to clarify which agent's model (e.g. `000/12345` -> `<agent-id>/<model_name>`) that you want to evaluate, if no value is set then all models of that agent will be evaluated
- [x] Construct a logic structure to extract the `agent_checkpoint_directories` if an explicit model is given (i.e. `models-to-evaluate != None`). The `agent_checkpoint_directories` is a dictionary where the keys represent the agent ids and the values are a list of the agent's (key's) checkpoint (model) directories.
- [x] Need to update the `evaluate_saved_models` call inside of `ultra/tune.py`