### PR TITLE
Add flag to disable mission shuffling when generating scenarios in ULTRA

### DIFF
--- a/ultra/docs/multiagent.md
+++ b/ultra/docs/multiagent.md
@@ -44,7 +44,7 @@ The following steps will show how to create a multi-agent task with 4 agents.
              percent: 1.0  # 100% of these scenarios will be 2 lane, c-intersections.
              specs: [[50kmh,low-density,0.34],[70kmh,low-density,0.33],[100kmh,low-density,0.33]]
    ```
-   > This will create a task consisting of 12 scenarios (10 training, 2 testing). Each scenario supports 4 agents, and missions are shuffled so that agents do different missions in different training scenarios. Each agent will be tested separately, attempting to perform a left-turn from the South lane to the West lane in low-density traffic of various speeds.
+   > This will create a task consisting of 12 scenarios (10 training, 2 testing). Each scenario supports 4 agents, and missions are shuffled by default so that agents do different missions in different training scenarios. To not shuffle the missions, include the `--no-mission-shuffle` flag when generating the scenarios. Each agent will be tested separately, attempting to perform a left-turn from the South lane to the West lane in low-density traffic of various speeds.
 3. Add your task to `ultra/config.yaml`:
    ```yaml
      task0-4agents:  # The name of the task.

--- a/ultra/tests/scenarios/task00-multiagent/config.yaml
+++ b/ultra/tests/scenarios/task00-multiagent/config.yaml
@@ -111,3 +111,30 @@ levels:
                   [50kmh,high-density,0.01],[70kmh,high-density,0.01],[100kmh,high-density,0.01]] # 3%
           stops: null
           bubbles: null
+  shuffle_test:
+    train:
+      total: 20
+      ego_missions:
+      - start: south-SN  # Turn left going from South to West.
+        end:   west-EW
+      - start: west-WE   # Turn right going from West to South.
+        end:   south-NS
+      - start: east-EW   # Turn left going from East to South.
+        end:   south-NS
+      intersection_types:
+        2lane_t:
+           percent: 1
+           specs: [[70kmh,no-traffic,1]]
+           stops: null
+           bubbles: null
+    test:
+      total: 1
+      ego_missions:
+      - start: south-SN  # Turn left going from South to West.
+        end:   west-EW
+      intersection_types:
+        2lane_t:
+           percent: 1
+           specs: [[70kmh,no-traffic,1]]
+           stops: null
+           bubbles: null

--- a/ultra/tests/test_scenarios.py
+++ b/ultra/tests/test_scenarios.py
@@ -155,14 +155,16 @@ class ScenariosTest(unittest.TestCase):
         num_scenario_missions_that_differ = 0
 
         for dirpath, _, files in os.walk(SAVE_DIR):
+            # Testing scenarios only contain one mission, therefore there is no need to
+            # test if they are shuffled. Only test the training scenarios.
             if "missions.pkl" in files and "train" in dirpath:
                 with open(os.path.join(dirpath, "missions.pkl"), "rb") as missions_file:
                     missions = pickle.load(missions_file)
                 if not first_missions:
                     first_missions = missions
                 # Check to see if this current scenario's missions are in a different
-                # order as the first scenario's missions. That is, that either the start
-                # or end lanes are different.
+                # order as the first scenario's missions. Check equality of missions by
+                # checking that their start and end lanes are the same.
                 self.assertTrue(len(missions) == len(first_missions))
                 for mission, first_mission in zip(missions, first_missions):
                     if (
@@ -207,14 +209,16 @@ class ScenariosTest(unittest.TestCase):
         first_missions = None
 
         for dirpath, _, files in os.walk(SAVE_DIR):
+            # Testing scenarios only contain one mission, therefore there is no need to
+            # test if they are shuffled. Only test the training scenarios.
             if "missions.pkl" in files and "train" in dirpath:
                 with open(os.path.join(dirpath, "missions.pkl"), "rb") as missions_file:
                     missions = pickle.load(missions_file)
                 if not first_missions:
                     first_missions = missions
                 # Ensure that this current scenario's missions are in the same order as
-                # the first scenario's missions. That is, that their start and end lanes
-                # are the same.
+                # the first scenario's missions. Check equality of missions by checking
+                # that their start and end lanes are the same.
                 self.assertTrue(len(missions) == len(first_missions))
                 for mission, first_mission in zip(missions, first_missions):
                     self.assertEqual(

--- a/ultra/tests/test_scenarios.py
+++ b/ultra/tests/test_scenarios.py
@@ -144,7 +144,7 @@ class ScenariosTest(unittest.TestCase):
             f"--save-dir {SAVE_DIR}"
         )
 
-        # Test generation without the --no-shuffle flag.
+        # Test generation without the --no-mission-shuffle flag.
         try:
             os.system(generate_command)
         except Exception as error:
@@ -199,7 +199,7 @@ class ScenariosTest(unittest.TestCase):
             f"--save-dir {SAVE_DIR}"
         )
 
-        # Test generation with the --no-shuffle flag.
+        # Test generation with the --no-mission-shuffle flag.
         try:
             os.system(generate_command)
         except Exception as error:

--- a/ultra/ultra/scenarios/generate_scenarios.py
+++ b/ultra/ultra/scenarios/generate_scenarios.py
@@ -320,6 +320,7 @@ def generate_stopwatcher(
 
 def generate_left_turn_missions(
     missions,
+    shuffle_missions,
     route_distributions,
     route_lanes,
     speed,
@@ -464,7 +465,8 @@ def generate_left_turn_missions(
             for ego_route in ego_routes
         ]
     # Shuffle the missions so agents don't do the same route all the time.
-    random.shuffle(mission_objects)
+    if shuffle_missions:
+        random.shuffle(mission_objects)
     gen_missions(scenario, mission_objects)
 
     if bubbles:
@@ -637,6 +639,7 @@ def generate_social_vehicles(
 def scenario_worker(
     seeds,
     ego_missions,
+    shuffle_missions,
     route_lanes,
     route_distributions,
     map_dir,
@@ -660,6 +663,7 @@ def scenario_worker(
 
         generate_left_turn_missions(
             missions=ego_missions,
+            shuffle_missions=shuffle_missions,
             route_lanes=route_lanes,
             route_distributions=route_distributions,
             map_dir=map_dir,
@@ -686,6 +690,7 @@ def build_scenarios(
     stopwatcher_route,
     save_dir,
     root_path,
+    shuffle_missions=True,
     pool_dir=None,
     dynamic_pattern_func=None,
 ):
@@ -783,6 +788,7 @@ def build_scenarios(
                     args=(
                         temp_seeds,
                         ego_missions,
+                        shuffle_missions,
                         route_lanes,
                         route_distributions,
                         map_dir,
@@ -832,6 +838,11 @@ if __name__ == "__main__":
     parser.add_argument(
         "--root-dir", help="directory of maps", type=str, default="ultra/scenarios"
     )
+    parser.add_argument(
+        "--no-mission-shuffle",
+        help="Do not shuffle ego missions.",
+        action="store_false",
+    )
 
     args = parser.parse_args()
 
@@ -847,4 +858,5 @@ if __name__ == "__main__":
         stopwatcher_route=stopwatcher_route,
         save_dir=args.save_dir,
         root_path=args.root_dir,
+        shuffle_missions=args.no_mission_shuffle,
     )

--- a/ultra/ultra/scenarios/interface.py
+++ b/ultra/ultra/scenarios/interface.py
@@ -73,6 +73,11 @@ if __name__ == "__main__":
         help="aggressive/default/slow/blocker/crusher south-west",
         nargs="+",
     )
+    parser_generate_scenarios.add_argument(
+        "--no-mission-shuffle",
+        help="Do not shuffle ego missions.",
+        action="store_false",
+    )
 
     parser_generate_scenarios.set_defaults(which="generate")
 
@@ -140,6 +145,7 @@ if __name__ == "__main__":
             save_dir=args.save_dir,
             root_path=args.root_dir,
             pool_dir=args.pool_dir,
+            shuffle_missions=args.no_mission_shuffle,
         )
     else:
         ray.init()


### PR DESCRIPTION
By default, mission shuffling is still done when creating scenarios. However, the `--no-mission-shuffle` flag is now added so that scenarios without shuffled missions can be generated.