### PR TITLE
ULTRA Migrate from step-based to episode-based sampling

### DIFF
--- a/ultra/tests/test_evaluate.py
+++ b/ultra/tests/test_evaluate.py
@@ -363,7 +363,7 @@ class EvaluateTest(unittest.TestCase):
         # do, then the evaluation training data is properly saved under the results.pkl
         # and also correctly added to the tensorboard
         for index in evaluation_training_results[AGENT_ID].keys():
-            self.assertFalse((index) % eval_rate)
+            self.assertEqual((index) % eval_rate, 0)
 
     def test_extract_policy_from_path(self):
         paths = [

--- a/ultra/tests/test_evaluate.py
+++ b/ultra/tests/test_evaluate.py
@@ -313,6 +313,58 @@ class EvaluateTest(unittest.TestCase):
             print(err)
             self.assertTrue(False)
 
+    def test_record_evaluation_at_proper_episode_indices(self):
+        """Due to parallelization, there might arise a situation where the episode
+        object at the beginning of an evaluation would not match the episode
+        object when recording to tensorboard. This test ensures that the evaluation data
+        (for both test and train scenarios) is recorded at the proper episode index.
+        """
+        AGENT_ID = "000"
+        log_dir = os.path.join(
+            EvaluateTest.OUTPUT_DIRECTORY, "output_eval_episode_check_log/"
+        )
+
+        # Arbitary values for evaluation rate and number of training episodes
+        eval_rate = 4
+        num_episodes = 20
+
+        train_command = (
+            "python ultra/train.py "
+            f"--task 00 --level eval_test --policy sac --headless --episodes {num_episodes} "
+            f"--eval-rate {eval_rate} --eval-episodes 2 --max-episode-steps 2 --log-dir {log_dir}"
+        )
+
+        if not os.path.exists(log_dir):
+            os.system(train_command)
+
+        with open(
+            os.path.join(
+                log_dir, os.listdir(log_dir)[0], "pkls/Evaluation/results.pkl"
+            ),
+            "rb",
+        ) as handle:
+            evaluation_results = dill.load(handle)
+
+        # Check if the episode indices are divisible by the evaluation rate. If they
+        # do, then the evaluation data is properly saved under the results.pkl
+        # and also correctly added to the tensorboard
+        for index in evaluation_results[AGENT_ID].keys():
+            self.assertFalse((index) % eval_rate)
+
+        with open(
+            os.path.join(
+                log_dir, os.listdir(log_dir)[0], "pkls/Evaluation_Training/results.pkl"
+            ),
+            "rb",
+        ) as handle:
+            evaluation_training_results = dill.load(handle)
+
+        # Check if the episode indices are divisible by the evaluation rate. If they
+        # do, then the evaluation training data is properly saved under the results.pkl
+        # and also correctly added to the tensorboard
+        for index in evaluation_training_results[AGENT_ID].keys():
+            self.assertFalse((index) % eval_rate)
+
     def test_extract_policy_from_path(self):
         paths = [
             "from.ultra.baselines.sac:sac-v0",

--- a/ultra/tests/test_evaluate.py
+++ b/ultra/tests/test_evaluate.py
@@ -349,7 +349,7 @@ class EvaluateTest(unittest.TestCase):
         # do, then the evaluation data is properly saved under the results.pkl
         # and also correctly added to the tensorboard
         for index in evaluation_results[AGENT_ID].keys():
-            self.assertFalse((index) % eval_rate)
+            self.assertEqual((index) % eval_rate, 0)
 
         with open(
             os.path.join(

--- a/ultra/ultra/evaluate.py
+++ b/ultra/ultra/evaluate.py
@@ -73,9 +73,7 @@ def evaluation_check(
 
     for agent_id in agent_ids_to_evaluate:
         # Get the checkpoint directory for the current agent and save its model.
-        checkpoint_directory = episode.checkpoint_dir(
-            agent_id, episode.index
-        )
+        checkpoint_directory = episode.checkpoint_dir(agent_id, episode.index)
         agents[agent_id].save(checkpoint_directory)
 
         evaluation_train_task_id = evaluate.remote(

--- a/ultra/ultra/evaluate.py
+++ b/ultra/ultra/evaluate.py
@@ -74,7 +74,7 @@ def evaluation_check(
     for agent_id in agent_ids_to_evaluate:
         # Get the checkpoint directory for the current agent and save its model.
         checkpoint_directory = episode.checkpoint_dir(
-            agent_id, episode.get_itr(agent_id)
+            agent_id, episode.index
         )
         agents[agent_id].save(checkpoint_directory)
 
@@ -138,7 +138,9 @@ def collect_evaluations(evaluation_task_ids: dict):
             episode.eval_train_mode()
 
         episode.info[episode.active_tag] = ray.get(ready_evaluation_task_id)
-        episode.record_tensorboard(recording_step=agent_iteration)
+        episode.record_tensorboard(
+            recording_step=episode.index
+        )  # Record evaluation episodically
         episode.train_mode()
 
     return len(evaluation_task_ids) > 0
@@ -338,7 +340,7 @@ def evaluate_saved_models(
                     )
                 ]
             )[0]
-            episode.record_tensorboard()
+            episode.record_tensorboard(recording_step=1)
             episode.eval_count += 1
     finally:
         time.sleep(1)

--- a/ultra/ultra/evaluate.py
+++ b/ultra/ultra/evaluate.py
@@ -338,7 +338,7 @@ def evaluate_saved_models(
                     )
                 ]
             )[0]
-            episode.record_tensorboard(recording_step=1)
+            episode.record_tensorboard(recording_step=episode.index)
             episode.eval_count += 1
     finally:
         time.sleep(1)

--- a/ultra/ultra/train.py
+++ b/ultra/ultra/train.py
@@ -189,7 +189,7 @@ def train(
             observations = next_observations
 
         episode.record_episode()
-        episode.record_tensorboard()
+        episode.record_tensorboard(recording_step=episode.index)
 
         if finished:
             break

--- a/ultra/ultra/tune.py
+++ b/ultra/ultra/tune.py
@@ -188,7 +188,7 @@ def tune_train(
 
         # Normalize the data and record this episode on tensorboard.
         episode.record_episode()
-        episode.record_tensorboard()
+        episode.record_tensorboard(recording_step=episode.index)
 
         # Save the agent if we have reached its save rate.
         if (episode.index + 1) % save_rate == 0:

--- a/ultra/ultra/utils/episode.py
+++ b/ultra/ultra/utils/episode.py
@@ -281,7 +281,9 @@ class Episode:
         self.initialize_tb_writer()
 
         for agent_id, agent_info in self.info[self.active_tag].items():
-            agent_itr = recording_step if recording_step else self.get_itr(agent_id)
+            agent_itr = (
+                recording_step if recording_step is not None else self.get_itr(agent_id)
+            )
             data = {}
 
             for key, value in agent_info.data.items():


### PR DESCRIPTION
Addressing Issue: #928

- [x] Sample data episodically in `train.py` and `tune.py`
- [x] Save checkpoint directory in terms of episode index
- [x] Add an unit test inside of `test_evaluate.py` to make sure that the evaluation data is recorded at proper episode indices