### PR TITLE
ULTRA Run tests in forked subprocesses

### DIFF
--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -45,7 +45,7 @@ jobs:
           --ignore=./tests/test_rllib_train.py \
           --ignore=./tests/test_tune.py \
           --ignore=./tests/test_train.py \
-          --ignore=./tests/test_evaluate.py \
+          --ignore=./tests/test_evaluate.py
           pytest -v \
           ./tests/test_train.py \
           --forked \

--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -44,7 +44,7 @@ jobs:
           --ignore=./tests/test_social_vehicles.py \
           --ignore=./tests/test_rllib_train.py \
           --ignore=./tests/test_tune.py \
-          --ignore=./tests/test_train.py \
+          --ignore=./tests/test_train.py
           pytest -v \
           ./tests/test_train.py \
           --forked \

--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -48,9 +48,6 @@ jobs:
           --ignore=./tests/test_evaluate.py
           pytest -v \
           ./tests/test_train.py \
-          --forked \
-          --durations=0
-          pytest -v \
           ./tests/test_evaluate.py \
           --forked \
           --durations=0

--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -45,10 +45,15 @@ jobs:
           --ignore=./tests/test_rllib_train.py \
           --ignore=./tests/test_tune.py \
           --ignore=./tests/test_train.py
+          --ignore=./tests/test_evaluate.py
           pytest -v \
           ./tests/test_train.py \
           --forked \
-          --durations=0 \
+          --durations=0
+          pytest -v \
+          ./tests/test_evaluate.py \
+          --forked \
+          --durations=0
 
   test-light-base-tests:
     runs-on: ubuntu-18.04

--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -44,6 +44,11 @@ jobs:
           --ignore=./tests/test_social_vehicles.py \
           --ignore=./tests/test_rllib_train.py \
           --ignore=./tests/test_tune.py \
+          --ignore=./tests/test_train.py \
+          pytest -v \
+          ./tests/test_train.py \
+          --forked \
+          --durations=0 \
 
   test-light-base-tests:
     runs-on: ubuntu-18.04

--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -44,8 +44,8 @@ jobs:
           --ignore=./tests/test_social_vehicles.py \
           --ignore=./tests/test_rllib_train.py \
           --ignore=./tests/test_tune.py \
-          --ignore=./tests/test_train.py
-          --ignore=./tests/test_evaluate.py
+          --ignore=./tests/test_train.py \
+          --ignore=./tests/test_evaluate.py \
           pytest -v \
           ./tests/test_train.py \
           --forked \

--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -46,6 +46,11 @@ jobs:
           --ignore=./tests/test_tune.py \
           --ignore=./tests/test_train.py \
           --ignore=./tests/test_evaluate.py
+          # To prevent segementation faults and/or termination
+          # signals (i.e. SIGABRT), the train and evaluate tests
+          # are forked into separate subprocesses. Hence, the
+          # heavy tests are divided up into two parts (forked
+          # and unforked)
           pytest -v \
           ./tests/test_train.py \
           ./tests/test_evaluate.py \


### PR DESCRIPTION
Fork unit tests inside of `test_evaluate.py` and `test_train.py` to prevent segmentation faults and other termination signal (i.e. SIGABRT)