### PR TITLE
Say which tests are run in ULTRA CI tests rather than use `--ignore`

### DIFF
--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -29,33 +29,21 @@ jobs:
           pip install --upgrade -e .
           pip install --upgrade numpy
       - name: Run ultra tests (heavy)
+        # To prevent segmentation faults and/or termination signals (i.e. SIGABRT), the
+        # train and evaluate tests are forked into separate subprocesses. Hence, the
+        # heavy tests are divided up into two parts (forked and unforked).
         run: |
           cd ultra
           . .venv/bin/activate
           scl scenario build-all ultra/scenarios/pool
           pytest -v \
-          ./tests/ \
           --durations=0 \
-          --ignore=./tests/test_ultra_package.py \
-          --ignore=./tests/test_adapter.py \
-          --ignore=./tests/test_env.py \
-          --ignore=./tests/test_episodes.py \
-          --ignore=./tests/test_scenarios.py \
-          --ignore=./tests/test_social_vehicles.py \
-          --ignore=./tests/test_rllib_train.py \
-          --ignore=./tests/test_tune.py \
-          --ignore=./tests/test_train.py \
-          --ignore=./tests/test_evaluate.py
-          # To prevent segementation faults and/or termination
-          # signals (i.e. SIGABRT), the train and evaluate tests
-          # are forked into separate subprocesses. Hence, the
-          # heavy tests are divided up into two parts (forked
-          # and unforked)
+          ./tests/test_analysys.py
           pytest -v \
-          ./tests/test_train.py \
-          ./tests/test_evaluate.py \
+          --durations=0 \
           --forked \
-          --durations=0
+          ./tests/test_train.py \
+          ./tests/test_evaluate.py
 
   test-light-base-tests:
     runs-on: ubuntu-18.04
@@ -88,12 +76,14 @@ jobs:
           . .venv/bin/activate
           scl scenario build-all ultra/scenarios/pool
           pytest -v \
-          ./tests/ \
           --durations=0 \
-          --ignore=./tests/test_ultra_package.py \
-          --ignore=./tests/test_train.py \
-          --ignore=./tests/test_evaluate.py \
-          --ignore=./tests/test_analysis.py \
+          ./tests/test_adapter.py \
+          ./tests/test_env.py \
+          ./tests/test_episode.py \
+          ./tests/test_rllib_train.py \
+          ./tests/test_scenarios.py \
+          ./tests/test_social_vehicles.py \
+          ./tests/test_tune.py
 
   test-package-via-setup:
     runs-on: ubuntu-18.04

--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -38,7 +38,7 @@ jobs:
           scl scenario build-all ultra/scenarios/pool
           pytest -v \
           --durations=0 \
-          ./tests/test_analysys.py
+          ./tests/test_analysis.py
           pytest -v \
           --durations=0 \
           --forked \


### PR DESCRIPTION
Before, it was hard to determine which tests were part of the `test-heavy-base-tests` and `test-light-base-tests` jobs because the `pytest` command used to run the jobs only included the tests that would be ignored.

This change makes it easier to see which tests are run in the two ULTRA CI jobs.