### PR TITLE
Add frame stacking to ULTRA

### DIFF
--- a/ultra/docs/adapters.md
+++ b/ultra/docs/adapters.md
@@ -125,21 +125,20 @@ parameter to be `RGB(width=64, height=64, resolution=(50 / 64))`. This requireme
 outlined in this module's `required_interface`.
 
 This default image observation adapter produces a NumPy array of type `float32` and with
-shape `(1, 64, 64)`. Each element of the array is normalized to be in the range
+shape `(4, 64, 64)`. Each element of the array is normalized to be in the range
 `[0, 1]`. This observation space is outlined in this module's `gym_space`.
 
 This adapter receives an observation from the environment that contains a
 `smarts.core.sensors.TopDownRGB` instance in the observation. The `data` attribute of
-this class is a NumPy array of type `uint8` and shape `(64, 64, 3)`. The adapter
+this class is a NumPy array of type `uint8` and shape `(4, 64, 64, 3)`. The adapter
 converts this array to gray-scale by dotting it with `(0.1, 0.8, 0.1)`, resulting in the
 value of each gray-scale pixel to be a linear combination of the red (R), green (G), and
 blue (B) components of that pixel: `0.1 * R + 0.8 * G + 0.1 * B`. This gray-scale
 weighting was chosen to accentuate the differences in gray values between the ego
 vehicle, social vehicles, and the road. The gray-scale image is then normalized by
-dividing the array by `255.0`, and its 0th dimension is 'unsqueezed' to produce a
-3-dimensional array. The output is a NumPy array of type `float32` and with shape
-`(1, 64, 64)`. The behaviour of this adapter is fully defined in this module's `adapt`
-function.
+dividing the array by `255.0`. The output is a NumPy array of type `float32` and with
+shape `(4, 64, 64)`. The most recent frame is at the highest index of this array. The
+behaviour of this adapter is fully defined in this module's `adapt` function.
 
 ### [ultra.adapters.default_observation_vector_adapter](../ultra/adapters/default_observation_vector_adapter.py)
 

--- a/ultra/docs/ultra_environments.md
+++ b/ultra/docs/ultra_environments.md
@@ -1,0 +1,14 @@
+# ULTRA Environment
+
+ULTRA's Gym and RLlib environments inherit from SMARTS' `smarts.env.hiway_env.HiWayEnv`
+and `smarts.env.rllib_hiway_env.RLlibHiWayEnv` respectively. However, they differ in two
+ways:
+1. ULTRA's gym environment takes a `scenario_info` parameter that is used to specify a
+specific task and level that describe the type of scenarios the environment will use.
+2. ULTRA's gym environment performs automatic framestacking of certain parts of the
+environment observation it receives from SMARTS. Currently, if an agent has a
+`TopDownRGB` in its observation, the ULTRA environment will change the `data` attribute
+of this class to still be a NumPy array, but with shape
+`(_STACK_SIZE, HEIGHT, WIDTH, 3)` where `_STACK_SIZE` is the number of frames to stack
+(its value can be found in `ultra.env.ultra_env`), `HEIGHT` is the height of the RGB
+image, and `WIDTH` is the width of the RGB image.

--- a/ultra/docs/ultra_environments.md
+++ b/ultra/docs/ultra_environments.md
@@ -1,14 +1,20 @@
 # ULTRA Environment
 
 ULTRA's Gym and RLlib environments inherit from SMARTS' `smarts.env.hiway_env.HiWayEnv`
-and `smarts.env.rllib_hiway_env.RLlibHiWayEnv` respectively. However, they differ in two
-ways:
-1. ULTRA's gym environment takes a `scenario_info` parameter that is used to specify a
+and `smarts.env.rllib_hiway_env.RLlibHiWayEnv` respectively.
+
+ULTRA's Gym environment differs in two ways from SMARTS' HiWayEnv:
+1. ULTRA's Gym environment takes a `scenario_info` parameter that is used to specify a
 specific task and level that describe the type of scenarios the environment will use.
-2. ULTRA's gym environment performs automatic framestacking of certain parts of the
+2. ULTRA's Gym environment performs automatic framestacking of certain parts of the
 environment observation it receives from SMARTS. Currently, if an agent has a
 `TopDownRGB` in its observation, the ULTRA environment will change the `data` attribute
 of this class to still be a NumPy array, but with shape
 `(_STACK_SIZE, HEIGHT, WIDTH, 3)` where `_STACK_SIZE` is the number of frames to stack
 (its value can be found in `ultra.env.ultra_env`), `HEIGHT` is the height of the RGB
 image, and `WIDTH` is the width of the RGB image.
+
+ULTRA's RLlib environment differs in one way from SMARTS' RLlibHiWayEnv:
+1. ULTRA's RLlib environment takes a `scenario_info` key as part of its config. This
+`scenario_info` key is used to specify a specific task and level that describe the type
+of scenarios the environment will use.

--- a/ultra/tests/test_adapter.py
+++ b/ultra/tests/test_adapter.py
@@ -165,7 +165,7 @@ class AdapterTest(unittest.TestCase):
         self.assertIn(AGENT_ID, observations)
         self.assertIsInstance(observations[AGENT_ID], np.ndarray)
         self.assertEqual(observations[AGENT_ID].dtype, "float32")
-        self.assertEqual(observations[AGENT_ID].shape, (1, 64, 64))
+        self.assertEqual(observations[AGENT_ID].shape, (4, 64, 64))
         self.assertEqual(space.dtype, observations[AGENT_ID].dtype)
         self.assertEqual(space.shape, observations[AGENT_ID].shape)
         self.assertTrue(space.contains(observations[AGENT_ID]))

--- a/ultra/tests/test_env.py
+++ b/ultra/tests/test_env.py
@@ -120,15 +120,15 @@ class EnvTest(unittest.TestCase):
         )
 
         def check_environment_observations_stack(environment):
-            self.assertIsInstance(environment.observations_stack, deque)
+            self.assertIsInstance(environment.smarts_observations_stack, deque)
             self.assertEqual(
-                len(environment.observations_stack), ENVIRONMENT_STACK_SIZE
+                len(environment.smarts_observations_stack), ENVIRONMENT_STACK_SIZE
             )
-            self.assertIsInstance(environment.observations_stack[0], dict)
+            self.assertIsInstance(environment.smarts_observations_stack[0], dict)
             self.assertTrue(
                 all(
-                    str(environment.observations_stack[0]) == str(observations)
-                    for observations in environment.observations_stack
+                    str(environment.smarts_observations_stack[0]) == str(observations)
+                    for observations in environment.smarts_observations_stack
                 )
             )
 
@@ -138,7 +138,9 @@ class EnvTest(unittest.TestCase):
             self.assertIsInstance(observations[AGENT_ID].top_down_rgb, TopDownRGB)
             self.assertEqual(
                 observations[AGENT_ID].top_down_rgb.metadata,
-                environment.observations_stack[-1][AGENT_ID].top_down_rgb.metadata,
+                environment.smarts_observations_stack[-1][
+                    AGENT_ID
+                ].top_down_rgb.metadata,
             )
             self.assertEqual(
                 observations[AGENT_ID].top_down_rgb.data.shape,
@@ -153,7 +155,7 @@ class EnvTest(unittest.TestCase):
                         observations[AGENT_ID].top_down_rgb.data[i],
                     )
                     for i, observations_from_stack in enumerate(
-                        environment.observations_stack
+                        environment.smarts_observations_stack
                     )
                 )
             )

--- a/ultra/tests/test_env.py
+++ b/ultra/tests/test_env.py
@@ -19,11 +19,21 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
+from collections import deque
+from smarts.core.sensors import TopDownRGB
 import unittest
 
 import gym
+import numpy as np
 import ray
 
+from smarts.core.agent_interface import (
+    AgentInterface,
+    NeighborhoodVehicles,
+    RGB,
+    Waypoints,
+)
+from smarts.core.agent import Agent, AgentSpec
 from smarts.core.controllers import ActionSpaceType
 from smarts.zoo.registry import make
 from ultra.baselines.agent_spec import BaselineAgentSpec
@@ -82,9 +92,94 @@ class EnvTest(unittest.TestCase):
         ray.shutdown()
         self.assertTrue(timestep_sec1 == timestep_sec)
 
+    def test_observations_stacking(self):
+        EPISODES = 3
+        WIDTH = 64
+        HEIGHT = WIDTH
+        RESOLUTION = 50 / WIDTH
+        ENVIRONMENT_STACK_SIZE = 4
+
+        agent_spec = AgentSpec(
+            interface=AgentInterface(
+                waypoints=Waypoints(lookahead=1),
+                neighborhood_vehicles=NeighborhoodVehicles(radius=10.0),
+                rgb=RGB(width=WIDTH, height=HEIGHT, resolution=RESOLUTION),
+                action=ActionSpaceType.Lane,
+            ),
+            agent_builder=TestLaneAgent,
+        )
+        agent = agent_spec.build_agent()
+
+        environment = gym.make(
+            "ultra.env:ultra-v0",
+            agent_specs={AGENT_ID: agent_spec},
+            scenario_info=("00", "easy"),
+            headless=True,
+            timestep_sec=0.1,
+            seed=2,
+        )
+
+        def check_environment_observations_stack(environment):
+            self.assertIsInstance(environment.observations_stack, deque)
+            self.assertEqual(
+                len(environment.observations_stack), ENVIRONMENT_STACK_SIZE
+            )
+            self.assertIsInstance(environment.observations_stack[0], dict)
+            self.assertTrue(
+                all(
+                    str(environment.observations_stack[0]) == str(observations)
+                    for observations in environment.observations_stack
+                )
+            )
+
+        def check_stacked_observations(environment, observations):
+            self.assertIn(AGENT_ID, observations)
+            self.assertTrue(AGENT_ID, observations[AGENT_ID].top_down_rgb)
+            self.assertIsInstance(observations[AGENT_ID].top_down_rgb, TopDownRGB)
+            self.assertEqual(
+                observations[AGENT_ID].top_down_rgb.metadata,
+                environment.observations_stack[-1][AGENT_ID].top_down_rgb.metadata,
+            )
+            self.assertEqual(
+                observations[AGENT_ID].top_down_rgb.data.shape,
+                (ENVIRONMENT_STACK_SIZE, HEIGHT, WIDTH, 3),
+            )
+            # Ensure the stacked observation's TopDownRGB data is in the same order, and
+            # and contains the same NumPy arrays as the environment's observation stack.
+            self.assertTrue(
+                all(
+                    np.array_equal(
+                        observations_from_stack[AGENT_ID].top_down_rgb.data,
+                        observations[AGENT_ID].top_down_rgb.data[i],
+                    )
+                    for i, observations_from_stack in enumerate(
+                        environment.observations_stack
+                    )
+                )
+            )
+
+        for _ in range(EPISODES):
+            dones = {"__all__": False}
+            observations = environment.reset()
+
+            check_environment_observations_stack(environment)
+            check_stacked_observations(environment, observations)
+
+            while not dones["__all__"]:
+                action = agent.act(observations[AGENT_ID])
+                observations, _, dones, _ = environment.step({AGENT_ID: action})
+                check_stacked_observations(environment, observations)
+
+        environment.close()
+
 
 # other attributes are not set
 #'action_space', 'close', 'get_task', 'headless', 'info', 'metadata', 'observation_space', 'render', 'reset', 'reward_range', 'scenario_info', 'scenario_log', 'scenarios', 'seed', 'spec', 'step', 'timestep_sec', 'unwrapped'
+
+
+class TestLaneAgent(Agent):
+    def act(self, _):
+        return "keep_lane"
 
 
 def prepare_test_env_agent(headless=True):

--- a/ultra/ultra/adapters/default_observation_image_adapter.py
+++ b/ultra/ultra/adapters/default_observation_image_adapter.py
@@ -28,12 +28,13 @@ from smarts.core.sensors import Observation
 
 _WIDTH = 64
 _HEIGHT = 64
+_STACK = 4
 _RESOLUTION = 50 / 64
 
 
 # The space of the adapted observation.
 gym_space: gym.Space = gym.spaces.Box(
-    low=0.0, high=1.0, shape=(1, _HEIGHT, _WIDTH), dtype=np.float32
+    low=0.0, high=1.0, shape=(_STACK, _HEIGHT, _WIDTH), dtype=np.float32
 )
 # This adapter requires SMARTS to pass the top-down RGB image in the agent's
 # observation.
@@ -50,13 +51,18 @@ def adapt(observation: Observation) -> np.ndarray:
         observation (Observation): The raw environment observation received from SMARTS.
 
     Returns:
-        np.ndarray: A numpy.ndarray of size (1, _HEIGHT, _WIDTH) that is the gray-scale
-            image of the top-down RGB image. The gray-scale value for each pixel is
-            calculated as 0.1 * R + 0.8 * G + 0.1 * B, and each value is normalized to
-            be between 0 and 1 inclusive with type float32.
+        np.ndarray: A numpy.ndarray of size (_STACK, _HEIGHT, _WIDTH) that is the
+            gray-scale image of the top-down RGB image. The gray-scale value for each
+            pixel is calculated as 0.1 * R + 0.8 * G + 0.1 * B, and each value is
+            normalized to be between 0 and 1 inclusive with type float32.
     """
     rgb_image = observation.top_down_rgb.data
+
+    assert len(rgb_image.shape) == 4  # (stack size, height, width, RGB channels)
+    assert len(rgb_image) >= _STACK  # The given stack size must be >= _STACK.
+
     gray_image = np.dot(rgb_image, (0.1, 0.8, 0.1))
     gray_image = np.divide(gray_image, 255.0)
-    gray_image = np.expand_dims(gray_image, axis=0)
+    gray_image = gray_image[-_STACK:]  # Keep the _STACK most recent frames.
+
     return gray_image.astype(np.float32)

--- a/ultra/ultra/env/ultra_env.py
+++ b/ultra/ultra/env/ultra_env.py
@@ -126,11 +126,19 @@ class UltraEnv(HiWayEnv):
         return observations, rewards, agent_dones, infos
 
     def reset(self):
-        observations = super().reset()
+        scenario = next(self._scenarios_iterator)
+
+        self._dones_registered = 0
+        simulator_observations = self._smarts.reset(scenario)
 
         for _ in range(_STACK_SIZE):
-            self.observations_stack.append(copy.deepcopy(observations))
-        observations = self._stack_top_down_rgbs(observations)
+            self.observations_stack.append(copy.deepcopy(simulator_observations))
+        observations = self._stack_top_down_rgbs(simulator_observations)
+
+        observations = {
+            agent_id: self._agent_specs[agent_id].observation_adapter(obs)
+            for agent_id, obs in simulator_observations.items()
+        }
 
         return observations
 

--- a/ultra/ultra/env/ultra_env.py
+++ b/ultra/ultra/env/ultra_env.py
@@ -19,22 +19,29 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
+from collections import deque
+import copy
 import glob
 import math
 import os
 from itertools import cycle
 from sys import path
+from typing import Dict
 
 import numpy as np
 import yaml, inspect
 from scipy.spatial import distance
 
 from smarts.core.scenario import Scenario
+from smarts.core.sensors import Observation, TopDownRGB
 from smarts.env.hiway_env import HiWayEnv
 import ultra.adapters as adapters
 from ultra.baselines.common.yaml_loader import load_yaml
 
 path.append("./ultra")
+
+
+_STACK_SIZE = 4
 
 
 class UltraEnv(HiWayEnv):
@@ -56,6 +63,8 @@ class UltraEnv(HiWayEnv):
             _scenarios = glob.glob(f"{self.scenarios['train']}")
         else:
             _scenarios = glob.glob(f"{self.scenarios['test']}")
+
+        self.observations_stack = deque(maxlen=_STACK_SIZE)
 
         super().__init__(
             scenarios=_scenarios,
@@ -90,6 +99,10 @@ class UltraEnv(HiWayEnv):
 
         observations, rewards, agent_dones, extras = self._smarts.step(agent_actions)
 
+        # TODO: Stack observations here that need to be stacked.
+        self.observations_stack.append(copy.deepcopy(observations))
+        observations = self._stack_top_down_rgbs(observations)
+
         infos = {
             agent_id: {"score": value, "env_obs": observations[agent_id]}
             for agent_id, value in extras["scores"].items()
@@ -112,6 +125,15 @@ class UltraEnv(HiWayEnv):
 
         return observations, rewards, agent_dones, infos
 
+    def reset(self):
+        observations = super().reset()
+
+        for _ in range(_STACK_SIZE):
+            self.observations_stack.append(copy.deepcopy(observations))
+        observations = self._stack_top_down_rgbs(observations)
+
+        return observations
+
     def get_task(self, task_id, task_level):
         base_dir = os.path.join(os.path.dirname(__file__), "../")
         config_path = os.path.join(base_dir, "config.yaml")
@@ -131,3 +153,65 @@ class UltraEnv(HiWayEnv):
             "timestep_sec": self.timestep_sec,
             "headless": self.headless,
         }
+
+    # TODO: Should this return an observation or mutate the given observation?
+    def _stack_top_down_rgbs(
+        self, current_observations: Dict[str, Observation]
+    ) -> Observation:
+        """For every observation in current_observations with a non-None top_down_rgb
+        attribute, this method replaces the TopDownRGB attribute of the observation with
+        a TopDownRGB instance whose data attribute is a NumPy array of stacked
+        TopDownRGB data of the current observation and previous observations.
+
+        For each agent with an observation, if they have a TopDownRGB in their
+        observation, stack the data of the TopDownRGB with previous TopDownRGB data in
+        the observations stack. If the agent does not have previous TopDownRGB data in
+        the observations stack, copy the current TopDownRGB data to fill the stack.
+
+        Note: This method expects that current_observations is in
+            self.stacked_observations as the rightmost element.
+
+        Note: This can be extended to stack other parts of the observations such as the
+            drivable area grid map, lidar, occupancy grid map, etc.
+
+        Note: This has not been tested with a multi-agent scenario.
+
+        Note: This is like an environment observation adapter.
+
+        Example:
+            For a 64x64 TopDownRGB image received from SMARTS, the data component of the
+            TopDownRGB is a NumPy array with shape (64, 64, 3). Stack this current data
+            with data from the previous observations to make the current TopDownRGB data
+            to be an array with shape (_STACK_SIZE, 64, 64, 3).
+
+        Args:
+            current_observation (Observation): The environment observation.
+
+        Returns:
+            Observation: The environment observation with stacked TopDownRGB data.
+        """
+        for agent_id, current_observation in current_observations.items():
+            if current_observation.top_down_rgb:
+                # This agent's observation contains a TopDownRGB, stack its data.
+                current_top_down_rgb = current_observation.top_down_rgb
+
+                top_down_rgb_data = []
+                for observations in self.observations_stack:
+                    if agent_id in observations:
+                        top_down_rgb_data.append(
+                            observations[agent_id].top_down_rgb.data
+                        )
+                    else:
+                        # Use the current observation's TopDownRGB data if this agent
+                        # doesn't have previous observations to use to build the stack.
+                        top_down_rgb_data.append(current_top_down_rgb.data)
+                stacked_top_down_rgb_data = np.stack(top_down_rgb_data)
+
+                # Create the new TopDownRGB with stacked data.
+                stacked_top_down_rgb = TopDownRGB(
+                    metadata=current_top_down_rgb.metadata,
+                    data=stacked_top_down_rgb_data,
+                )
+
+                current_observations[agent_id].top_down_rgb = stacked_top_down_rgb
+        return current_observations

--- a/ultra/ultra/rllib_train.py
+++ b/ultra/ultra/rllib_train.py
@@ -83,6 +83,9 @@ def train(
             f"{adapters.AdapterType.DefaultActionContinuous} action type."
         )
     if observation_type != adapters.AdapterType.DefaultObservationVector:
+        # NOTE: The SMARTS observations adaptation that is done in ULTRA's Gym
+        #       environment is not done in ULTRA's RLlib environment. If other
+        #       observation adapters are used, they may raise an Exception.
         raise Exception(
             f"RLlib training only supports the "
             f"{adapters.AdapterType.DefaultObservationVector} observation type."


### PR DESCRIPTION
After considering many options, this may be the solution to go with for frame stacking in the ULTRA environment. It is not as extensible as using environment wrappers, however it provides the ability to add frame stacking to specific observations, and provides agents with consistently-sized observations (provided their observation adapter produces a consistently-sized observation).

Environment wrappers cannot be used in ULTRA without some major refactoring. It would require the baselines to be changed along with how training and evaluation use the environments.

Frame stacking could not be done in the agents either due to the agents having both `act` and `step` methods. There was no guarantee that the observation passed to `step` was the observation observed directly after the previous time `step` was called. This made not possible to keep track of a stack of observations within the agent.

Finally, the comment on #921 outlines reasons why frame stacking cannot be implemented in the SMARTS simulator to be used by agents that specify a stack size in their `AgentInterface`.

Currently, only `TopDownRGB` elements of the observation are stacked by changing the `data` attribute of this class. This can similarly be done for any other element of the observations that uses a NumPy array like the `DrivableAreaGridMap` and the `OccupancyGridMap`.

TODO
- [x] Mention differences between ULTRA's Gym and RLlib environments now
- [x] Address TODO in `ultra_env.py`
- [x] Trim docstring of stacking method in `ultra_env.py`
- [x] Rename stacking method in `ultra_env.py` to be more general
- [x] Pass CI tests