### PR TITLE
Fix display exception string to print the exception

### DIFF
--- a/smarts/core/renderer.py
+++ b/smarts/core/renderer.py
@@ -103,10 +103,11 @@ class _ShowBaseInstance(ShowBase):
         except Exception as e:
             # Known reasons for this failing:
             raise RendererException(
-                f"Error in initializing framework for opening graphical display and creating scene graph. "
-                "A typical reason is display not found. Try running with different configurations of "
-                "`export DISPLAY=` using `:0`, `:1`... . If this does not work please consult "
-                "the documentation.\nException was: {e}"
+                f"Error in initializing framework for opening graphical display and "
+                f"creating scene graph. A typical reason is display not found. Try "
+                f"running with different configurations of `export DISPLAY=` using "
+                f"`:0`, `:1`... . If this does not work please consult the "
+                f"documentation.\nException was: {e}"
             ) from e
 
     def destroy(self):


### PR DESCRIPTION
Previously, since the string containing the `{e}` was not an f-string, the `RendererException` was outputting "Exception was: {e}" rather than the actual exception.

These changes also make this string more readable by making each line in the `RendererException`'s argument an f-string, and by explicitly complying with Black's line length of 88 characters.