### PR TITLE
ULTRA refactor `ultra_env.py`

### DIFF
--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -78,10 +78,8 @@ jobs:
           pytest -v \
           --durations=0 \
           ./tests/test_adapter.py \
-          ./tests/test_env.py \
           ./tests/test_episode.py \
           ./tests/test_rllib_train.py \
-          ./tests/test_scenarios.py \
           ./tests/test_social_vehicles.py \
           ./tests/test_tune.py
           pytest -v \

--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -84,6 +84,11 @@ jobs:
           ./tests/test_scenarios.py \
           ./tests/test_social_vehicles.py \
           ./tests/test_tune.py
+          pytest -v \
+          --durations=0 \
+          --forked \
+          ./tests/test_env.py \
+          ./tests/test_scenarios.py
 
   test-package-via-setup:
     runs-on: ubuntu-18.04

--- a/ultra/ultra/env/ultra_env.py
+++ b/ultra/ultra/env/ultra_env.py
@@ -56,13 +56,14 @@ class UltraEnv(HiWayEnv):
         eval_mode=False,
         ordered_scenarios=False,
     ):
-        self.agent_specs = agent_specs
         self.scenario_info = scenario_info
         self.headless = headless
         self.timestep_sec = timestep_sec
         self.seed = seed
         self.eval_mode = eval_mode
-        self.ordered_scenarios = ordered_scenarios
+
+        agent_specs = agent_specs
+        ordered_scenarios = ordered_scenarios
 
         self.scenarios = self.get_scenarios(scenario_info)
 
@@ -157,7 +158,7 @@ class UltraEnv(HiWayEnv):
 
         Args:
             scenario_info Tuple[str, str]: The first index represents
-            task id and second index represents task's level
+                task id and second index represents task's level
 
         Returns:
             List[str]: Absolute path of scenarios

--- a/ultra/ultra/env/ultra_env.py
+++ b/ultra/ultra/env/ultra_env.py
@@ -128,12 +128,6 @@ class UltraEnv(HiWayEnv):
 
         return observations, rewards, agent_dones, infos
 
-<<<<<<< HEAD
-    def get_scenarios(self, scenario_info):
-        # scenario_info[0]: task, scenario_info[1]: level
-        task_id, task_level = scenario_info[0], scenario_info[1]
-        
-=======
     def reset(self):
         scenario = next(self._scenarios_iterator)
 
@@ -151,8 +145,10 @@ class UltraEnv(HiWayEnv):
 
         return observations
 
-    def get_task(self, task_id, task_level):
->>>>>>> 165f8fb45f131cb27de6f8b16ad6ad6845e4121b
+    def get_scenarios(self, scenario_info):
+        # scenario_info[0]: task, scenario_info[1]: level
+        task_id, task_level = scenario_info[0], scenario_info[1]
+        
         base_dir = os.path.join(os.path.dirname(__file__), "../")
         config_path = os.path.join(base_dir, _CONFIG_FILE)
 

--- a/ultra/ultra/env/ultra_env.py
+++ b/ultra/ultra/env/ultra_env.py
@@ -160,9 +160,9 @@ class UltraEnv(HiWayEnv):
         scenario_paths["test"] = os.path.join(base_dir, scenario_paths["test"])
 
         if not self.eval_mode:
-            _scenarios = glob.glob(f"{scenario_paths["train"]}")
+            _scenarios = glob.glob(f"{scenario_paths['train']}")
         else:
-            _scenarios = glob.glob(f"{scenario_paths["test"]}")
+            _scenarios = glob.glob(f"{scenario_paths['test']}")
 
         return _scenarios
 

--- a/ultra/ultra/env/ultra_env.py
+++ b/ultra/ultra/env/ultra_env.py
@@ -26,7 +26,7 @@ import math
 import os
 from itertools import cycle
 from sys import path
-from typing import Dict
+from typing import Dict, List, Tuple
 
 import numpy as np
 import yaml, inspect
@@ -145,8 +145,23 @@ class UltraEnv(HiWayEnv):
 
         return observations
 
-    def get_scenarios(self, scenario_info):
-        # scenario_info[0]: task, scenario_info[1]: level
+    def get_scenarios(self, scenario_info: Tuple[str, str]) -> List[str]:
+        """Finds all of the scenarios from the given scenario information
+
+        To obtain the path of scenarios:
+            1. Get the filename patterns of the train and test scenarios from
+               ultra/config.yaml from the given task and level.
+            2. Change the filename patterns from relative to absolute path
+            3. Depending on the evaluation mode, we can provide glob.glob with
+               the appropriate filename pattern to return a list of scenario dirs
+               
+        Args:
+            scenario_info Tuple[str, str]: The first index represents
+            task id and second index represents task's level
+        
+        Returns:
+            List[str]: Absolute path of scenarios
+        """
         task_id, task_level = scenario_info[0], scenario_info[1]
 
         base_dir = os.path.join(os.path.dirname(__file__), "../")

--- a/ultra/ultra/env/ultra_env.py
+++ b/ultra/ultra/env/ultra_env.py
@@ -65,12 +65,12 @@ class UltraEnv(HiWayEnv):
         agent_specs = agent_specs
         ordered_scenarios = ordered_scenarios
 
-        self.scenarios = self.get_scenarios(scenario_info)
+        scenarios = self.get_scenarios(scenario_info)
 
         self.smarts_observations_stack = deque(maxlen=_STACK_SIZE)
 
         super().__init__(
-            scenarios=self.scenarios,
+            scenarios=scenarios,
             agent_specs=agent_specs,
             headless=self.headless,
             timestep_sec=self.timestep_sec,

--- a/ultra/ultra/env/ultra_env.py
+++ b/ultra/ultra/env/ultra_env.py
@@ -71,7 +71,7 @@ class UltraEnv(HiWayEnv):
 
         super().__init__(
             scenarios=self.scenarios,
-            agent_specs=self.agent_specs,
+            agent_specs=agent_specs,
             headless=self.headless,
             timestep_sec=self.timestep_sec,
             seed=self.seed,

--- a/ultra/ultra/env/ultra_env.py
+++ b/ultra/ultra/env/ultra_env.py
@@ -154,11 +154,11 @@ class UltraEnv(HiWayEnv):
             2. Change the filename patterns from relative to absolute path
             3. Depending on the evaluation mode, we can provide glob.glob with
                the appropriate filename pattern to return a list of scenario dirs
-               
+
         Args:
             scenario_info Tuple[str, str]: The first index represents
             task id and second index represents task's level
-        
+
         Returns:
             List[str]: Absolute path of scenarios
         """

--- a/ultra/ultra/env/ultra_env.py
+++ b/ultra/ultra/env/ultra_env.py
@@ -148,7 +148,7 @@ class UltraEnv(HiWayEnv):
     def get_scenarios(self, scenario_info):
         # scenario_info[0]: task, scenario_info[1]: level
         task_id, task_level = scenario_info[0], scenario_info[1]
-        
+
         base_dir = os.path.join(os.path.dirname(__file__), "../")
         config_path = os.path.join(base_dir, _CONFIG_FILE)
 


### PR DESCRIPTION
The `ultra_env.py` needs a bit of refactoring:
- [x] Remove `get_tasks()` because the method name and its purpose do not compliment each other properly. Instead add a new method `get_scenarios()` which takes in the `scenario_info` tuple and returns a list of either all training or testing scenarios that corresponds to the specified task and level