### PR TITLE
ULTRA Sanity check on baselines

### DIFF
--- a/ultra/tests/test_baselines.py
+++ b/ultra/tests/test_baselines.py
@@ -1,0 +1,48 @@
+# MIT License
+#
+# Copyright (C) 2021. Huawei Technologies Co., Ltd. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+import unittest
+import os, shutil
+
+
+class BaselinesTest(unittest.TestCase):
+    # Put generated files and folders in this directory.
+    OUTPUT_DIRECTORY = "tests/baselines_test/"
+
+    def test_train_evaluate_baselines(self):
+        """Ensure that all baselines are trainable and testable. Evaluating
+        the baselines will test their save() and load() methods"""
+        BASELINES = ["bdqn", "dqn", "ppo", "sac", "td3"]
+        log_dir = os.path.join(BaselinesTest.OUTPUT_DIRECTORY, "logs/")
+        for baseline in BASELINES:
+            try:
+                os.system(
+                    f"python ultra/train.py --policy {baseline} --task 00 --level easy --episodes 1 --eval-episodes 2 "
+                    f"--max-episode-steps 2 --log-dir {log_dir} --headless"
+                )
+            except Exception as err:
+                print(err)
+                self.assertTrue(False)
+
+            if not os.path.exists(log_dir):
+                self.assertTrue(False)
+            else:
+                shutil.rmtree(log_dir)

--- a/ultra/tests/test_train.py
+++ b/ultra/tests/test_train.py
@@ -137,25 +137,6 @@ class TrainTest(unittest.TestCase):
             self.assertTrue(False)
             ray.shutdown()
 
-    def test_train_baselines(self):
-        """Ensure that all baselines are trainable"""
-        BASELINES = ["bdqn", "dqn", "ppo", "sac", "td3"]
-        log_dir = os.path.join(TrainTest.OUTPUT_DIRECTORY, "logs/")
-        for baseline in BASELINES:
-            try:
-                os.system(
-                    f"python ultra/train.py --policy {baseline} --task 00 --level easy --episodes 1 --eval-episodes 0 "
-                    f"--max-episode-steps 2 --log-dir {log_dir} --headless"
-                )
-            except Exception as err:
-                print(err)
-                self.assertTrue(False)
-
-            if not os.path.exists(log_dir):
-                self.assertTrue(False)
-            else:
-                shutil.rmtree(log_dir)
-
     def test_check_agents_from_pool(self):
         seed = 2
         policy = ""

--- a/ultra/tests/test_train.py
+++ b/ultra/tests/test_train.py
@@ -138,7 +138,7 @@ class TrainTest(unittest.TestCase):
             ray.shutdown()
 
     def test_train_baselines(self):
-        '''Ensure that all baselines are trainable'''
+        """Ensure that all baselines are trainable"""
         BASELINES = ["bdqn", "dqn", "ppo", "sac", "td3"]
         log_dir = os.path.join(TrainTest.OUTPUT_DIRECTORY, "logs/")
         for baseline in BASELINES:

--- a/ultra/tests/test_train.py
+++ b/ultra/tests/test_train.py
@@ -137,6 +137,25 @@ class TrainTest(unittest.TestCase):
             self.assertTrue(False)
             ray.shutdown()
 
+    def test_train_baselines(self):
+        '''Ensure that all baselines are trainable'''
+        BASELINES = ["bdqn", "dqn", "ppo", "sac", "td3"]
+        log_dir = os.path.join(TrainTest.OUTPUT_DIRECTORY, "logs/")
+        for baseline in BASELINES:
+            try:
+                os.system(
+                    f"python ultra/train.py --policy {baseline} --task 00 --level easy --episodes 1 --eval-episodes 0 "
+                    f"--max-episode-steps 2 --log-dir {log_dir} --headless"
+                )
+            except Exception as err:
+                print(err)
+                self.assertTrue(False)
+
+            if not os.path.exists(log_dir):
+                self.assertTrue(False)
+            else:
+                shutil.rmtree(log_dir)
+
     def test_check_agents_from_pool(self):
         seed = 2
         policy = ""


### PR DESCRIPTION
To ensure that all of the ultra baselines (bdqn, dqn, ppo, sac, td3) are working properly, we can run a end-to-end training run for each baseline. This way we can expose any run-time issues across all of the baselines, and not just the default (i.e is sac)

@christianjans Do you think of any others tests across all baselines which might expose any issues?