### PR TITLE
ULTRA Run light base tests in forked subprocesses

### DIFF
--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -77,6 +77,7 @@ jobs:
           scl scenario build-all ultra/scenarios/pool
           pytest -v \
           --durations=0 \
+          --forked \
           ./tests/test_adapter.py \
           ./tests/test_env.py \
           ./tests/test_episode.py \


### PR DESCRIPTION
To counter the problem in #966: The light base tests must be forked subprocesses to prevent resource issues, which in turns eliminates the unexpected termination signals and/or (seg faults).

Running the tests in forked subprocesses did not drastically increased the testing time (db4e4d0), which is a good thing 👍 😆  