### PR TITLE
ULTRA Allow scenarios to be directly added to the environment

### DIFF
--- a/ultra/docs/ultra_environments.md
+++ b/ultra/docs/ultra_environments.md
@@ -6,7 +6,11 @@ and `smarts.env.rllib_hiway_env.RLlibHiWayEnv` respectively.
 ULTRA's Gym environment differs in two ways from SMARTS' HiWayEnv:
 1. ULTRA's Gym environment takes a `scenario_info` parameter that is used to specify a
 specific task and level that describe the type of scenarios the environment will use.
-2. ULTRA's Gym environment performs automatic framestacking of certain parts of the
+2. ULTRA's Gym environment can also take a `scenarios` parameter to directly specified
+the scenarios in list to which the environment will use. **Note:** If the scenarios
+are specified by the `scenarios` parameter then the `scenario_info` parameter will be 
+ignored.
+3. ULTRA's Gym environment performs automatic framestacking of certain parts of the
 environment observation it receives from SMARTS. Currently, if an agent has a
 `TopDownRGB` in its observation, the ULTRA environment will change the `data` attribute
 of this class to still be a NumPy array, but with shape

--- a/ultra/ultra/env/ultra_env.py
+++ b/ultra/ultra/env/ultra_env.py
@@ -26,7 +26,7 @@ import math
 import os
 from itertools import cycle
 from sys import path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Sequence
 
 import numpy as np
 import yaml, inspect
@@ -53,6 +53,7 @@ class UltraEnv(HiWayEnv):
         headless,
         timestep_sec,
         seed,
+        scenarios: Sequence[str] = None,
         eval_mode=False,
         ordered_scenarios=False,
     ):
@@ -65,7 +66,8 @@ class UltraEnv(HiWayEnv):
         agent_specs = agent_specs
         ordered_scenarios = ordered_scenarios
 
-        scenarios = self.get_scenarios(scenario_info)
+        if not scenarios:
+            scenarios = self.get_scenarios(scenario_info)
 
         self.smarts_observations_stack = deque(maxlen=_STACK_SIZE)
 

--- a/ultra/ultra/train.py
+++ b/ultra/ultra/train.py
@@ -200,6 +200,7 @@ def train(
         "ultra.env:ultra-v0",
         agent_specs=agent_specs,
         scenario_info=scenario_info,
+        scenarios=scenarios,
         headless=headless,
         timestep_sec=timestep_sec,
         seed=seed,

--- a/ultra/ultra/train.py
+++ b/ultra/ultra/train.py
@@ -200,7 +200,6 @@ def train(
         "ultra.env:ultra-v0",
         agent_specs=agent_specs,
         scenario_info=scenario_info,
-        scenarios=scenarios,
         headless=headless,
         timestep_sec=timestep_sec,
         seed=seed,


### PR DESCRIPTION
Unlike SMARTS, ULTRA adopted the `scenario_info` technique to use the task and level to retrieve the scenarios that are needed for either training or evaluation (train and test scenarios respectively). This approach provides a structure in which we can simply use the task and level identification to add the scenarios to the environment. The more intuitive way would be to manually select the scenarios in sequence and then pass those scenarios to the environment. Therefore, as users we have additional control over specific scenarios that we want to train on, and we can freely store them in any directory that we want. 

However, at the end of both approaches will produce a list of scenarios paths that will ultimately be passed onto the smarts environment. 

A short summary of both approaches
1. `scenario_info` approach: Organizes the scenarios based on task and level, and also considers what scenarios to be used based on if the agent is being trained or evaluated
2. `scenarios` approach: Load in scenarios from external directories into a list and then bypass it through the smarts env using the ultra env 

Some considerations
- Do we want to include a flag (`--scenarios`) that will take in a list of scenarios from the CLI?
- The scenarios that are added manually will not be constrained to the evaluation mode (i.e. if testing scenarios are included during training, they will be implemented)