### PR TITLE
Use one argument to specify scenarios in ULTRA env

### DIFF
--- a/ultra/docs/ultra_environments.md
+++ b/ultra/docs/ultra_environments.md
@@ -6,7 +6,11 @@ and `smarts.env.rllib_hiway_env.RLlibHiWayEnv` respectively.
 ULTRA's Gym environment differs in two ways from SMARTS' HiWayEnv:
 1. ULTRA's Gym environment takes a `scenario_info` parameter that is used to specify a
 specific task and level that describe the type of scenarios the environment will use.
-2. ULTRA's Gym environment performs automatic framestacking of certain parts of the
+2. ULTRA's Gym environment can also take a `scenarios` parameter to directly specified
+the scenarios in list to which the environment will use. **Note:** If the scenarios
+are specified by the `scenarios` parameter then the `scenario_info` parameter will be 
+ignored.
+3. ULTRA's Gym environment performs automatic framestacking of certain parts of the
 environment observation it receives from SMARTS. Currently, if an agent has a
 `TopDownRGB` in its observation, the ULTRA environment will change the `data` attribute
 of this class to still be a NumPy array, but with shape

--- a/ultra/tests/test_env.py
+++ b/ultra/tests/test_env.py
@@ -20,7 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 from collections import deque
-from smarts.core.sensors import TopDownRGB
+import glob
+import pathlib
 import unittest
 
 import gym
@@ -35,8 +36,10 @@ from smarts.core.agent_interface import (
 )
 from smarts.core.agent import Agent, AgentSpec
 from smarts.core.controllers import ActionSpaceType
+from smarts.core.sensors import TopDownRGB
 from smarts.zoo.registry import make
 from ultra.baselines.agent_spec import BaselineAgentSpec
+from ultra.env.ultra_env import UltraEnv
 from ultra.baselines.ppo.ppo.policy import PPOPolicy
 
 AGENT_ID = "001"
@@ -78,6 +81,37 @@ class EnvTest(unittest.TestCase):
         ray.shutdown()
         self.assertTrue(scenarios[0] == prebuilt_scenario1)
         self.assertTrue(scenarios[1] == prebuilt_scenario2)
+
+    def test_get_scenarios_from_scenario_info(self):
+        TASK_LEVEL = ("00", "easy")
+        TASK_LEVEL_TRAIN_SCENARIOS = [
+            str(pathlib.Path(path).resolve())
+            for path in glob.glob("tests/task/train_task00*")
+        ]
+        TASK_LEVEL_TEST_SCENARIOS = [
+            str(pathlib.Path(path).resolve())
+            for path in glob.glob("tests/task/test_task00*")
+        ]
+        FAKE_SCENARIOS = ["folder/scenario_1", "folder/scenario_2", "folder/scenario_3"]
+
+        # Test using a valid (task, level) tuple for training scenarios.
+        scenarios = UltraEnv.get_scenarios_from_scenario_info(TASK_LEVEL, False)
+        for scenario in scenarios:
+            self.assertIn(scenario, TASK_LEVEL_TRAIN_SCENARIOS)
+            self.assertIn("train", str(scenario))
+
+        # Test using a valid (task, level) tuple for testing scenarios.
+        scenarios = UltraEnv.get_scenarios_from_scenario_info(TASK_LEVEL, True)
+        for scenario in scenarios:
+            self.assertIn(scenario, TASK_LEVEL_TEST_SCENARIOS)
+            self.assertIn("test", str(scenarios))
+
+        # Test using multiple sequences of scenario directories of varying length.
+        for num_scenarios in range(1, 4):
+            scenarios = FAKE_SCENARIOS[:num_scenarios]
+            scenarios = UltraEnv.get_scenarios_from_scenario_info(scenarios, False)
+            for scenario in scenarios:
+                self.assertIn(scenario, FAKE_SCENARIOS)
 
     def test_headless(self):
         @ray.remote(max_calls=1, num_gpus=0, num_cpus=1)

--- a/ultra/tests/test_env.py
+++ b/ultra/tests/test_env.py
@@ -93,7 +93,7 @@ class EnvTest(unittest.TestCase):
         # Test using multiple sequences of scenario directories of varying length.
         for num_scenarios in range(1, 4):
             scenarios = FAKE_SCENARIOS[:num_scenarios]
-            scenarios = UltraEnv.get_scenarios_from_scenario_info(scenarios, False)
+            scenarios = UltraEnv.get_scenarios_from_scenario_info(scenarios)
             for scenario in scenarios:
                 self.assertIn(scenario, FAKE_SCENARIOS)
 

--- a/ultra/tests/test_env.py
+++ b/ultra/tests/test_env.py
@@ -66,22 +66,6 @@ class EnvTest(unittest.TestCase):
         self.assertTrue(task_id1 == task_id)
         self.assertTrue(task_level1 == task_level)
 
-    def test_scenario_sequence(self):
-        @ray.remote(max_calls=1, num_gpus=0, num_cpus=1)
-        def run_experiment():
-            _, env = prepare_test_env_agent(
-                scenario_info=[prebuilt_scenario1, prebuilt_scenario2]
-            )
-            scenarios = env.scenario_info
-            env.close()
-            return scenarios
-
-        ray.init(ignore_reinit_error=True)
-        scenarios = ray.get(run_experiment.remote())
-        ray.shutdown()
-        self.assertTrue(scenarios[0] == prebuilt_scenario1)
-        self.assertTrue(scenarios[1] == prebuilt_scenario2)
-
     def test_get_scenarios_from_scenario_info(self):
         TASK_LEVEL = ("00", "easy")
         TASK_LEVEL_TRAIN_SCENARIOS = [

--- a/ultra/ultra/env/ultra_env.py
+++ b/ultra/ultra/env/ultra_env.py
@@ -23,7 +23,7 @@ from collections import deque
 import copy
 import glob
 import math
-import os
+import pathlib
 from itertools import cycle
 from sys import path
 from typing import Dict, List, Tuple, Sequence, Union
@@ -158,15 +158,15 @@ class UltraEnv(HiWayEnv):
         try:
             # Attempt to load scenarios from a (task, level) tuple.
             task, level = scenario_info
-            base_dir = os.path.join(os.path.dirname(__file__), "../")
-            task_config_path = os.path.join(base_dir, _CONFIG_FILE)
+            base_dir = pathlib.Path(__file__).parent.parent
+            task_config_path = base_dir / _CONFIG_FILE
 
             with open(task_config_path, "r") as tasks_file:
                 tasks = yaml.safe_load(tasks_file)["tasks"]
             scenario_paths = tasks[f"task{task}"][level]
 
-            scenario_paths["train"] = os.path.join(base_dir, scenario_paths["train"])
-            scenario_paths["test"] = os.path.join(base_dir, scenario_paths["test"])
+            scenario_paths["train"] = (base_dir / scenario_paths["train"]).resolve()
+            scenario_paths["test"] = (base_dir / scenario_paths["test"]).resolve()
 
             if not eval_mode:
                 scenarios = glob.glob(f"{scenario_paths['train']}")

--- a/ultra/ultra/env/ultra_env.py
+++ b/ultra/ultra/env/ultra_env.py
@@ -172,9 +172,12 @@ class UltraEnv(HiWayEnv):
                 scenarios = glob.glob(f"{scenario_paths['train']}")
             else:
                 scenarios = glob.glob(f"{scenario_paths['test']}")
-        except Exception:
+        except (KeyError, ValueError):
             # Treat scenario_info as a list of scenario directories.
             scenarios = scenario_info
+        except Exception as exception:
+            # Otherwise, something else has gone wrong.
+            raise exception
 
         return scenarios
 

--- a/ultra/ultra/env/ultra_env.py
+++ b/ultra/ultra/env/ultra_env.py
@@ -26,7 +26,7 @@ import math
 import os
 from itertools import cycle
 from sys import path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Sequence
 
 import numpy as np
 import yaml, inspect
@@ -53,6 +53,7 @@ class UltraEnv(HiWayEnv):
         headless,
         timestep_sec,
         seed,
+        scenarios: Sequence[str] = None,
         eval_mode=False,
         ordered_scenarios=False,
     ):
@@ -65,7 +66,8 @@ class UltraEnv(HiWayEnv):
         agent_specs = agent_specs
         ordered_scenarios = ordered_scenarios
 
-        scenarios = self.get_scenarios(scenario_info)
+        if not scenarios:
+            scenarios = self.get_scenarios(scenario_info)
 
         self.smarts_observations_stack = deque(maxlen=_STACK_SIZE)
 

--- a/ultra/ultra/env/ultra_env.py
+++ b/ultra/ultra/env/ultra_env.py
@@ -142,7 +142,7 @@ class UltraEnv(HiWayEnv):
 
     @staticmethod
     def get_scenarios_from_scenario_info(
-        scenario_info: Union[Tuple[str, str], Sequence[str]], eval_mode: bool
+        scenario_info: Union[Tuple[str, str], Sequence[str]], eval_mode: bool = False
     ) -> List[str]:
         """Finds all scenarios from a given (task, level) tuple, or sequence of scenario
         directories.
@@ -151,6 +151,9 @@ class UltraEnv(HiWayEnv):
             scenario_info (Union[Tuple[str, str], Sequence[str]]): Either a tuple of
                 two strings (task, level) that describe the scenarios of the specific
                 task and level, or a sequence of scenario directory strings.
+            eval_mode (bool): Used only when obtaining scenarios from a (task, level)
+                tuple. This determines whether to return the evaluation scenarios of the
+                specified task's level. Training scenarios are returned by default.
 
         Returns:
             List[str]: A list of scenario directory strings.

--- a/ultra/ultra/env/ultra_env.py
+++ b/ultra/ultra/env/ultra_env.py
@@ -26,7 +26,7 @@ import math
 import os
 from itertools import cycle
 from sys import path
-from typing import Dict, List, Tuple, Sequence
+from typing import Dict, List, Tuple, Sequence, Union
 
 import numpy as np
 import yaml, inspect
@@ -53,30 +53,22 @@ class UltraEnv(HiWayEnv):
         headless,
         timestep_sec,
         seed,
-        scenarios: Sequence[str] = None,
         eval_mode=False,
         ordered_scenarios=False,
     ):
         self.scenario_info = scenario_info
         self.headless = headless
         self.timestep_sec = timestep_sec
-        self.seed = seed
-        self.eval_mode = eval_mode
-
-        agent_specs = agent_specs
-        ordered_scenarios = ordered_scenarios
-
-        if not scenarios:
-            scenarios = self.get_scenarios(scenario_info)
-
         self.smarts_observations_stack = deque(maxlen=_STACK_SIZE)
+
+        scenarios = UltraEnv.get_scenarios_from_scenario_info(scenario_info, eval_mode)
 
         super().__init__(
             scenarios=scenarios,
             agent_specs=agent_specs,
-            headless=self.headless,
-            timestep_sec=self.timestep_sec,
-            seed=self.seed,
+            headless=headless,
+            timestep_sec=timestep_sec,
+            seed=seed,
             visdom=False,
         )
 
@@ -148,41 +140,43 @@ class UltraEnv(HiWayEnv):
 
         return observations
 
-    def get_scenarios(self, scenario_info: Tuple[str, str]) -> List[str]:
-        """Finds all of the scenarios from the given scenario information
-
-        To obtain the path of scenarios:
-            1. Get the filename patterns of the train and test scenarios from
-               ultra/config.yaml from the given task and level.
-            2. Change the filename patterns from relative to absolute path
-            3. Depending on the evaluation mode, we can provide glob.glob with
-               the appropriate filename pattern to return a list of scenario dirs
+    @staticmethod
+    def get_scenarios_from_scenario_info(
+        scenario_info: Union[Tuple[str, str], Sequence[str]], eval_mode: bool
+    ) -> List[str]:
+        """Finds all scenarios from a given (task, level) tuple, or sequence of scenario
+        directories.
 
         Args:
-            scenario_info Tuple[str, str]: The first index represents
-                task id and second index represents task's level
+            scenario_info (Union[Tuple[str, str], Sequence[str]]): Either a tuple of
+                two strings (task, level) that describe the scenarios of the specific
+                task and level, or a sequence of scenario directory strings.
 
         Returns:
-            List[str]: Absolute path of scenarios
+            List[str]: A list of scenario directory strings.
         """
-        task_id, task_level = scenario_info[0], scenario_info[1]
+        try:
+            # Attempt to load scenarios from a (task, level) tuple.
+            task, level = scenario_info
+            base_dir = os.path.join(os.path.dirname(__file__), "../")
+            task_config_path = os.path.join(base_dir, _CONFIG_FILE)
 
-        base_dir = os.path.join(os.path.dirname(__file__), "../")
-        config_path = os.path.join(base_dir, _CONFIG_FILE)
+            with open(task_config_path, "r") as tasks_file:
+                tasks = yaml.safe_load(tasks_file)["tasks"]
+            scenario_paths = tasks[f"task{task}"][level]
 
-        with open(config_path, "r") as task_file:
-            tasks = yaml.safe_load(task_file)["tasks"]
-            scenario_paths = tasks[f"task{task_id}"][task_level]
+            scenario_paths["train"] = os.path.join(base_dir, scenario_paths["train"])
+            scenario_paths["test"] = os.path.join(base_dir, scenario_paths["test"])
 
-        scenario_paths["train"] = os.path.join(base_dir, scenario_paths["train"])
-        scenario_paths["test"] = os.path.join(base_dir, scenario_paths["test"])
+            if not eval_mode:
+                scenarios = glob.glob(f"{scenario_paths['train']}")
+            else:
+                scenarios = glob.glob(f"{scenario_paths['test']}")
+        except Exception:
+            # Treat scenario_info as a list of scenario directories.
+            scenarios = scenario_info
 
-        if not self.eval_mode:
-            _scenarios = glob.glob(f"{scenario_paths['train']}")
-        else:
-            _scenarios = glob.glob(f"{scenario_paths['test']}")
-
-        return _scenarios
+        return scenarios
 
     @property
     def info(self):

--- a/ultra/ultra/train.py
+++ b/ultra/ultra/train.py
@@ -200,6 +200,7 @@ def train(
         "ultra.env:ultra-v0",
         agent_specs=agent_specs,
         scenario_info=scenario_info,
+        scenarios=scenarios,
         headless=headless,
         timestep_sec=timestep_sec,
         seed=seed,

--- a/ultra/ultra/train.py
+++ b/ultra/ultra/train.py
@@ -200,7 +200,6 @@ def train(
         "ultra.env:ultra-v0",
         agent_specs=agent_specs,
         scenario_info=scenario_info,
-        scenarios=scenarios,
         headless=headless,
         timestep_sec=timestep_sec,
         seed=seed,


### PR DESCRIPTION
Hi @JenishPatel99, I decided to make a separate PR for these changes. Let me know what you think.

The CI test I added doesn't really check much, but it is modelled after the existing CI test for the task-level scenario info (`tests/test_env.py::EnvTest::test_scenario_task`). I have made sure (by simply printing out the scenarios on line 65 of `ultra_env.py`) that the scenarios are being obtained correctly.