### PR TITLE
ULTRA decrease large amounts of vehicles from traffic distributions

### DIFF
--- a/ultra/ultra/env/ultra_env.py
+++ b/ultra/ultra/env/ultra_env.py
@@ -70,6 +70,7 @@ class UltraEnv(HiWayEnv):
             timestep_sec=timestep_sec,
             seed=seed,
             visdom=False,
+            endless_traffic=False,
         )
 
         if ordered_scenarios:

--- a/ultra/ultra/scenarios/common/distributions.py
+++ b/ultra/ultra/scenarios/common/distributions.py
@@ -146,7 +146,7 @@ t_patterns = {
             },
             "south-north": None,  # blocking
             "west-east": {
-                "vehicles": 1000,
+                "vehicles": 200,
                 "start_end_on_different_lanes_probability": 0.0,
                 "distribution": behavior_distribution,
                 "begin_time_init": {
@@ -169,7 +169,7 @@ t_patterns = {
                 "deadlock_optimization": True,
             },
             "east-west": {
-                "vehicles": 1000,
+                "vehicles": 200,
                 "start_end_on_different_lanes_probability": 0.0,
                 "distribution": behavior_distribution,
                 "begin_time_init": {
@@ -225,7 +225,7 @@ t_patterns = {
             },
             "south-north": None,  # blocking
             "west-east": {
-                "vehicles": 1000,
+                "vehicles": 200,
                 "start_end_on_different_lanes_probability": 0.0,
                 "distribution": behavior_distribution,
                 "begin_time_init": {
@@ -237,7 +237,7 @@ t_patterns = {
             },
             "west-north": None,  # blocking
             "east-west": {
-                "vehicles": 1000,
+                "vehicles": 200,
                 "start_end_on_different_lanes_probability": 0.0,
                 "distribution": behavior_distribution,
                 "begin_time_init": {
@@ -307,7 +307,7 @@ t_patterns = {
             },  # blocking
             "south-north": None,  # blocking
             "west-east": {
-                "vehicles": 1000,
+                "vehicles": 200,
                 "distribution": {
                     "default": 0.7,
                     "aggressive": 0.30,
@@ -348,7 +348,7 @@ t_patterns = {
                 "deadlock_optimization": False,
             },  # blocking
             "east-west": {
-                "vehicles": 1000,
+                "vehicles": 200,
                 "distribution": {
                     "default": 0.7,
                     "aggressive": 0.30,
@@ -763,7 +763,7 @@ cross_patterns = {
                 "deadlock_optimization": True,
             },
             "south-north": {
-                "vehicles": 1000,
+                "vehicles": 200,
                 "start_end_on_different_lanes_probability": 0.0,
                 "distribution": behavior_distribution,
                 "begin_time_init": {
@@ -780,7 +780,7 @@ cross_patterns = {
             "east-north": None,  # blocking
             "east-south": None,
             "north-south": {
-                "vehicles": 1000,
+                "vehicles": 200,
                 "start_end_on_different_lanes_probability": 0.0,
                 "distribution": behavior_distribution,
                 "begin_time_init": {
@@ -844,7 +844,7 @@ cross_patterns = {
                 "deadlock_optimization": False,
             },
             "south-north": {
-                "vehicles": 1000,
+                "vehicles": 200,
                 "start_end_on_different_lanes_probability": 0.0,
                 "distribution": behavior_distribution,
                 "begin_time_init": {
@@ -861,7 +861,7 @@ cross_patterns = {
             "east-south": None,
             "west-south": None,
             "north-south": {
-                "vehicles": 1000,
+                "vehicles": 200,
                 "start_end_on_different_lanes_probability": 0.0,
                 "distribution": behavior_distribution,
                 "begin_time_init": {
@@ -934,7 +934,7 @@ cross_patterns = {
                 "deadlock_optimization": True,
             },
             "south-north": {
-                "vehicles": 1000,
+                "vehicles": 200,
                 "distribution": {
                     "default": 0.7,
                     "aggressive": 0.3,
@@ -960,7 +960,7 @@ cross_patterns = {
             "east-north": None,  # blocking
             "east-south": None,
             "north-south": {
-                "vehicles": 1000,
+                "vehicles": 200,
                 "distribution": {
                     "default": 0.70,
                     "aggressive": 0.30,


### PR DESCRIPTION
There were instances inside `distributions.py` where the number of vehicles for a single route was set to 1000. However, during a normal run with out baselines, we have never exhausted all 1000 of vehicles. I do feel it is unnecessary to have these many. This will also help decrease the scenario generation as we have less vehicles to construct and ID. Let me know your thoughts on this @christianjans  