### PR TITLE
ULTRA set `endless_traffic` flag to false inside ULTRA

### DIFF
--- a/ultra/docs/ultra_environments.md
+++ b/ultra/docs/ultra_environments.md
@@ -18,8 +18,8 @@ of this class to still be a NumPy array, but with shape
 (its value can be found in `ultra.env.ultra_env`), `HEIGHT` is the height of the RGB
 image, and `WIDTH` is the width of the RGB image.
 4. ULTRA's Gym environment sets the `endless_traffic` flag to be False. This stops
-social vehicles from teleporting back to their starting position once completion of
-mission route. 
+social vehicles from teleporting back to their starting position once they complete
+their mission route.
 
 ULTRA's RLlib environment differs in one way from SMARTS' RLlibHiWayEnv:
 1. ULTRA's RLlib environment takes a `scenario_info` key as part of its config. This

--- a/ultra/docs/ultra_environments.md
+++ b/ultra/docs/ultra_environments.md
@@ -3,7 +3,7 @@
 ULTRA's Gym and RLlib environments inherit from SMARTS' `smarts.env.hiway_env.HiWayEnv`
 and `smarts.env.rllib_hiway_env.RLlibHiWayEnv` respectively.
 
-ULTRA's Gym environment differs in two ways from SMARTS' HiWayEnv:
+ULTRA's Gym environment differs in a few ways from SMARTS' HiWayEnv:
 1. ULTRA's Gym environment takes a `scenario_info` parameter that is used to specify a
 specific task and level that describe the type of scenarios the environment will use.
 2. ULTRA's Gym environment can also take a `scenarios` parameter to directly specified
@@ -17,6 +17,9 @@ of this class to still be a NumPy array, but with shape
 `(_STACK_SIZE, HEIGHT, WIDTH, 3)` where `_STACK_SIZE` is the number of frames to stack
 (its value can be found in `ultra.env.ultra_env`), `HEIGHT` is the height of the RGB
 image, and `WIDTH` is the width of the RGB image.
+4. ULTRA's Gym environment sets the `endless_traffic` flag to be False. This stops
+social vehicles from teleporting back to their starting position once completion of
+mission route. 
 
 ULTRA's RLlib environment differs in one way from SMARTS' RLlibHiWayEnv:
 1. ULTRA's RLlib environment takes a `scenario_info` key as part of its config. This

--- a/ultra/ultra/env/ultra_env.py
+++ b/ultra/ultra/env/ultra_env.py
@@ -70,6 +70,7 @@ class UltraEnv(HiWayEnv):
             timestep_sec=timestep_sec,
             seed=seed,
             visdom=False,
+            endless_traffic=False,
         )
 
         if ordered_scenarios:

--- a/ultra/ultra/scenarios/README.md
+++ b/ultra/ultra/scenarios/README.md
@@ -61,7 +61,7 @@
 3. Generate scenarios for training:
     ```sh
     # Remove existing easy scenarios.
-    $ rm -rf ultra/scenarios/task1/t*_<task>_<level>_*
+    $ rm -rf ultra/scenarios/task1/t*_task1_easy_*
 
     # Generate the analysis scenarios from the analysis maps in the analysis pool.
     $ python ultra/scenarios/interface.py generate --task 1 --level easy --pool-dir ultra/scenarios/pool/analysis_pool/

--- a/ultra/ultra/scenarios/README.md
+++ b/ultra/ultra/scenarios/README.md
@@ -61,7 +61,7 @@
 3. Generate scenarios for training:
     ```sh
     # Remove existing easy scenarios.
-    $ rm -rf ultra/scenarios/task1/t*_easy_*
+    $ rm -rf ultra/scenarios/task1/t*_<task>_<level>_*
 
     # Generate the analysis scenarios from the analysis maps in the analysis pool.
     $ python ultra/scenarios/interface.py generate --task 1 --level easy --pool-dir ultra/scenarios/pool/analysis_pool/


### PR DESCRIPTION
The `endless_traffic` flag is used inside the `sumo_traffic_simulation.py` to control whether social vehicles are allowed to teleport back to their starting position once completed their mission route. Teleportation of the social vehicles is not necessary inside of ULTRA's environment because the scenarios that are generated by the traffic distribution does not account for that behavior. Thus, to disable this feature, we must pass `endless_traffic=False` to the parent constructor in `ultra_env.py`. I have opted to not make this feature optional in ULTRA because it goes against the core scenario setup, thus users will not be able to pass the `endless_traffic` flag