### PR TITLE
Add `[camera-obs]` to `Dockerfile`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All text added must be human-readable.
 Copy and pasting the git commit messages is __NOT__ enough.
 
 ## [Unreleased]
+### Fixed
+- Added `camera-obs` to the SMARTS Dockerfile so that camera observations can be used in the generated image without extra work.
+
 ## [0.4.17] - 2021-07-02
 ### Added 
 - Added `ActionSpace.Imitation` and a controller to support it.  See Issue #844.

--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -59,7 +59,7 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt
 ENV PYTHONPATH=/src
 COPY . /src
 WORKDIR /src
-RUN pip install --no-cache-dir -e .[train,test,dev]
+RUN pip install --no-cache-dir -e .[train,test,dev,camera-obs]
 
 # For Envision
 EXPOSE 8081


### PR DESCRIPTION
In looking at the 0_4_17 Docker image I had noticed that `camera-obs` was missing.