### PR TITLE
Bugfix missing smarts egg info

### DIFF
--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -59,7 +59,8 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt
 ENV PYTHONPATH=/src
 COPY . /src
 WORKDIR /src
-RUN pip install --no-cache-dir -e .[train,test,dev,camera-obs]
+RUN pip install --no-cache-dir -e .[train,test,dev,camera-obs] \
+    && cp /src/smarts.egg-info /media/smarts.egg-info
 
 # For Envision
 EXPOSE 8081
@@ -70,7 +71,11 @@ RUN echo "/usr/bin/Xorg " \
     "-noreset +extension GLX +extension RANDR +extension RENDER" \
     "-logfile ./xdummy.log -config /etc/X11/xorg.conf -novtswitch $DISPLAY &" >> ~/.bashrc
 
-# Suppress message of missing /dev/input folder
-RUN echo "mkdir -p /dev/input" >> ~/.bashrc
+# Suppress message of missing /dev/input folder and copy smarts.egg-info if not there
+RUN echo "mkdir -p /dev/input\n" \
+         "if [[ ! -d /src/smarts.egg-info ]]; then" \
+         "   cp -r /media/smarts.egg-info /src/smarts.egg-info;" \
+         "   chmod -R 777 /src/smarts.egg-info;" \
+         "fi" >> ~/.bashrc
 
 SHELL ["/bin/bash", "-c", "-l"]

--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -60,7 +60,7 @@ ENV PYTHONPATH=/src
 COPY . /src
 WORKDIR /src
 RUN pip install --no-cache-dir -e .[train,test,dev,camera-obs] \
-    && cp /src/smarts.egg-info /media/smarts.egg-info
+    && cp -r /src/smarts.egg-info /media/smarts.egg-info
 
 # For Envision
 EXPOSE 8081

--- a/utils/docker/Dockerfile.headless
+++ b/utils/docker/Dockerfile.headless
@@ -52,12 +52,17 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt
 ENV PYTHONPATH=/src
 COPY . /src
 WORKDIR /src
-RUN pip install --no-cache-dir -e .[train,test,dev,camera-obs]
+RUN pip install --no-cache-dir -e .[train,test,dev,camera-obs] \
+    && cp -r /src/smarts.egg-info /media/smarts.egg-info
 
 # For Envision
 EXPOSE 8081
 
-# Suppress message of missing /dev/input folder
-RUN echo "mkdir -p /dev/input" >> ~/.bashrc
+# Suppress message of missing /dev/input folder and copy smarts.egg-info if not there
+RUN echo "mkdir -p /dev/input\n" \
+         "if [[ ! -d /src/smarts.egg-info ]]; then" \
+         "   cp -r /media/smarts.egg-info /src/smarts.egg-info;" \
+         "   chmod -R 777 /src/smarts.egg-info;" \
+         "fi" >> ~/.bashrc
 
 SHELL ["/bin/bash", "-c", "-l"]


### PR DESCRIPTION
This is to fix an issue where mapping the repo as in the instructions to the /src directory would then further require a `smarts.egg-info` to be generated to use the repository code (which requires pip.)