### PR TITLE
ULTRA set `sumo_seed` to same as the scenario seed

### DIFF
--- a/ultra/ultra/scenarios/generate_scenarios.py
+++ b/ultra/ultra/scenarios/generate_scenarios.py
@@ -34,6 +34,7 @@ from multiprocessing import Manager, Process
 from shutil import copyfile
 from typing import Any, Dict, Sequence
 
+import numpy as np
 import yaml
 
 from smarts.core.utils.sumo import sumolib
@@ -345,6 +346,7 @@ def generate_left_turn_missions(
         }
 
     random.seed(seed)
+    np.random.seed(seed)
     all_flows = []
     metadata = {"routes": {}, "total_vehicles": 0, "stopwatcher": None}
 

--- a/ultra/ultra/scenarios/generate_scenarios.py
+++ b/ultra/ultra/scenarios/generate_scenarios.py
@@ -34,7 +34,6 @@ from multiprocessing import Manager, Process
 from shutil import copyfile
 from typing import Any, Dict, Sequence
 
-import numpy as np
 import yaml
 
 from smarts.core.utils.sumo import sumolib
@@ -335,8 +334,8 @@ def generate_left_turn_missions(
     intersection_name,
     traffic_density,
 ):
-    # dont worry about these seeds, theyre used by sumo
-    sumo_seed = random.choice([0, 1, 2, 3, 4])
+    # By default the sumo_seed is set to the scenario seed
+    sumo_seed = seed
     stopwatcher_info = None
     stopwatcher_added = False
     if stopwatcher_behavior:
@@ -346,7 +345,6 @@ def generate_left_turn_missions(
         }
 
     random.seed(seed)
-    np.random.seed(seed)
     all_flows = []
     metadata = {"routes": {}, "total_vehicles": 0, "stopwatcher": None}
 


### PR DESCRIPTION
I am not quite sure why the `sumo_seed` was set to a random integer between 1 and 5, indicated below:
https://github.com/huawei-noah/SMARTS/blob/9fbf3d6195d7eb409fe0b2107155e00ed235b408/ultra/ultra/scenarios/generate_scenarios.py#L339

To ensure complete reproducibility of scenarios it is best to keep the `sumo_seed` same as the scenario seed.

Side task:
- [x] Remove unnecessary numpy import 