### PR TITLE
Fix missing /dev/input and smarts.egg-info in singularity container

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,23 +283,23 @@ $ cd </path/to/SMARTS>
 $ sudo singularity build ./utils/singularity/smarts.sif ./utils/singularity/smarts.def
 
 # Use the container to build the required scenarios.
-$ singularity shell --containall --bind ../SMARTS:/SMARTS ./utils/singularity/smarts.sif
+$ singularity shell --containall --bind ../SMARTS:/src ./utils/singularity/smarts.sif
 # Inside the container
-Singularity> scl scenario build /SMARTS/scenarios/loop/
+Singularity> scl scenario build /src/scenarios/loop/
 Singularity> exit
 
 # Then, run the container using one of the following methods.
 
 # 1. Run container in interactive mode.
-$ singularity shell --containall --bind ../SMARTS:/SMARTS ./utils/singularity/smarts.sif
+$ singularity shell --containall --bind ../SMARTS:/src ./utils/singularity/smarts.sif
 # Inside the container
-Singularity> python3.7 /SMARTS/examples/single_agent.py /SMARTS/scenarios/loop/ --headless
+Singularity> python3.7 /src/examples/single_agent.py /src/scenarios/loop/ --headless
 
 # 2. Run commands within the container from the host system.
-$ singularity exec --containall --bind ../SMARTS:/SMARTS ./utils/singularity/smarts.sif python3.7 /SMARTS/examples/single_agent.py /SMARTS/scenarios/loop/ --headless
+$ singularity exec --containall --bind ../SMARTS:/src ./utils/singularity/smarts.sif python3.7 /src/examples/single_agent.py /src/scenarios/loop/ --headless
 
 # 3. Run container instance in the background.
-$ singularity instance start --containall --bind ../SMARTS:/SMARTS ./utils/singularity/smarts.sif smarts_train /SMARTS/examples/single_agent.py /SMARTS/scenarios/loop/ --headless
+$ singularity instance start --containall --bind ../SMARTS:/src ./utils/singularity/smarts.sif smarts_train /src/examples/single_agent.py /src/scenarios/loop/ --headless
 ```
 
 ### Troubleshooting

--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -60,7 +60,7 @@ ENV PYTHONPATH=/src
 COPY . /src
 WORKDIR /src
 RUN pip install --no-cache-dir -e .[train,test,dev,camera-obs] \
-    && cp /src/smarts.egg-info /media/smarts.egg-info
+    && cp -r /src/smarts.egg-info /media/smarts.egg-info
 
 # For Envision
 EXPOSE 8081

--- a/utils/docker/Dockerfile.headless
+++ b/utils/docker/Dockerfile.headless
@@ -52,12 +52,17 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt
 ENV PYTHONPATH=/src
 COPY . /src
 WORKDIR /src
-RUN pip install --no-cache-dir -e .[train,test,dev,camera-obs]
+RUN pip install --no-cache-dir -e .[train,test,dev,camera-obs] \
+    && cp -r /src/smarts.egg-info /media/smarts.egg-info
 
 # For Envision
 EXPOSE 8081
 
-# Suppress message of missing /dev/input folder
-RUN echo "mkdir -p /dev/input" >> ~/.bashrc
+# Suppress message of missing /dev/input folder and copy smarts.egg-info if not there
+RUN echo "mkdir -p /dev/input\n" \
+         "if [[ ! -d /src/smarts.egg-info ]]; then" \
+         "   cp -r /media/smarts.egg-info /src/smarts.egg-info;" \
+         "   chmod -R 777 /src/smarts.egg-info;" \
+         "fi" >> ~/.bashrc
 
 SHELL ["/bin/bash", "-c", "-l"]

--- a/utils/singularity/setup.sh
+++ b/utils/singularity/setup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Suppress message of missing /dev/input folder 
+mkdir -p /dev/input
+
+# Copy and paste smarts.egg-info if not available
+if [[ ! -d /src/smarts.egg-info ]]; then
+    cp -r /media/smarts.egg-info /src/smarts.egg-info;
+    chmod -R 777 /src/smarts.egg-info;
+fi

--- a/utils/singularity/smarts.def
+++ b/utils/singularity/smarts.def
@@ -49,11 +49,12 @@ From: ubuntu:bionic
     # Copy source files and install SMARTS
     cd ${SINGULARITY_CONTAINER}/src
     pip install --no-cache-dir -e .[train,test,dev,camera-obs]
+    cp -r ${SINGULARITY_CONTAINER}/src/smarts.egg-info ${SINGULARITY_CONTAINER}/media/smarts.egg-info
 
 %environment
     export SUMO_HOME=/usr/share/sumo
     export PYTHONPATH=/src
+    . /src/utils/singularity/setup.sh
 
 %startscript
-    mkdir -p /dev/input
     python3.7 "$@"    


### PR DESCRIPTION
Singularity container
1) Adds missing `/dev/input` folder.
2) Adds `smarts.egg-info` in singularity container when source code folders are binded. See pull request #1018 for reference.