### PR TITLE
Mission start_pose support

### DIFF
--- a/examples/ros/src/smarts_ros/scripts/ros_driver.py
+++ b/examples/ros/src/smarts_ros/scripts/ros_driver.py
@@ -292,7 +292,8 @@ class ROSDriver:
         else:
             goal = EndlessGoal()
         mission = Mission(
-            start=Start.from_pose(ROSDriver._pose_from_ros(ros_agent_spec.start_pose)),
+            start=None,
+            start_pose=ROSDriver._pose_from_ros(ros_agent_spec.start_pose),
             goal=goal,
             # TODO:  how to prevent them from spawning on top of another existing vehicle? (see how it's done in SUMO traffic)
             entry_tactic=default_entry_tactic(ros_agent_spec.start_speed),

--- a/smarts/core/mission_planner.py
+++ b/smarts/core/mission_planner.py
@@ -128,7 +128,7 @@ class MissionPlanner:
             self._route = EmptyRoute()
         else:
             start_lane = self._road_network.nearest_lane(
-                self._mission.start.position,
+                self._mission.start_pos,
                 include_junctions=False,
                 include_special=False,
             )
@@ -399,7 +399,7 @@ class MissionPlanner:
             neighborhood_vehicles[0].pose.position[:2]
         )
         start_lane = self._road_network.nearest_lane(
-            self._mission.start.position,
+            self._mission.start_pos,
             include_junctions=False,
             include_special=False,
         )

--- a/smarts/core/scenario.py
+++ b/smarts/core/scenario.py
@@ -177,6 +177,10 @@ class Mission:
     def is_complete(self, vehicle, distance_travelled):
         return self.goal.is_reached(vehicle)
 
+    @property
+    def start_pos(self):
+        return self.start.position if self.start else self.start_pose.position
+
 
 @dataclass(frozen=True)
 class LapMission:

--- a/smarts/core/trap_manager.py
+++ b/smarts/core/trap_manager.py
@@ -140,7 +140,7 @@ class TrapManager:
             sorted_vehicle_ids = sorted(
                 list(social_vehicle_ids),
                 key=lambda v: squared_dist(
-                    vehicles[v].position[:2], trap.mission.start.position
+                    vehicles[v].position[:2], trap.mission.start_pos
                 ),
             )
             for v_id in sorted_vehicle_ids:
@@ -195,12 +195,12 @@ class TrapManager:
                 mission = trap.mission
                 if len(agent_vehicle_comp) > 0:
                     agent_vehicle_comp.sort(
-                        key=lambda v: squared_dist(v[0], mission.start.position)
+                        key=lambda v: squared_dist(v[0], mission.start_pos)
                     )
 
                     # Make sure there is not an agent vehicle in the same location
                     pos, largest_dimension, _ = agent_vehicle_comp[0]
-                    if squared_dist(pos, mission.start.position) < largest_dimension:
+                    if squared_dist(pos, mission.start_pos) < largest_dimension:
                         continue
 
                 vehicle = TrapManager._make_vehicle(
@@ -306,16 +306,16 @@ class TrapManager:
         n_lane = None
 
         if default_entry_speed is None:
-            n_lane = road_network.nearest_lane(mission.start.position)
+            n_lane = road_network.nearest_lane(mission.start_pos)
             default_entry_speed = n_lane.getSpeed()
 
         if zone is None:
-            n_lane = n_lane or road_network.nearest_lane(mission.start.position)
+            n_lane = n_lane or road_network.nearest_lane(mission.start_pos)
             lane_speed = n_lane.getSpeed()
             start_edge_id = n_lane.getEdge().getID()
             start_lane = n_lane.getIndex()
             lane_length = n_lane.getLength()
-            start_pos = mission.start.position
+            start_pos = mission.start_pos
             vehicle_offset_into_lane = road_network.offset_into_lane(
                 n_lane, (start_pos[0], start_pos[1])
             )

--- a/smarts/core/vehicle.py
+++ b/smarts/core/vehicle.py
@@ -345,11 +345,16 @@ class Vehicle:
                 initial_speed = mission.task.initial_speed
 
         start = mission.start
-        start_pose = Pose.from_front_bumper(
-            front_bumper_position=np.array(start.position),
-            heading=start.heading,
-            length=chassis_dims.length,
-        )
+        if start:
+            assert not mission.start_pose
+            start_pose = Pose.from_front_bumper(
+                front_bumper_position=np.array(start.position),
+                heading=start.heading,
+                length=chassis_dims.length,
+            )
+        else:
+            assert mission.start_pose
+            start_pose = mission.start_pose
 
         vehicle_color = (
             SceneColors.Agent.value if trainable else SceneColors.SocialAgent.value


### PR DESCRIPTION
Adding support for specifying a Mission `start_pose` as a `Pose` object instead of `start` as a `Start` object. 

This fixes a bug where a newly-added ROS agent's position was offset by half of the vehicle length.