### PR TITLE
ROS agent mission start fix

### DIFF
--- a/examples/ros/src/smarts_ros/scripts/test_smarts_ros.py
+++ b/examples/ros/src/smarts_ros/scripts/test_smarts_ros.py
@@ -27,6 +27,7 @@ class TestSmartsRos(TestCase):
     """Node to test the smarts_ros package."""
 
     def __init__(self):
+        super().__init__()
         self._smarts_info_srv = None
         self._control_publisher = None
         self._agents = {}
@@ -105,11 +106,10 @@ class TestSmartsRos(TestCase):
 
     def _agents_callback(self, agents: AgentsStamped):
         rospy.logdebug(f"got report about {len(agents.agents)} agents")
-        self.assertEqual(
-            len(agents.agents),
-            len(self._agents),
-            f"{len(agents.agents)} != {len(self._agents)}",
-        )
+        if len(agents.agents) != len(self._agents):
+            rospy.logwarn(
+                f"SMARTS reporting {len(agents.agents)} agents, but we've added {len(self._agents)}."
+            )
 
     def _entities_callback(self, entities: EntitiesStamped):
         rospy.logdebug(f"got report about {len(entities.entities)} agents")
@@ -117,21 +117,7 @@ class TestSmartsRos(TestCase):
     def run_forever(self):
         if not self._smarts_info_srv:
             raise RuntimeError("must call setup_ros() first.")
-
         scenario = self._init_scenario()
-
-        rospy.sleep(3)  # hack to avoid race w/ resetting the SMARTS scenario
-        smarts_info = self._smarts_info_srv()
-        self.assertEqual(
-            scenario,
-            smarts_info.current_scenario_path,
-            f"'{scenario}' != '{smarts_info.current_scenario_path}'",
-        )
-        self.assertEqual(0, smarts_info.step_count, f"{smarts_info.step_count}")
-        self.assertEqual(
-            0.0, smarts_info.elapsed_sim_time, f"{smarts_info.elapsed_sim_time}"
-        )
-
         rospy.spin()
 
 

--- a/smarts/core/scenario.py
+++ b/smarts/core/scenario.py
@@ -29,7 +29,7 @@ from dataclasses import dataclass, field
 from functools import lru_cache
 from itertools import cycle, product
 from pathlib import Path
-from typing import Any, Dict, Sequence, Tuple
+from typing import Any, Dict, Optional, Sequence, Tuple
 
 import numpy as np
 from cached_property import cached_property
@@ -52,12 +52,14 @@ from smarts.sstudio.types import Via as SSVia
 class Start:
     position: Tuple[int, int]
     heading: Heading
+    from_front_bumper: Optional[bool] = True
 
     @classmethod
     def from_pose(cls, pose: Pose):
         return cls(
             position=pose.position[:2],
             heading=pose.heading,
+            from_front_bumper=False,
         )
 
 

--- a/smarts/core/vehicle.py
+++ b/smarts/core/vehicle.py
@@ -345,11 +345,14 @@ class Vehicle:
                 initial_speed = mission.task.initial_speed
 
         start = mission.start
-        start_pose = Pose.from_front_bumper(
-            front_bumper_position=np.array(start.position),
-            heading=start.heading,
-            length=chassis_dims.length,
-        )
+        if start.from_front_bumper:
+            start_pose = Pose.from_front_bumper(
+                front_bumper_position=np.array(start.position),
+                heading=start.heading,
+                length=chassis_dims.length,
+            )
+        else:
+            start_pose = Pose.from_center(start.position, start.heading)
 
         vehicle_color = (
             SceneColors.Agent.value if trainable else SceneColors.SocialAgent.value

--- a/smarts/core/vehicle.py
+++ b/smarts/core/vehicle.py
@@ -312,8 +312,9 @@ class Vehicle:
     def vehicle_type(self):
         return VEHICLE_CONFIGS[self._vehicle_config_type].vehicle_type
 
-    @staticmethod
+    @classmethod
     def build_agent_vehicle(
+        cls,
         sim,
         vehicle_id,
         agent_interface,
@@ -383,7 +384,8 @@ class Vehicle:
         # change this to dynamic_action_spaces later when pr merged
         if agent_interface and agent_interface.action in sim.dynamic_action_spaces:
             if mission.vehicle_spec:
-                self._log.warning(
+                logger = logging.getLogger(cls.__name__)
+                logger.warning(
                     "setting vehicle dimensions on a AckermannChassis not yet supported"
                 )
             chassis = AckermannChassis(


### PR DESCRIPTION
Fixes ROS agent position being off by half car-length because Mission starts were assumed to be from the front-bumper.

Also fixed a bug with a bad reference to `self._log` in a static method that I saw along the way.

Also removed some unnecessary checks from the test node (since they were risky due to race conditions and since it's not being used primarily to "test" sending the initial agents). 

(replaces obsolete/cancelled PR #1033)