### PR TITLE
ULTRA Update done criteria

### DIFF
--- a/ultra/ultra/baselines/agent_spec.py
+++ b/ultra/ultra/baselines/agent_spec.py
@@ -24,7 +24,7 @@ import numpy as np
 import torch, yaml, os, inspect, dill
 
 from smarts.core.agent import AgentSpec
-from smarts.core.agent_interface import AgentInterface
+from smarts.core.agent_interface import AgentInterface, DoneCriteria
 from ultra.baselines.common.yaml_loader import load_yaml
 import ultra.adapters as adapters
 
@@ -111,6 +111,7 @@ class BaselineAgentSpec(AgentSpec):
                 interface=AgentInterface(
                     **adapter_interface_requirements,
                     max_episode_steps=max_episode_steps,
+                    done_criteria=DoneCriteria(wrong_way=True)
                     debug=True,
                 ),
                 agent_params=dict(

--- a/ultra/ultra/baselines/agent_spec.py
+++ b/ultra/ultra/baselines/agent_spec.py
@@ -72,7 +72,9 @@ class BaselineAgentSpec(AgentSpec):
                     reward_adapter=spec.reward_adapter,
                     info_adapter=spec.info_adapter,
                 )
-
+                
+                # Update the interface.done_criteria for existing agent specs
+                new_spec.interface.done_criteria = DoneCriteria(wrong_way=True)
                 spec = new_spec
         else:
             # If policy_params is None, then there must be a params.yaml file in the
@@ -111,7 +113,7 @@ class BaselineAgentSpec(AgentSpec):
                 interface=AgentInterface(
                     **adapter_interface_requirements,
                     max_episode_steps=max_episode_steps,
-                    done_criteria=DoneCriteria(wrong_way=True)
+                    done_criteria=DoneCriteria(wrong_way=True),
                     debug=True,
                 ),
                 agent_params=dict(


### PR DESCRIPTION
To stop vehicles from sliding into the oncoming traffic lanes, the `wrong_way` criteria should be enforced. This will terminate an episode if the vehicle goes into another lane. I do believe this necessary for our continuous policies to properly complete a scenario without driving in the opposite lane @christianjans Let me know your thoughts on this one