### PR TITLE
fix ROS dt issues

### DIFF
--- a/examples/ros/src/smarts_ros/scripts/ros_driver.py
+++ b/examples/ros/src/smarts_ros/scripts/ros_driver.py
@@ -607,7 +607,7 @@ class ROSDriver:
             while not rospy.is_shutdown():
 
                 obs = self._check_reset()
-                if not self._scenario_path:
+                if obs is None or not self._scenario_path:
                     if not warned_scenario:
                         rospy.loginfo("waiting for scenario on control channel...")
                         warned_scenario = True

--- a/examples/ros/src/smarts_ros/scripts/test_smarts_ros.py
+++ b/examples/ros/src/smarts_ros/scripts/test_smarts_ros.py
@@ -76,7 +76,7 @@ class TestSmartsRos(TestCase):
     def _init_scenario(self):
         scenario = rospy.get_param("~scenario")
         self.assertTrue(os.path.isdir(scenario))
-        rospy.loginfo(f"Tester using scneario at {scenario}.")
+        rospy.loginfo(f"Tester using scenario at {scenario}.")
 
         control_msg = SmartsControl()
         control_msg.reset_with_scenario_path = scenario

--- a/smarts/core/provider.py
+++ b/smarts/core/provider.py
@@ -37,6 +37,7 @@ class ProviderState:
         assert our_vehicles.isdisjoint(other_vehicles)
 
         self.vehicles += other.vehicles
+        self.dt = max(self.dt, other.dt, key=lambda x: x if x else 0)
 
     def filter(self, vehicle_ids):
         provider_vehicle_ids = [v.vehicle_id for v in self.vehicles]

--- a/smarts/core/smarts.py
+++ b/smarts/core/smarts.py
@@ -608,7 +608,6 @@ class SMARTS:
                         pybullet_vehicle = self._vehicle_index.vehicle_by_id(vehicle_id)
                         assert isinstance(pybullet_vehicle.chassis, BoxChassis)
                         pybullet_vehicle.update_state(vehicle, dt=dt)
-                        pybullet_vehicle.updated = True
             else:
                 # This vehicle is a social vehicle
                 if vehicle_id in self._vehicle_index.social_vehicle_ids():
@@ -629,7 +628,6 @@ class SMARTS:
                 if not vehicle.updated:
                     # Note:  update_state() happens *after* pybullet has been stepped.
                     social_vehicle.update_state(vehicle, dt=dt)
-                    vehicle.updated = True
 
     def _step_pybullet(self):
         pybullet_substeps = max(1, round(self._last_dt / self._pybullet_period))

--- a/smarts/core/vehicle.py
+++ b/smarts/core/vehicle.py
@@ -538,6 +538,7 @@ class Vehicle:
         self._chassis.control(*args, **kwargs)
 
     def update_state(self, state: VehicleState, dt: float):
+        state.updated = True
         if not state.privileged:
             assert isinstance(self._chassis, BoxChassis)
             self.control(pose=state.pose, speed=state.speed, dt=dt)


### PR DESCRIPTION
This came out of plotting the velocity received by the chassis in update_state with the position delta divided by `dt` (as discussed in our meeting earlier).

I discovered that the `dt` for the `ProviderState` object wasn't being merged.

Along the way, I (very slightly) improved the accuracy of the `dt` computation in `ros_driver.py` (and added the moving-average code back in), fixed a race condition at startup, as well as fixed another minor bug where the `updated` state wasn't being set correctly for Agent-controlled vehicles.

