### PR TITLE
re-apply control forces with each step of pybullet

### DIFF
--- a/smarts/core/smarts.py
+++ b/smarts/core/smarts.py
@@ -632,8 +632,11 @@ class SMARTS:
                     vehicle.updated = True
 
     def _step_pybullet(self):
-        pybullet_substeps = max(1, round(self._last_dt / self._pybullet_period))
+        self._bullet_client.stepSimulation()
+        pybullet_substeps = max(1, round(self._last_dt / self._pybullet_period)) - 1
         for _ in range(pybullet_substeps):
+            for vehicle in self._vehicle_index.vehicles:
+                vehicle.chassis.reapply_last_control()
             self._bullet_client.stepSimulation()
 
     def _pybullet_provider_step(self, agent_actions) -> ProviderState:


### PR DESCRIPTION
As we discovered in testing today, when we break the pybullet step into substeps (for non-fixed time-stepping), it appears to be necessary to reapply the control forces to the vehicle with each pybullet substep.