### PR TITLE
Allow for `total: 0` in ULTRA's task configs

### DIFF
--- a/ultra/ultra/scenarios/generate_scenarios.py
+++ b/ultra/ultra/scenarios/generate_scenarios.py
@@ -816,20 +816,13 @@ def build_scenarios(
                 jobs.append(sub_proc)
                 sub_proc.start()
                 inner_prev_split = inner_cur_split
-            if len(mode_seeds) > 0:
-                generation_stats = (
-                    f">> {mode} {intersection_type} "
-                    f"count: {seed_count} "
-                    f"generated: {seed_count / len(mode_seeds)} "
-                    f"real: {intersection_percent}"
-                )
-            else:
-                generation_stats = (
-                    f">> {mode} {intersection_type} "
-                    f"count: {seed_count} "
-                    f"generated: 0 "
-                    f"real: {intersection_percent}"
-                )
+            generated = seed_count / len(mode_seeds) if len(mode_seeds) > 0 else 0
+            generation_stats = (
+                f">> {mode} {intersection_type} "
+                f"count: {seed_count} "
+                f"generated: {generated} "
+                f"real: {intersection_percent}"
+            )
             print(generation_stats)
             # print("--")
             prev_split = cur_split

--- a/ultra/ultra/scenarios/generate_scenarios.py
+++ b/ultra/ultra/scenarios/generate_scenarios.py
@@ -816,9 +816,21 @@ def build_scenarios(
                 jobs.append(sub_proc)
                 sub_proc.start()
                 inner_prev_split = inner_cur_split
-            print(
-                f">> {mode} {intersection_type} count:{seed_count} generated: {seed_count/len(mode_seeds)} real: {intersection_percent}"
-            )
+            if len(mode_seeds) > 0:
+                generation_stats = (
+                    f">> {mode} {intersection_type} "
+                    f"count: {seed_count} "
+                    f"generated: {seed_count / len(mode_seeds)} "
+                    f"real: {intersection_percent}"
+                )
+            else:
+                generation_stats = (
+                    f">> {mode} {intersection_type} "
+                    f"count: {seed_count} "
+                    f"generated: 0 "
+                    f"real: {intersection_percent}"
+                )
+            print(generation_stats)
             # print("--")
             prev_split = cur_split
             main_seed_count += seed_count


### PR DESCRIPTION
Allow a total of 0 to be specified in ULTRA's task config for either the task's training or testing scenarios.