### PR TITLE
Add dt to Observation class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Added `step_count` and `elapsed_sim_time` to the `Observation` class.  See PR #974 and Issues #884 and #918.
 - Added the ability to externally update SMARTS state via a new privileged-access `ExternalProvider`.
 - Allow specifying "-latest" as a version suffix for zoo locator strings.
+- Added `dt` to `Observation` class to inform users of the observations of the variable timestep.
 ### Changed
 - Social-agent-buffer is instantiated only if the scenario requires social agents.
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Added the ability to pass an optional `time_delta_since_last_step` to SMARTS' `step()` function
   to support variable timesteps for co-simulation.
 - Added `step_count` and `elapsed_sim_time` to the `Observation` class.  See PR #974 and Issues #884 and #918.
+- Added `dt` to `Observation` class to inform users of the observations of the variable timestep.
 - Added the ability to externally update SMARTS state via a new privileged-access `ExternalProvider`.
 - Allow specifying "-latest" as a version suffix for zoo locator strings.
-- Added `dt` to `Observation` class to inform users of the observations of the variable timestep.
 ### Changed
 - Social-agent-buffer is instantiated only if the scenario requires social agents.
 ### Deprecated

--- a/smarts/core/sensors.py
+++ b/smarts/core/sensors.py
@@ -126,6 +126,11 @@ class Vias:
 
 @dataclass
 class Observation:
+    # dt is the amount of sim_time the last step took .
+    # step_count is the number of steps take by SMARTS so far.
+    # elapsed_sim_time is the amout of simulation time that's passed so far.
+    # note: to get the average step_time, elapsed_sim_time can be divided by step_count
+    dt: float
     step_count: int
     elapsed_sim_time: float
     events: Events
@@ -305,6 +310,7 @@ class Sensors:
 
         return (
             Observation(
+                dt=sim.last_dt,
                 step_count=sim.step_count,
                 elapsed_sim_time=sim.elapsed_sim_time,
                 events=events,


### PR DESCRIPTION
As the title says.  This will be useful to external agents when running with a non-fixed timestep.

This is marked as a breaking changes since it's an interface change.  So it is targetted for the v0.5 release with the other timestep-related stuff.