### PR TITLE
ULTRA Add wheel installation step in setup doc

### DIFF
--- a/ultra/docs/setup.md
+++ b/ultra/docs/setup.md
@@ -23,6 +23,7 @@ $ pip install --upgrade pip
 $ source .venv/bin/activate
 
 # 6 - Install dependencies.
+$ pip install wheel
 $ pip install -e .
 ```
 


### PR DESCRIPTION
It seems like we do not include the wheel installation step in our setup docs. This is needed for ULTRA deps, and it is not provided through smarts installation. 