### PR TITLE
ground collisions clarification

### DIFF
--- a/smarts/core/chassis.py
+++ b/smarts/core/chassis.py
@@ -59,9 +59,13 @@ with open(controller_filepath, "r") as controller_file:
 def _query_bullet_contact_points(bullet_client, bullet_id, link_index):
     contact_objects = set()
 
-    min_, max_ = bullet_client.getAABB(bullet_id, link_index)
     # `getContactPoints` does not pick up collisions well so we cast a fast box check on the physics
+    min_, max_ = bullet_client.getAABB(bullet_id, link_index)
+    # note that getAABB returns a box around the link_index link only,
+    # which means it's offset from the ground (min_ has a positive z)
+    # if link_index=0 (the chassis link) is used.
     overlapping_objects = bullet_client.getOverlappingObjects(min_, max_)
+    # the pairs returned by getOverlappingObjects() appear to be in the form (body_id, link_idx)
     if overlapping_objects is not None:
         contact_objects = set(oo for oo, _ in overlapping_objects if oo != bullet_id)
 
@@ -528,7 +532,7 @@ class AckermannChassis(Chassis):
 
     @property
     def contact_points(self):
-        ## 0 is the chassis link index
+        ## 0 is the chassis link index (which means ground won't be included)
         contact_points = _query_bullet_contact_points(self._client, self._bullet_id, 0)
         return [
             ContactPoint(bullet_id=p[2], contact_point=p[5], contact_point_other=p[6])

--- a/smarts/core/tests/test_collision.py
+++ b/smarts/core/tests/test_collision.py
@@ -49,7 +49,13 @@ def bullet_client():
     path = Path(__file__).parent / "../smarts/core/models/plane.urdf"
     with pkg_resources.path(models, "plane.urdf") as path:
         plane_path = str(path.absolute())
-    client.loadURDF(plane_path, useFixedBase=True)
+    # create the ground plane to be big enough that the vehicles can potentially contact the ground too
+    client.loadURDF(
+        plane_path,
+        useFixedBase=True,
+        basePosition=(0, 0, 0),
+        globalScaling=1000.0 / 1e6,
+    )
 
     yield client
     client.disconnect()
@@ -80,15 +86,18 @@ def test_collision(bullet_client: bc.BulletClient):
         bullet_client=chassis._client,
     )
 
-    collisions = step_with_vehicle_commands(chassis, steps=1)
-    assert b_chassis.bullet_id in [c.bullet_id for c in collisions]
+    collisions = step_with_vehicle_commands(chassis, steps=2)
     assert len(collisions) > 0
+    collided_bullet_ids = set([c.bullet_id for c in collisions])
+    GROUND_ID = 0
+    assert b_chassis.bullet_id in collided_bullet_ids
+    assert chassis.bullet_id not in collided_bullet_ids
+    assert GROUND_ID not in collided_bullet_ids
 
 
 def test_non_collision(bullet_client: bc.BulletClient):
     """Spawn without overlap to check for the most basic collision"""
 
-    GROUND_ID = 0
     chassis = AckermannChassis(
         Pose.from_center([0, 0, 0], Heading(-math.pi * 0.5)), bullet_client
     )
@@ -101,13 +110,9 @@ def test_non_collision(bullet_client: bc.BulletClient):
     )
 
     collisions = step_with_vehicle_commands(chassis, steps=1)
-    collided_bullet_ids = [c.bullet_id for c in collisions]
+    collided_bullet_ids = set([c.bullet_id for c in collisions])
     assert b_chassis.bullet_id not in collided_bullet_ids
-    assert (
-        len(collisions) == 0
-        or len(collided_bullet_ids) == 1
-        and GROUND_ID in set(collided_bullet_ids)
-    )
+    assert len(collisions) == 0
 
 
 def test_collision_collide_with_standing_vehicle(bullet_client: bc.BulletClient):
@@ -123,8 +128,12 @@ def test_collision_collide_with_standing_vehicle(bullet_client: bc.BulletClient)
         bullet_client=chassis._client,
     )
     collisions = step_with_vehicle_commands(chassis, steps=1000, throttle=1, steering=0)
+    collided_bullet_ids = set([c.bullet_id for c in collisions])
+    GROUND_ID = 0
     assert len(collisions) > 0
-    assert b_chassis.bullet_id in [c.bullet_id for c in collisions]
+    assert b_chassis.bullet_id in collided_bullet_ids
+    assert chassis.bullet_id not in collided_bullet_ids
+    assert GROUND_ID not in collided_bullet_ids
 
 
 def _joust(wkc: AckermannChassis, bkc: AckermannChassis, steps, throttle=1):
@@ -140,7 +149,6 @@ def _joust(wkc: AckermannChassis, bkc: AckermannChassis, steps, throttle=1):
 
 def test_collision_joust(bullet_client: bc.BulletClient):
     """ Run two agents at each other to test for clipping. """
-    GROUND_ID = 0
     white_knight_chassis = AckermannChassis(
         Pose.from_center([10, 0, 0], Heading(math.pi * 0.5)), bullet_client
     )
@@ -223,7 +231,7 @@ def test_ackerman_chassis_size_unchanged(bullet_client: bc.BulletClient):
         bullet_client=bullet_client,
     )
     collisions = step_with_vehicle_commands(chassis, steps=10)
-    assert len(collisions) < 1
+    assert len(collisions) == 0
 
 
 AGENT_1 = "Agent_007"


### PR DESCRIPTION
Earlier, I was confused and mistaken about there being a bug in `_query_bullet_contact_points()` as I was expecting it to also return contacts with the ground plane.  

Once I figured out that it does not, I added comments and tweaked `test_collisions.py` to clarify that ground collisions will never be included in `contact_points`.

