### PR TITLE
fixed regression where route polygons instead of vertices were being …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Prevent vehicle insertion on top of ignored social vehicles when the `TrapManager` defaults to emitting a vehicle for the ego to control. See PR #1043
 - Prevent `TrapManager`from trapping vehicles in Bubble airlocks.  See Issue #1064.
 - Social-agent-buffer is instantiated only if the scenario requires social agents
+- Mapped Polygon object output of Route.geometry() to sequence of coordinates.
 ### Deprecated
 - The `timestep_sec` property of SMARTS is being deprecated in favor of `fixed_timesep_sec`
   for clarity since we are adding the ability to have variable time steps.

--- a/smarts/core/road_map.py
+++ b/smarts/core/road_map.py
@@ -380,7 +380,7 @@ class RoadMap:
 
         @property
         def geometry(self) -> Sequence[Sequence[Tuple[float, float]]]:
-            """A sequence of polygons describing the shape of each road on the route"""
+            """A sequence of polygon vertices describing the shape of each road on the route"""
             return []
 
         def distance_between(self, start: Point, end: Point) -> float:

--- a/smarts/core/sumo_road_network.py
+++ b/smarts/core/sumo_road_network.py
@@ -26,7 +26,7 @@ import trimesh
 import trimesh.scene
 from cached_property import cached_property
 from functools import lru_cache
-from shapely.geometry import Polygon, mapping
+from shapely.geometry import Polygon
 from shapely.ops import snap, triangulate
 from subprocess import check_output
 from trimesh.exchange import gltf
@@ -768,9 +768,11 @@ class SumoRoadNetwork(RoadMap):
         @cached_property
         def geometry(self) -> Sequence[Sequence[Tuple[float, float]]]:
             return [
-                mapping(road.buffered_shape(sum([lane._width for lane in road.lanes])))[
-                    "coordinates"
-                ]
+                list(
+                    road.buffered_shape(
+                        sum([lane._width for lane in road.lanes])
+                    ).exterior.coords
+                )
                 for road in self.roads
             ]
 

--- a/smarts/core/sumo_road_network.py
+++ b/smarts/core/sumo_road_network.py
@@ -773,7 +773,9 @@ class SumoRoadNetwork(RoadMap):
         @cached_property
         def geometry(self) -> Sequence[Sequence[Tuple[float, float]]]:
             return [
-                road.buffered_shape(sum([lane._width for lane in road.lanes]))
+                road.buffered_shape(
+                    sum([lane._width for lane in road.lanes])
+                ).exterior.coords
                 for road in self.roads
             ]
 

--- a/smarts/core/sumo_road_network.py
+++ b/smarts/core/sumo_road_network.py
@@ -19,22 +19,18 @@
 # THE SOFTWARE.
 import logging
 import math
+import numpy as np
 import os
 import random
-import re
-from functools import lru_cache
-from subprocess import check_output
-from tempfile import NamedTemporaryFile
-from typing import List, NamedTuple, Sequence, Tuple, Union
-
-import numpy as np
 import trimesh
 import trimesh.scene
 from cached_property import cached_property
-from shapely import ops
-from shapely.geometry import Polygon
+from functools import lru_cache
+from shapely.geometry import Polygon, mapping
 from shapely.ops import snap, triangulate
+from subprocess import check_output
 from trimesh.exchange import gltf
+from typing import List, Sequence, Tuple
 
 from .coordinates import BoundingBox, Heading, Point, Pose, RefLinePoint
 from .road_map import RoadMap, Waypoint
@@ -48,7 +44,6 @@ from .utils.math import (
 
 from smarts.core.utils.sumo import sumolib  # isort:skip
 from sumolib.net.edge import Edge  # isort:skip
-from sumolib.net.lane import Lane  # isort:skip
 
 
 def _convert_camera(camera):
@@ -773,9 +768,9 @@ class SumoRoadNetwork(RoadMap):
         @cached_property
         def geometry(self) -> Sequence[Sequence[Tuple[float, float]]]:
             return [
-                road.buffered_shape(
-                    sum([lane._width for lane in road.lanes])
-                ).exterior.coords
+                mapping(road.buffered_shape(sum([lane._width for lane in road.lanes])))[
+                    "coordinates"
+                ]
                 for road in self.roads
             ]
 


### PR DESCRIPTION
Fixed a regression arising from the merge of the `map_abstraction` branch where `Route` polygons were being returned for its `.geometry` property instead of its vertices.