### PR TITLE
Translate traffic history vehicle positions on import for shifted maps

### DIFF
--- a/smarts/core/road_map.py
+++ b/smarts/core/road_map.py
@@ -56,14 +56,6 @@ class RoadMap:
         raise NotImplementedError()
 
     @property
-    def xy_offset(self) -> Tuple[float, float]:
-        """optional: this is the amount that external coordinates must
-        be shifted in order to have the coordinate system (bounding_box)
-        start at the origin.  Will be (0. 0) for most maps."""
-        # TAI:  get rid of this, fix traffic_history_provider instead
-        return (0, 0)
-
-    @property
     def scale_factor(self) -> float:
         # map units per meter
         return 1.0

--- a/smarts/core/scenario.py
+++ b/smarts/core/scenario.py
@@ -424,7 +424,6 @@ class Scenario:
 
     def discover_missions_of_traffic_histories(self) -> Dict[str, Mission]:
         vehicle_missions = {}
-        map_offset = self._road_map.xy_offset
         for row in self._traffic_history.first_seen_times():
             start_time = float(row[1])
             pphs = self._traffic_history.vehicle_pose_at_time(row[0], start_time)
@@ -438,7 +437,7 @@ class Scenario:
             hhx, hhy = radians_to_vec(heading) * (0.5 * veh_length)
             vehicle_missions[v_id] = Mission(
                 start=Start(
-                    (pos_x + map_offset[0] + hhx, pos_y + map_offset[1] + hhy),
+                    (pos_x + hhx, pos_y + hhy),
                     Heading(heading),
                 ),
                 entry_tactic=entry_tactic,

--- a/smarts/core/sumo_road_network.py
+++ b/smarts/core/sumo_road_network.py
@@ -177,16 +177,6 @@ class SumoRoadNetwork(RoadMap):
             lanepoint_spacing=lanepoint_spacing,
         )
 
-    # TODO:  get rid of this, fix traffic_history_provider
-    @cached_property
-    def xy_offset(self):
-        """ This is our offset from what's in the original net file. """
-        return (
-            self._graph.getLocationOffset()
-            if self._graph and getattr(self._graph, "_shifted_by_smarts", False)
-            else [0, 0]
-        )
-
     @property
     def source(self) -> str:
         """ This is the net.xml file that corresponds with our possibly-offset coordinates. """

--- a/smarts/sstudio/genhistories.py
+++ b/smarts/sstudio/genhistories.py
@@ -140,6 +140,9 @@ class _TrajectoryDataset:
         insert_traj_sql = "INSERT INTO Trajectory VALUES (?, ?, ?, ?, ?, ?, ?)"
         vehicle_ids = set()
         itcur = dbconxn.cursor()
+
+        x_offset = self._dataset_spec.get("x_offset", 0.0)
+        y_offset = self._dataset_spec.get("y_offset", 0.0)
         for row in self.rows:
             vid = int(self.column_val_in_row(row, "vehicle_id"))
             if vid not in vehicle_ids:
@@ -168,8 +171,10 @@ class _TrajectoryDataset:
                     float(self.column_val_in_row(row, "sim_time")) / 1000,
                     time_precision,
                 ),
-                float(self.column_val_in_row(row, "position_x")) * self.scale,
-                float(self.column_val_in_row(row, "position_y")) * self.scale,
+                float(self.column_val_in_row(row, "position_x") + x_offset)
+                * self.scale,
+                float(self.column_val_in_row(row, "position_y") + y_offset)
+                * self.scale,
                 float(self.column_val_in_row(row, "heading_rad")),
                 float(self.column_val_in_row(row, "speed")) * self.scale,
                 self.column_val_in_row(row, "lane_id"),
@@ -335,8 +340,8 @@ class NGSIM(_TrajectoryDataset):
         df["sim_time"] = df["global_time"] - min(df["global_time"])
 
         # offset of the map from the data...
-        x_offset = self._dataset_spec.get("x_offset_px", 0) / self.scale
-        y_offset = self._dataset_spec.get("y_offset_px", 0) / self.scale
+        x_margin = self._dataset_spec.get("x_margin_px", 0) / self.scale
+        y_margin = self._dataset_spec.get("y_margin_px", 0) / self.scale
 
         df["length"] *= METERS_PER_FOOT
         df["width"] *= METERS_PER_FOOT
@@ -346,10 +351,10 @@ class NGSIM(_TrajectoryDataset):
         df["position_y"] *= METERS_PER_FOOT
         # SMARTS uses center not front
         df["position_x"] = (
-            df["position_x"] * METERS_PER_FOOT - 0.5 * df["length"] - x_offset
+            df["position_x"] * METERS_PER_FOOT - 0.5 * df["length"] - x_margin
         )
-        if y_offset:
-            df["position_x"] = df["position_y"] - y_offset
+        if y_margin:
+            df["position_x"] = df["position_y"] - y_margin
 
         if self._flip_y:
             max_y = self._dataset_spec["map_net"]["max_y"]
@@ -644,6 +649,8 @@ def _check_args(args):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
+    parser.add_argument("--x_offset", help="X offset of map", type=float)
+    parser.add_argument("--y_offset", help="Y offset of map", type=float)
     parser.add_argument(
         "--force",
         "-f",
@@ -679,6 +686,12 @@ if __name__ == "__main__":
     else:
         with open(args.dataset, "r") as yf:
             dataset_spec = yaml.safe_load(yf)["trajectory_dataset"]
+
+    if args.x_offset:
+        dataset_spec["x_offset"] = args.x_offset
+
+    if args.y_offset:
+        dataset_spec["y_offset"] = args.y_offset
 
     source = dataset_spec.get("source", "NGSIM")
     if source == "NGSIM":

--- a/smarts/sstudio/genscenario.py
+++ b/smarts/sstudio/genscenario.py
@@ -26,6 +26,7 @@ import itertools
 import logging
 import os
 import pickle
+from smarts.core.sumo_road_network import SumoRoadNetwork
 import subprocess
 import sys
 from dataclasses import replace
@@ -397,6 +398,16 @@ def _validate_entry_tactic(mission):
 
 
 def gen_traffic_histories(scenario: str, histories_datasets, overwrite: bool):
+    # For SUMO maps, we need to check if the map was shifted and translate the vehicle positions if so
+    xy_offset = None
+    road_network_path = os.path.join(scenario, "map.net.xml")
+    if os.path.exists(road_network_path):
+        road_network = SumoRoadNetwork.from_file(road_network_path)
+        if road_network._graph and getattr(
+            road_network._graph, "_shifted_by_smarts", False
+        ):
+            xy_offset = road_network._graph.getLocationOffset()
+
     genhistories_py = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "genhistories.py"
     )
@@ -417,6 +428,9 @@ def gen_traffic_histories(scenario: str, histories_datasets, overwrite: bool):
         th_file = f"{base}.shf"
         if overwrite:
             cmd += ["-f"]
+        if xy_offset:
+            cmd += ["--x_offset", str(xy_offset[0])]
+            cmd += ["--y_offset", str(xy_offset[1])]
         elif os.path.exists(os.path.join(scenario, th_file)):
             continue
         cmd += [th_file]


### PR DESCRIPTION
For SUMO maps that have been shifted, we now shift the positions of the traffic history vehicles on import (before writing them to the SQLite db). This lets us remove the `xy_offset` property from `RoadMap` and eliminates the need to do this shifting at runtime.