### PR TITLE
ROS deployment dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Added the ability to externally update SMARTS state via a new privileged-access `ExternalProvider`.
 - Allow specifying "-latest" as a version suffix for zoo locator strings.
 - Extended Imitation Learning codebase to allow importing traffic histories from the Waymo motion dataset and replay in a SMARTS simulation. See PR #1060.
-- Added `ros` and `remote-agent` extension rules to `setup.py`.
+- Added `ros` extension rule to `setup.py`.
 ### Changed
 - Made changes to log sections of the scenario step in `smarts.py` to help evaluate smarts performance problems. See Issue #661.
 - Introducted `RoadMap` class to abstract away from `SumoRoadNetwork` 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Added the ability to externally update SMARTS state via a new privileged-access `ExternalProvider`.
 - Allow specifying "-latest" as a version suffix for zoo locator strings.
 - Extended Imitation Learning codebase to allow importing traffic histories from the Waymo motion dataset and replay in a SMARTS simulation. See PR #1060.
+- Added `ros` and `remote-agent` extension rules to `setup.py` and remove dependency on `twisted`.
 ### Changed
 - Made changes to log sections of the scenario step in `smarts.py` to help evaluate smarts performance problems. See Issue #661.
 - Introducted `RoadMap` class to abstract away from `SumoRoadNetwork` 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Added the ability to externally update SMARTS state via a new privileged-access `ExternalProvider`.
 - Allow specifying "-latest" as a version suffix for zoo locator strings.
 - Extended Imitation Learning codebase to allow importing traffic histories from the Waymo motion dataset and replay in a SMARTS simulation. See PR #1060.
-- Added `ros` and `remote-agent` extension rules to `setup.py` and remove dependency on `twisted`.
+- Added `ros` and `remote-agent` extension rules to `setup.py`.
 ### Changed
 - Made changes to log sections of the scenario step in `smarts.py` to help evaluate smarts performance problems. See Issue #661.
 - Introducted `RoadMap` class to abstract away from `SumoRoadNetwork` 

--- a/requirements.txt
+++ b/requirements.txt
@@ -170,6 +170,7 @@ torchvision==0.5.0
 tornado==6.1
 traitlets==5.0.5
 trimesh==3.9.20
+Twisted==21.2.0
 typing==3.7.4.3
 typing-extensions==3.10.0.0
 urllib3==1.26.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -170,7 +170,6 @@ torchvision==0.5.0
 tornado==6.1
 traitlets==5.0.5
 trimesh==3.9.20
-Twisted==21.2.0
 typing==3.7.4.3
 typing-extensions==3.10.0.0
 urllib3==1.26.5

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "psutil",
         "visdom",
         "pybullet==3.0.6",
-        "sklearn",  # KDTree from sklearn is used by waypoints
+        "sklearn",  # KDTree from sklearn is used by sumo lanepoints
         "tableprint",
         "trimesh",  # Used for writing .glb files
         "pynput",  # Used by HumanKeyboardAgent
@@ -44,15 +44,11 @@ setup(
         "cloudpickle<1.4.0",
         "tornado",
         "websocket-client",
+        # The following is used for imitation learning and envision
+        "ijson",
         # The following are for the /smarts/algorithms
         "matplotlib",
         "scikit-image",
-        # The following are for /smarts/zoo
-        "grpcio==1.37.0",
-        "PyYAML",
-        "twisted",
-        # The following are used for imitation learning
-        "ijson",
     ],
     extras_require={
         "test": [
@@ -86,8 +82,18 @@ setup(
             "Panda3D==1.10.9",
             "panda3d-gltf==0.13",
         ],
+        "ros": [
+            "rospkg",
+            "catkin_pkg",
+        ],
         "waymo": [
             "waymo-open-dataset-tf-2-2-0",
+        ],
+        "remote-agents": [
+            # The following are for /smarts/zoo
+            "grpcio==1.37.0",
+            "protobuf",
+            "PyYAML",
         ],
     },
     entry_points={"console_scripts": ["scl=cli.cli:scl"]},

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,11 @@ setup(
         # The following are for the /smarts/algorithms
         "matplotlib",
         "scikit-image",
+        # The following are for /smarts/zoo and remote agents
+        "grpcio==1.37.0",
+        "protobuf",
+        "PyYAML",
+        "twisted",
     ],
     extras_require={
         "test": [
@@ -88,12 +93,6 @@ setup(
         ],
         "waymo": [
             "waymo-open-dataset-tf-2-2-0",
-        ],
-        "remote-agents": [
-            # The following are for /smarts/zoo
-            "grpcio==1.37.0",
-            "protobuf",
-            "PyYAML",
         ],
     },
     entry_points={"console_scripts": ["scl=cli.cli:scl"]},

--- a/smarts/core/agent_manager.py
+++ b/smarts/core/agent_manager.py
@@ -25,7 +25,6 @@ from smarts.core.agent_interface import AgentInterface
 from smarts.core.bubble_manager import BubbleManager
 from smarts.core.data_model import SocialAgent
 from smarts.core.plan import Plan
-from smarts.core.remote_agent_buffer import RemoteAgentBuffer
 from smarts.core.sensors import Observation, Sensors
 from smarts.core.utils.id import SocialAgentId
 from smarts.core.vehicle import VehicleState
@@ -343,6 +342,8 @@ class AgentManager:
         social_agents = sim.scenario.social_agents
         if social_agents:
             if not self._remote_agent_buffer:
+                from smarts.core.remote_agent_buffer import RemoteAgentBuffer
+
                 self._remote_agent_buffer = RemoteAgentBuffer(
                     zoo_manager_addrs=self._zoo_addrs
                 )
@@ -460,6 +461,8 @@ class AgentManager:
 
     def start_social_agent(self, agent_id, social_agent, agent_model):
         if not self._remote_agent_buffer:
+            from smarts.core.remote_agent_buffer import RemoteAgentBuffer
+
             self._remote_agent_buffer = RemoteAgentBuffer(
                 zoo_manager_addrs=self._zoo_addrs
             )


### PR DESCRIPTION
This PR adds a ROS extension rule to `setup.py` to facilitate deploying ROS-enabled versions of SMARTS.

It also makes the dependency on `protobuf` optional by only conditionally importing `RemoteAgentBuffer` when remote social agents are actually used.