### PR TITLE
ROS reset refactor

### DIFF
--- a/examples/ros/README.md
+++ b/examples/ros/README.md
@@ -98,12 +98,12 @@ rosrun smarts_ros ros_driver.py _target_freq:=20
 ### Scenarios
 
 Then, when you want to initialize SMARTS on a scenario,
-have one of the nodes on the ROS network publish an appropriate `SmartsControl` messsage on the `SMARTS/control` topic,
+have one of the nodes on the ROS network publish an appropriate `SmartsReset` messsage on the `SMARTS/reset` topic,
 after which SMARTS will begin handling messages from the `SMARTS/entities_in` channel.
 
 Or you could manually reset SMARTS from the command line with:
 ```bash
-rostopic pub /SMARTS/control smarts_ros/SmartsControl '{ reset_with_scenario_path: /full/path/to/scenario }'
+rostopic pub /SMARTS/reset smarts_ros/SmartsReset '{ reset_with_scenario_path: /full/path/to/scenario }'
 ```
 
 

--- a/examples/ros/src/smarts_ros/CMakeLists.txt
+++ b/examples/ros/src/smarts_ros/CMakeLists.txt
@@ -56,7 +56,7 @@ find_package(catkin REQUIRED COMPONENTS
    AgentTask.msg
    AgentReport.msg
    AgentsStamped.msg
-   SmartsControl.msg
+   SmartsReset.msg
  )
 
 ## Generate services in the 'srv' folder

--- a/examples/ros/src/smarts_ros/msg/SmartsControl.msg
+++ b/examples/ros/src/smarts_ros/msg/SmartsControl.msg
@@ -1,6 +1,0 @@
-
-# Send this whenever it is desired for SMARTS
-# to restart the simulation with a new scenario:
-string reset_with_scenario_path
-
-AgentSpec[]  initial_agents    # optional (may also be added dynamically via SMARTS/agent_spec topic)

--- a/examples/ros/src/smarts_ros/msg/SmartsReset.msg
+++ b/examples/ros/src/smarts_ros/msg/SmartsReset.msg
@@ -1,0 +1,4 @@
+
+string  scenario    # may be a path or a name, depending on the environment
+
+AgentSpec[]  initial_agents    # optional (may also be added dynamically via SMARTS/agent_spec topic)

--- a/examples/ros/src/smarts_ros/scripts/test_smarts_ros.py
+++ b/examples/ros/src/smarts_ros/scripts/test_smarts_ros.py
@@ -128,7 +128,7 @@ class TestSmartsRos(TestCase):
             return
         if not self._agents:
             self._create_agent()
-        for agent_spec in self._agents.items():
+        for agent_spec in self._agents.values():
             self._agent_publisher.publish(agent_spec)
 
     def run_forever(self):

--- a/examples/ros/src/smarts_ros/scripts/test_smarts_ros.py
+++ b/examples/ros/src/smarts_ros/scripts/test_smarts_ros.py
@@ -75,8 +75,7 @@ class TestSmartsRos(TestCase):
     def _vector_to_xyzw(v, xyzw):
         xyzw.x, xyzw.y, xyzw.z, xyzw.w = v[0], v[1], v[2], v[3]
 
-    @staticmethod
-    def _create_agent():
+    def _create_agent(self):
         agent_spec = AgentSpec()
         agent_spec.agent_id = "TestROSAgent"
         agent_spec.veh_type = AgentSpec.VEHICLE_TYPE_CAR
@@ -104,7 +103,7 @@ class TestSmartsRos(TestCase):
 
         self._agents = {}
         if rospy.get_param("~add_agent", False):
-            agent_spec = TestSmartsRos._create_agent()
+            agent_spec = self._create_agent()
             reset_msg.initial_agents = [agent_spec]
 
         self._reset_publisher.publish(reset_msg)
@@ -128,7 +127,7 @@ class TestSmartsRos(TestCase):
         if reset_msg.initial_agents or not rospy.get_param("~add_agent", False):
             return
         if not self._agents:
-            TestSmartsRos._create_agent()
+            self._create_agent()
         for agent_spec in self._agents.items():
             self._agent_publisher.publish(agent_spec)
 

--- a/examples/ros/src/smarts_ros/scripts/test_smarts_ros.py
+++ b/examples/ros/src/smarts_ros/scripts/test_smarts_ros.py
@@ -17,7 +17,7 @@ from smarts_ros.msg import (
     AgentsStamped,
     EntitiesStamped,
     EntityState,
-    SmartsControl,
+    SmartsReset,
 )
 from smarts_ros.srv import SmartsInfo
 from smarts.core.coordinates import fast_quaternion_from_angle
@@ -29,7 +29,7 @@ class TestSmartsRos(TestCase):
     def __init__(self):
         super().__init__()
         self._smarts_info_srv = None
-        self._control_publisher = None
+        self._reset_publisher = None
         self._agents = {}
 
     def setup_ros(
@@ -44,8 +44,8 @@ class TestSmartsRos(TestCase):
         # otherwise we use our default.
         namespace = def_namespace if not os.environ.get("ROS_NAMESPACE") else ""
 
-        self._control_publisher = rospy.Publisher(
-            f"{namespace}control", SmartsControl, queue_size=pub_queue_size
+        self._reset_publisher = rospy.Publisher(
+            f"{namespace}reset", SmartsReset, queue_size=pub_queue_size
         )
         self._agents_publisher = rospy.Publisher(
             f"{namespace}agent_spec", AgentSpec, queue_size=pub_queue_size
@@ -77,8 +77,8 @@ class TestSmartsRos(TestCase):
         scenario = rospy.get_param("~scenario")
         rospy.loginfo(f"Tester using scenario:  {scenario}.")
 
-        control_msg = SmartsControl()
-        control_msg.reset_with_scenario_path = scenario
+        reset_msg = SmartsReset()
+        reset_msg.scenario = scenario
         if rospy.get_param("~add_agent", False):
             agent_spec = AgentSpec()
             agent_spec.agent_id = "TestROSAgent"
@@ -96,10 +96,10 @@ class TestSmartsRos(TestCase):
             task.params_json = rospy.get_param("~task_params")
             agent_spec.tasks = [task]
             self._agents[agent_spec.agent_id] = agent_spec
-            control_msg.initial_agents = [agent_spec]
-        self._control_publisher.publish(control_msg)
+            reset_msg.initial_agents = [agent_spec]
+        self._reset_publisher.publish(reset_msg)
         rospy.loginfo(
-            f"SMARTS control message sent with scenario_path=f{control_msg.reset_with_scenario_path} and initial_agents=f{control_msg.initial_agents}."
+            f"SMARTS reset message sent with scenario_path=f{reset_msg.scenario} and initial_agents=f{reset_msg.initial_agents}."
         )
         return scenario
 


### PR DESCRIPTION
Simple refactor to change the name of `SmartsControl` to `SmartsReset` to clarify that it is only used in reset situations.

Also, updated `test_smarts_ros.py` to re-send any test agents on reset.

Also fixed minor race condition related to reset in `ros_driver.py`.