### PR TITLE
Python 3.8 fixes

### DIFF
--- a/smarts/core/plan.py
+++ b/smarts/core/plan.py
@@ -60,7 +60,7 @@ class Start:
         )
 
 
-@dataclass
+@dataclass(unsafe_hash=True)
 class Goal:
     def is_endless(self) -> bool:
         return True
@@ -69,12 +69,12 @@ class Goal:
         return False
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class EndlessGoal(Goal):
     pass
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class PositionalGoal(Goal):
     position: Point
     # target_heading: Heading

--- a/smarts/sstudio/tests/baseline.rou.xml
+++ b/smarts/sstudio/tests/baseline.rou.xml
@@ -4,7 +4,7 @@
 <configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/duarouterConfiguration.xsd">
 
     <input>
-        <net-file value="scenarios/intersections/4lane_t/map.net.xml"/>
+        <net-file value="scenarios/intersections/2lane_t/map.net.xml"/>
         <route-files value="/tmp/tmp6925s2db/trips.trips.xml"/>
     </input>
 
@@ -19,7 +19,7 @@
     </processing>
 
     <report>
-        <error-log value="/home/saul/.smarts/_duarouter_routing/traffic/generated.log"/>
+        <error-log value="/tmp/smarts/_duarouter_routing/traffic/generated.log"/>
         <no-step-log value="true"/>
     </report>
 

--- a/smarts/sstudio/tests/baseline.rou.xml
+++ b/smarts/sstudio/tests/baseline.rou.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- generated on Tue Sep  8 21:17:05 2020 by Eclipse SUMO duarouter Version 1.6.0
+<!-- generated on 2021-09-16 14:35:19 by Eclipse SUMO duarouter Version 1.10.0
 <configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/duarouterConfiguration.xsd">
 
     <input>
-        <net-file value="scenarios/intersections/2lane_t/map.net.xml"/>
-        <route-files value="/tmp/tmpvauebp9k/trips.trips.xml"/>
+        <net-file value="scenarios/intersections/4lane_t/map.net.xml"/>
+        <route-files value="/tmp/tmpbjfalps9/trips.trips.xml"/>
     </input>
 
     <output>
@@ -19,7 +19,7 @@
     </processing>
 
     <report>
-        <error-log value="/tmp/smarts/_duarouter_routing/traffic/generated.log"/>
+        <error-log value="/home/saul/.smarts/_duarouter_routing/traffic/generated.log"/>
         <no-step-log value="true"/>
     </report>
 
@@ -31,18 +31,18 @@
 -->
 
 <routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/routes_file.xsd">
-    <vType id="actor-car-5974851877247858186" minGap="2.50" maxSpeed="55.50" speedFactor="normc(1.00,0.20,0.20,2.00)" vClass="passenger" accel="2.6" decel="4.5" sigma="0.5"/>
-    <vehicle id="car-flow-route-edge-east-EW_0_30-edge-west-EW_0_-30--4117495477927931840--9115604273415384466--1-0.0" type="actor-car-5974851877247858186" depart="0.00" departLane="0" departPos="30.00" departSpeed="max" arrivalLane="0" arrivalPos="-30.00">
+    <vType id="actor-car-170490069500684938" minGap="2.50" maxSpeed="55.50" speedFactor="normc(1.00,0.20,0.20,2.00)" vClass="passenger" accel="2.6" decel="4.5" sigma="0.5"/>
+    <vehicle id="car-flow-route-edge-east-EW_0_30-edge-west-EW_0_-30-112670310863024920460051116542568968190--314985435287235156732952963285730887978--1-0.0" type="actor-car-170490069500684938" depart="0.00" departLane="0" departPos="30.00" departSpeed="max" arrivalLane="0" arrivalPos="-30.00">
         <route edges="edge-east-EW edge-west-EW"/>
     </vehicle>
-    <vType id="actor-car--1856733372394314985" minGap="2.50" maxSpeed="55.50" speedFactor="normc(0.80,0.20,0.20,2.00)" vClass="passenger" impatience="0.50" lcCooperative="0.25" lcImpatience="1" jmDriveAfterYellowTime="1.0" accel="2.6" decel="4.5" sigma="0.5"/>
-    <vehicle id="car-flow-route-edge-east-EW_0_30-edge-west-EW_0_-30--4117495477927931840--9115604273415384466--1-1.0" type="actor-car--1856733372394314985" depart="0.00" departLane="0" departPos="30.00" departSpeed="max" arrivalLane="0" arrivalPos="-30.00">
+    <vType id="actor-car-1628151229987693029" minGap="2.50" maxSpeed="55.50" speedFactor="normc(0.80,0.20,0.20,2.00)" vClass="passenger" impatience="0.50" lcCooperative="0.25" lcImpatience="1" jmDriveAfterYellowTime="1.0" accel="2.6" decel="4.5" sigma="0.5"/>
+    <vehicle id="car-flow-route-edge-east-EW_0_30-edge-west-EW_0_-30-112670310863024920460051116542568968190--314985435287235156732952963285730887978--1-1.0" type="actor-car-1628151229987693029" depart="0.00" departLane="0" departPos="30.00" departSpeed="max" arrivalLane="0" arrivalPos="-30.00">
         <route edges="edge-east-EW edge-west-EW"/>
     </vehicle>
-    <vehicle id="car-flow-route-edge-west-WE_0_30-edge-east-WE_0_-30--6121202786866783653--9115604273415384466--0-0.0" type="actor-car-5974851877247858186" depart="0.00" departLane="0" departPos="30.00" departSpeed="max" arrivalLane="0" arrivalPos="-30.00">
+    <vehicle id="car-flow-route-edge-west-WE_0_30-edge-east-WE_0_-30-327793626907654756799069529522845818864--314985435287235156732952963285730887978--0-0.0" type="actor-car-170490069500684938" depart="0.00" departLane="0" departPos="30.00" departSpeed="max" arrivalLane="0" arrivalPos="-30.00">
         <route edges="edge-west-WE edge-east-WE"/>
     </vehicle>
-    <vehicle id="car-flow-route-edge-west-WE_0_30-edge-east-WE_0_-30--6121202786866783653--9115604273415384466--0-1.0" type="actor-car--1856733372394314985" depart="0.00" departLane="0" departPos="30.00" departSpeed="max" arrivalLane="0" arrivalPos="-30.00">
+    <vehicle id="car-flow-route-edge-west-WE_0_30-edge-east-WE_0_-30-327793626907654756799069529522845818864--314985435287235156732952963285730887978--0-1.0" type="actor-car-1628151229987693029" depart="0.00" departLane="0" departPos="30.00" departSpeed="max" arrivalLane="0" arrivalPos="-30.00">
         <route edges="edge-west-WE edge-east-WE"/>
     </vehicle>
 </routes>

--- a/smarts/sstudio/tests/baseline.rou.xml
+++ b/smarts/sstudio/tests/baseline.rou.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- generated on 2021-09-16 14:35:19 by Eclipse SUMO duarouter Version 1.10.0
+<!-- generated on 2021-09-17 11:11:04 by Eclipse SUMO duarouter Version 1.10.0
 <configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/duarouterConfiguration.xsd">
 
     <input>
         <net-file value="scenarios/intersections/4lane_t/map.net.xml"/>
-        <route-files value="/tmp/tmpbjfalps9/trips.trips.xml"/>
+        <route-files value="/tmp/tmp6925s2db/trips.trips.xml"/>
     </input>
 
     <output>
@@ -31,18 +31,18 @@
 -->
 
 <routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/routes_file.xsd">
-    <vType id="actor-car-170490069500684938" minGap="2.50" maxSpeed="55.50" speedFactor="normc(1.00,0.20,0.20,2.00)" vClass="passenger" accel="2.6" decel="4.5" sigma="0.5"/>
-    <vehicle id="car-flow-route-edge-east-EW_0_30-edge-west-EW_0_-30-112670310863024920460051116542568968190--314985435287235156732952963285730887978--1-0.0" type="actor-car-170490069500684938" depart="0.00" departLane="0" departPos="30.00" departSpeed="max" arrivalLane="0" arrivalPos="-30.00">
+    <vType id="actor-car--6154633892093701017" minGap="2.50" maxSpeed="55.50" speedFactor="normc(1.00,0.20,0.20,2.00)" vClass="passenger" accel="2.6" decel="4.5" sigma="0.5"/>
+    <vehicle id="car-flow-route-edge-east-EW_0_30-edge-west-EW_0_-30--1926453700110831618---1272272649408374293--1-0.0" type="actor-car--6154633892093701017" depart="0.00" departLane="0" departPos="30.00" departSpeed="max" arrivalLane="0" arrivalPos="-30.00">
         <route edges="edge-east-EW edge-west-EW"/>
     </vehicle>
-    <vType id="actor-car-1628151229987693029" minGap="2.50" maxSpeed="55.50" speedFactor="normc(0.80,0.20,0.20,2.00)" vClass="passenger" impatience="0.50" lcCooperative="0.25" lcImpatience="1" jmDriveAfterYellowTime="1.0" accel="2.6" decel="4.5" sigma="0.5"/>
-    <vehicle id="car-flow-route-edge-east-EW_0_30-edge-west-EW_0_-30-112670310863024920460051116542568968190--314985435287235156732952963285730887978--1-1.0" type="actor-car-1628151229987693029" depart="0.00" departLane="0" departPos="30.00" departSpeed="max" arrivalLane="0" arrivalPos="-30.00">
+    <vType id="actor-car--3764963214027188709" minGap="2.50" maxSpeed="55.50" speedFactor="normc(0.80,0.20,0.20,2.00)" vClass="passenger" impatience="0.50" lcCooperative="0.25" lcImpatience="1" jmDriveAfterYellowTime="1.0" accel="2.6" decel="4.5" sigma="0.5"/>
+    <vehicle id="car-flow-route-edge-east-EW_0_30-edge-west-EW_0_-30--1926453700110831618---1272272649408374293--1-1.0" type="actor-car--3764963214027188709" depart="0.00" departLane="0" departPos="30.00" departSpeed="max" arrivalLane="0" arrivalPos="-30.00">
         <route edges="edge-east-EW edge-west-EW"/>
     </vehicle>
-    <vehicle id="car-flow-route-edge-west-WE_0_30-edge-east-WE_0_-30-327793626907654756799069529522845818864--314985435287235156732952963285730887978--0-0.0" type="actor-car-170490069500684938" depart="0.00" departLane="0" departPos="30.00" departSpeed="max" arrivalLane="0" arrivalPos="-30.00">
+    <vehicle id="car-flow-route-edge-west-WE_0_30-edge-east-WE_0_-30--8546353394728787984---1272272649408374293--0-0.0" type="actor-car--6154633892093701017" depart="0.00" departLane="0" departPos="30.00" departSpeed="max" arrivalLane="0" arrivalPos="-30.00">
         <route edges="edge-west-WE edge-east-WE"/>
     </vehicle>
-    <vehicle id="car-flow-route-edge-west-WE_0_30-edge-east-WE_0_-30-327793626907654756799069529522845818864--314985435287235156732952963285730887978--0-1.0" type="actor-car-1628151229987693029" depart="0.00" departLane="0" departPos="30.00" departSpeed="max" arrivalLane="0" arrivalPos="-30.00">
+    <vehicle id="car-flow-route-edge-west-WE_0_30-edge-east-WE_0_-30--8546353394728787984---1272272649408374293--0-1.0" type="actor-car--3764963214027188709" depart="0.00" departLane="0" departPos="30.00" departSpeed="max" arrivalLane="0" arrivalPos="-30.00">
         <route edges="edge-west-WE edge-east-WE"/>
     </vehicle>
 </routes>

--- a/smarts/sstudio/types.py
+++ b/smarts/sstudio/types.py
@@ -18,6 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 import collections.abc as collections_abc
+from ctypes import c_int64
 import hashlib
 import logging
 import pickle
@@ -43,11 +44,12 @@ from smarts.core.utils.id import SocialAgentId
 from smarts.core.utils.math import rotate_around_point
 
 
-def _pickle_hash(obj):
+def _pickle_hash(obj) -> int:
     pickle_bytes = pickle.dumps(obj, protocol=4)
     hasher = hashlib.md5()
     hasher.update(pickle_bytes)
-    return int(hasher.hexdigest(), 16)
+    val = int(hasher.hexdigest(), 16)
+    return c_int64(val).value
 
 
 class _SumoParams(collections_abc.Mapping):
@@ -319,7 +321,8 @@ class Flow:
     @property
     def id(self) -> str:
         return "flow-{}-{}-".format(
-            self.route.id, str(_pickle_hash(frozenset(self.actors.items())))
+            self.route.id,
+            str(_pickle_hash(sorted(self.actors.items(), key=lambda a: a[0].name))),
         )
 
     def __hash__(self):

--- a/smarts/sstudio/types.py
+++ b/smarts/sstudio/types.py
@@ -18,7 +18,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 import collections.abc as collections_abc
+import hashlib
 import logging
+import pickle
 import random
 from dataclasses import dataclass, field
 from sys import maxsize
@@ -39,6 +41,13 @@ from smarts.core.coordinates import RefLinePoint
 from smarts.core.road_map import RoadMap
 from smarts.core.utils.id import SocialAgentId
 from smarts.core.utils.math import rotate_around_point
+
+
+def _pickle_hash(obj):
+    pickle_bytes = pickle.dumps(obj, protocol=4)
+    hasher = hashlib.md5()
+    hasher.update(pickle_bytes)
+    return int(hasher.hexdigest(), 16)
 
 
 class _SumoParams(collections_abc.Mapping):
@@ -146,7 +155,7 @@ class Actor:
     pass
 
 
-@dataclass(frozen=True, unsafe_hash=True)
+@dataclass(frozen=True)
 class TrafficActor(Actor):
     """Used as a description/spec for traffic actors (e.x. Vehicles, Pedestrians,
     etc). The defaults provided are for a car, but the name is not set to make it
@@ -181,6 +190,9 @@ class TrafficActor(Actor):
         default_factory=LaneChangingModel, hash=False
     )
     junction_model: JunctionModel = field(default_factory=JunctionModel, hash=False)
+
+    def __hash__(self) -> int:
+        return _pickle_hash(self)
 
     @property
     def id(self) -> str:
@@ -265,7 +277,7 @@ class Route:
         return "route-{}-{}-{}-".format(
             "_".join(map(str, self.begin)),
             "_".join(map(str, self.end)),
-            hash(self),
+            _pickle_hash(self),
         )
 
     @property
@@ -307,13 +319,13 @@ class Flow:
     @property
     def id(self) -> str:
         return "flow-{}-{}-".format(
-            self.route.id, str(hash(frozenset(self.actors.items())))
+            self.route.id, str(_pickle_hash(frozenset(self.actors.items())))
         )
 
     def __hash__(self):
         # Custom hash since self.actors is not hashable, here we first convert to a
         # frozenset.
-        return hash((self.route, self.rate, frozenset(self.actors.items())))
+        return _pickle_hash((self.route, self.rate, frozenset(self.actors.items())))
 
     def __eq__(self, other):
         return self.__class__ == other.__class__ and hash(self) == hash(other)


### PR DESCRIPTION
This PR fixes some issues from using SMARTS with Python 3.8. The tests now pass with Python 3.8 and we can add this to the CI if we want.

- Added `unsafe_hash=True` to various `Goal` classes since they must be hashable, but can't be `frozen` because of 3.8-specific differences with dataclass inheritance
- Added a hash function that is consistent across Python versions for types that have their `id`s compared to an expected value in the sstudio tests