### PR TITLE
batch_mode for smarts_ros node

### DIFF
--- a/examples/ros/README.md
+++ b/examples/ros/README.md
@@ -88,6 +88,8 @@ ROS private node parameters if used via `rosrun`:
 
 - `_seed`:  Seed to use when initializing SMARTS' random number generator(s).  Defaults to `42`.
 
+- `_batch_mode`:  If `True`, the node will stay alive even if SMARTS crashes/dies, waiting for a new `SmartsReset` message on the `SMARTS/reset` topic.  Defaults to `False`.
+
 
 To specify these via the command line, use syntax like:
 ```bash

--- a/examples/ros/src/smarts_ros/launch/ros_driver.launch
+++ b/examples/ros/src/smarts_ros/launch/ros_driver.launch
@@ -5,6 +5,7 @@
   <arg name="buffer_size" default="3" doc="The number of entity messages to buffer to use for smoothing/extrapolation.  Must be a positive integer." />
   <arg name="headless" default="true" doc="Controls whether SMARTS should also emit its state to an Envision server." />
   <arg name="seed" default="42" doc="Seed to use when initializing SMARTS' random number generator(s)." />
+  <arg name="batch_mode" default="false" doc="If true, the node will stay alive even if SMARTS crashes/dies, waiting for a new SmartsReset message on the SMARTS/reset topic." />
 
   <node pkg="smarts_ros" name="SMARTS" type="ros_driver.py" output="screen">
     <param name="target_freq" type="double" value="$(arg target_freq)" />
@@ -12,6 +13,7 @@
     <param name="buffer_size" type="int" value="$(arg buffer_size)" />
     <param name="headless" type="bool" value="$(arg headless)" />
     <param name="seed" type="int" value="$(arg seed)" />
+    <param name="batch_mode" type="bool" value="$(arg batch_mode)" />
   </node>
 
 

--- a/examples/ros/src/smarts_ros/scripts/ros_driver.py
+++ b/examples/ros/src/smarts_ros/scripts/ros_driver.py
@@ -613,14 +613,24 @@ class ROSDriver:
                 if obs is not None:
                     observations = obs
 
-                actions = self._do_agents(observations)
+                try:
+                    actions = self._do_agents(observations)
 
-                step_delta = self._update_smarts_state()
+                    step_delta = self._update_smarts_state()
 
-                observations, _, dones, _ = self._smarts.step(actions, step_delta)
+                    observations, _, dones, _ = self._smarts.step(actions, step_delta)
 
-                self._publish_state()
-                self._publish_agents(observations, dones)
+                    self._publish_state()
+                    self._publish_agents(observations, dones)
+                except Exception as e:
+                    if isinstance(e, rospy.ROSInterruptException):
+                        raise e
+                    batch_mode = rospy.get_param("~batch_mode", False)
+                    if not batch_mode:
+                        raise e
+                    rospy.logerr(f"SMARTS raised exception:  {e}")
+                    rospy.logerr("Will wait for next reset...")
+                    self._scenario_path = None
 
                 if self._target_freq:
                     if rate.remaining().to_sec() <= 0.0:


### PR DESCRIPTION
Adds a parameter to the `smarts_ros` node to have it swallow SMARTS exceptions such that multiple tests can be run through ROS in batch mode without having to worry about SMARTS crashing.