### PR TITLE
Cache controller params on scenario reset

### DIFF
--- a/smarts/core/agent_manager.py
+++ b/smarts/core/agent_manager.py
@@ -430,7 +430,6 @@ class AgentManager:
             scenario.tire_parameters_filepath,
             trainable,
             scenario.surface_patches,
-            scenario.controller_parameters_filepath,
             agent_model.initial_speed,
             boid=boid,
         )

--- a/smarts/core/smarts.py
+++ b/smarts/core/smarts.py
@@ -363,6 +363,9 @@ class SMARTS:
             self._renderer.setup(scenario)
         self._setup_bullet_client(self._bullet_client)
         provider_state = self._setup_providers(self._scenario)
+        self._vehicle_index.load_controller_params(
+            scenario.controller_parameters_filepath
+        )
         self._agent_manager.setup_agents(self)
 
         self._harmonize_providers(provider_state)

--- a/smarts/core/trap_manager.py
+++ b/smarts/core/trap_manager.py
@@ -275,7 +275,6 @@ class TrapManager:
             sim.scenario.tire_parameters_filepath,
             True,
             sim.scenario.surface_patches,
-            sim.scenario.controller_parameters_filepath,
             initial_speed=initial_speed,
             boid=False,
         )

--- a/smarts/core/utils/resources.py
+++ b/smarts/core/utils/resources.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2021. Huawei Technologies Co., Ltd. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+import importlib.resources as pkg_resources
+import os
+
+import yaml
+
+from .. import models
+
+
+def load_controller_params(controller_filepath: str):
+    if (controller_filepath is None) or not os.path.exists(controller_filepath):
+        with pkg_resources.path(
+            models, "controller_parameters.yaml"
+        ) as controller_path:
+            controller_filepath = str(controller_path.absolute())
+    with open(controller_filepath, "r") as controller_file:
+        return yaml.safe_load(controller_file)

--- a/smarts/core/vehicle.py
+++ b/smarts/core/vehicle.py
@@ -335,7 +335,6 @@ class Vehicle:
         tire_filepath,
         trainable,
         surface_patches,
-        controller_filepath,
         initial_speed=None,
     ):
         mission = plan.mission
@@ -367,15 +366,9 @@ class Vehicle:
             with pkg_resources.path(models, urdf_name + ".urdf") as path:
                 vehicle_filepath = str(path.absolute())
 
-        if (controller_filepath is None) or not os.path.exists(controller_filepath):
-            with pkg_resources.path(
-                models, "controller_parameters.yaml"
-            ) as controller_path:
-                controller_filepath = str(controller_path.absolute())
-        with open(controller_filepath, "r") as controller_file:
-            controller_parameters = yaml.safe_load(controller_file)[
-                agent_interface.vehicle_type
-            ]
+        controller_parameters = sim.vehicle_index.controller_params_for_vehicle_type(
+            agent_interface.vehicle_type
+        )
 
         chassis = None
         # change this to dynamic_action_spaces later when pr merged

--- a/smarts/core/vehicle_index.py
+++ b/smarts/core/vehicle_index.py
@@ -22,18 +22,15 @@ from copy import copy, deepcopy
 from enum import IntEnum
 from io import StringIO
 from typing import FrozenSet, NamedTuple
-import importlib.resources as pkg_resources
-import yaml
-import os
 
 import numpy as np
 import tableprint as tp
 
 from smarts.core import gen_id
+from smarts.core.utils import resources
 from smarts.core.utils.cache import cache, clear_cache
 from smarts.core.utils.string import truncate
 
-from . import models
 from .chassis import AckermannChassis, BoxChassis
 from .controllers import ControllerState
 from .sensors import SensorState
@@ -682,13 +679,7 @@ class VehicleIndex:
         return self._controller_states[vehicle_id]
 
     def load_controller_params(self, controller_filepath: str):
-        if (controller_filepath is None) or not os.path.exists(controller_filepath):
-            with pkg_resources.path(
-                models, "controller_parameters.yaml"
-            ) as controller_path:
-                controller_filepath = str(controller_path.absolute())
-        with open(controller_filepath, "r") as controller_file:
-            self._controller_params = yaml.safe_load(controller_file)
+        self._controller_params = resources.load_controller_params(controller_filepath)
 
     def controller_params_for_vehicle_type(self, vehicle_type: str):
         assert self._controller_params, "Controller params have not been loaded"


### PR DESCRIPTION
From profiling, it was discovered that loading the controller parameters from the yaml file was causing a ~10 ms spike when a vehicle was created from a trap being triggered (see first image below)

![6lane (before)](https://user-images.githubusercontent.com/17256344/139150733-bd10a8bc-42b8-4ff4-a1ab-30b369399f62.png)

This PR prevents this spike from happening during the simulation loop by loading the yaml file on scenario reset (see next image for profiling data after the change)

![6lane (after)](https://user-images.githubusercontent.com/17256344/139150912-e98396a1-4909-4b07-9fd1-f5f56324c5df.png)