### PR TITLE
ROS logging issues

### DIFF
--- a/examples/ros/src/smarts_ros/scripts/ros_driver.py
+++ b/examples/ros/src/smarts_ros/scripts/ros_driver.py
@@ -42,10 +42,9 @@ from smarts.core.utils.math import (
     vec_to_radians,
     yaw_from_quaternion,
 )
+from smarts.core.utils.ros import log_everything_to_ROS
 from smarts.core.vehicle import VehicleState
 from smarts.zoo import registry
-
-from utils.ros import log_everything_to_ROS
 
 
 class ROSDriver:

--- a/smarts/core/utils/ros.py
+++ b/smarts/core/utils/ros.py
@@ -2,6 +2,9 @@ import logging
 import rospy
 
 
+# Note:  use of these utilities may require installing the SMARTS package with the "[ros]" extentions.
+
+
 class LogToROSHandler(logging.Handler):
     """
      Logging Handler that converts python logging levels to rospy logger levels.
@@ -44,12 +47,12 @@ def log_everything_to_ROS(level=None):
     NOTE:  In order to avoid an infinite recursion, the `propagate` property
     will be set to `False` on any existing loggers whose name starts with "ros".
     (All of the rospy loggers start with this string.)
-
     """
     root = logging.getLogger(None)
     for logger_name, logger in root.manager.loggerDict.items():
         if logger_name.startswith("ros"):
             logger.propagate = False
+    ros_handler = LogToROSHandler()
     if level is not None:
-        root.setLevel(level)
-    root.addHandler(LogToROSHandler())
+        ros_handler.setLevel(level)
+    root.addHandler(ros_handler)


### PR DESCRIPTION
Fixed two issues with PR #1113:

- the `utils/ros` folder is not included in our packaging, so I moved that to `smarts/core/utils/ros.py`
- the level should only be set for the handler that sends messages to rospy logging, not for all handlers
