### PR TITLE
Dimensions equal_if_defined method

### DIFF
--- a/smarts/core/coordinates.py
+++ b/smarts/core/coordinates.py
@@ -57,6 +57,13 @@ class Dimensions:
     def as_lwh(self):
         return (self.length, self.width, self.height)
 
+    def equal_if_defined(self, length: float, width: float, height: float) -> bool:
+        return (
+            (not self.length or self.length == -1 or self.length == length)
+            and (not self.width or self.width == -1 or self.width == width)
+            and (not self.height or self.height == -1 or self.height == height)
+        )
+
 
 class Point(NamedTuple):
     x: float

--- a/smarts/core/vehicle.py
+++ b/smarts/core/vehicle.py
@@ -541,11 +541,7 @@ class Vehicle:
         ) or not np.allclose(self._chassis.velocity_vectors[1], state.angular_velocity):
             linear_velocity = state.linear_velocity
             angular_velocity = state.angular_velocity
-        if (
-            state.dimensions.length != self.length
-            or state.dimensions.width != self.width
-            or state.dimensions.height != self.height
-        ):
+        if not state.dimensions.equal_if_defined(self.length, self.width, self.height):
             self._log.warning(
                 "Unable to change a vehicle's dimensions via external_state_update()."
             )


### PR DESCRIPTION
Added `equal_if_defined` for `Dimensions` class to quiet logger warnings coming from updating state from ROS messages (now that we can see them!).