### PR TITLE
Update deprecated Shapely functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Prevent `TrapManager`from trapping vehicles in Bubble airlocks.  See Issue #1064.
 - Social-agent-buffer is instantiated only if the scenario requires social agents
 - Mapped Polygon object output of Route.geometry() to sequence of coordinates.
+- Updated deprecated Shapely functionality.
 ### Deprecated
 - The `timestep_sec` property of SMARTS is being deprecated in favor of `fixed_timesep_sec`
   for clarity since we are adding the ability to have variable time steps.

--- a/smarts/core/utils/ros.py
+++ b/smarts/core/utils/ros.py
@@ -1,3 +1,25 @@
+# MIT License
+#
+# Copyright (C) 2021. Huawei Technologies Co., Ltd. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
 import logging
 import rospy
 

--- a/smarts/sstudio/types.py
+++ b/smarts/sstudio/types.py
@@ -518,19 +518,19 @@ class MapZone(Zone):
                 return lane_shape
 
             # For simplicty, we only deal w/ the == 1 or 2 case
-            if len(lane_shape) not in {1, 2}:
+            if len(lane_shape.geoms) not in {1, 2}:
                 return None
 
-            if len(lane_shape) == 1:
+            if len(lane_shape.geoms) == 1:
                 return lane_shape[0]
 
             # We assume that there are only two splited shapes to choose from
             keep_index = 0
-            if lane_shape[1].minimum_rotated_rectangle.contains(expected_point):
+            if lane_shape.geoms[1].minimum_rotated_rectangle.contains(expected_point):
                 # 0 is the discard piece, keep the other
                 keep_index = 1
 
-            lane_shape = lane_shape[keep_index]
+            lane_shape = lane_shape.geoms[keep_index]
 
             return lane_shape
 


### PR DESCRIPTION
Deprecated Shapely functionality is updated.

```
SMARTS/smarts/sstudio/types.py:521: ShapelyDeprecationWarning: __len__ for multi-part geometries is deprecated and will be removed in Shapely 2.0. Check the length of the `geoms` property instead to get the  number of parts of a multi-part geometry.
  if len(lane_shape) not in {1, 2}:

SMARTS/smarts/sstudio/types.py:529: ShapelyDeprecationWarning: __getitem__ for multi-part geometries is deprecated and will be removed in Shapely 2.0. Use the `geoms` property to access the constituent parts of a multi-part geometry.
  if lane_shape[1].minimum_rotated_rectangle.contains(expected_point):
```
