### PR TITLE
Single-agent env wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Added a `-y` option to `utils/setup/install_deps.sh` to accept installation by default. See issue #1081.
 - Added `ParallelEnv` class and a corresponding example to simulate multiple SMARTS environments in parallel, with synchronous or asynchronous episodes.
 - Added `smarts.core.utils.import_utils` to help with the dynamic import of modules.
+- Added `single_agent` env wrapper and unit test. The wrapper converts a single-agent SMARTS environment's step and reset output to be compliant with gym spaces.
 ### Changed
 - `test-requirements` github action job renamed to `check-requirements-change` and only checks for requirements changes without failing.
 - Moved examples tests to `examples` and used relative imports to fix a module collision with `aiohttp`'s `examples` module.

--- a/smarts/core/utils/episodes.py
+++ b/smarts/core/utils/episodes.py
@@ -17,11 +17,9 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-import os
-import sys
+
 import time
 from collections import defaultdict
-from contextlib import contextmanager
 from dataclasses import dataclass, field
 
 import tableprint as tp
@@ -63,9 +61,21 @@ class EpisodeLog:
     def record_step(self, observations=None, rewards=None, dones=None, infos=None):
         self.steps += 1
 
+        if not isinstance(observations, dict):
+            observations, rewards, dones, infos = self._convert_to_dict(
+                observations, rewards, dones, infos
+            )
+
         if dones.get("__all__", False) and infos is not None:
             for agent, score in infos.items():
                 self.scores[agent] = score["score"]
+
+    def _convert_to_dict(self, observations, rewards, dones, infos):
+        observations, rewards, infos = [
+            {"SingleAgent": obj} for obj in [observations, rewards, infos]
+        ]
+        dones = {"SingleAgent": dones, "__all__": dones}
+        return observations, rewards, dones, infos
 
 
 def episodes(n):

--- a/smarts/env/tests/test_single_agent.py
+++ b/smarts/env/tests/test_single_agent.py
@@ -1,0 +1,129 @@
+# MIT License
+#
+# Copyright (C) 2021. Huawei Technologies Co., Ltd. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import gym
+import numpy as np
+import pytest
+
+from smarts.core.agent import Agent, AgentSpec
+from smarts.core.agent_interface import RGB, AgentInterface
+from smarts.core.controllers import ActionSpaceType
+from smarts.env.wrappers.single_agent import SingleAgent
+
+
+def _make_agent_specs(num_agent):
+    agent_specs = {
+        "AGENT_"
+        + str(agent_id): AgentSpec(
+            interface=AgentInterface(
+                rgb=RGB(),
+                action=ActionSpaceType.Lane,
+            ),
+            agent_builder=lambda: Agent.from_function(lambda _: "keep_lane"),
+            observation_adapter=lambda obs: obs.top_down_rgb.data,
+            reward_adapter=lambda obs, reward: reward,
+            info_adapter=lambda obs, reward, info: info["score"],
+        )
+        for agent_id in range(num_agent)
+    }
+
+    obs_space = gym.spaces.Dict(
+        {
+            "AGENT_"
+            + str(agent_id): gym.spaces.Box(
+                low=0,
+                high=255,
+                shape=(
+                    agent_specs["AGENT_" + str(agent_id)].interface.rgb.width,
+                    agent_specs["AGENT_" + str(agent_id)].interface.rgb.height,
+                    3,
+                ),
+                dtype=np.uint8,
+            )
+            for agent_id in range(num_agent)
+        }
+    )
+
+    return agent_specs, obs_space
+
+
+@pytest.fixture
+def base_env(request):
+    agent_specs, obs_space = _make_agent_specs(request.param)
+    env = gym.make(
+        "smarts.env:hiway-v0",
+        scenarios=["scenarios/figure_eight"],
+        agent_specs=agent_specs,
+        headless=True,
+        visdom=False,
+        fixed_timestep_sec=0.01,
+    )
+    env.observation_space = obs_space
+
+    yield env
+    env.close()
+
+
+@pytest.mark.parametrize("base_env", [1, 2], indirect=True)
+def test_init(base_env):
+    agent_specs = base_env.agent_specs
+    obs_space = base_env.observation_space
+
+    # Test wrapping an env containing one and more than one agent
+    if len(agent_specs) > 1:
+        with pytest.raises(AssertionError):
+            env = SingleAgent(base_env)
+            env.close()
+        return
+    else:
+        env = SingleAgent(base_env)
+
+    # Test env observation space
+    agent_id = next(iter(agent_specs.keys()))
+    assert isinstance(env.observation_space, type(obs_space[agent_id]))
+    assert env.observation_space.shape == obs_space[agent_id].shape
+    assert env.observation_space.dtype == obs_space[agent_id].dtype
+
+    env.close()
+
+
+@pytest.mark.parametrize("base_env", [1], indirect=True)
+def test_reset_and_step(base_env):
+    agent_specs = base_env.agent_specs
+    obs_space = base_env.observation_space
+    env = SingleAgent(base_env)
+
+    # Test resetting the env
+    obs = env.reset()
+    assert isinstance(obs, np.ndarray)
+    agent_id = next(iter(agent_specs.keys()))
+    assert obs.shape == obs_space[agent_id].shape
+
+    # Test stepping the env
+    obs, reward, done, info = env.step("keep_lane")
+    assert isinstance(obs, np.ndarray)
+    assert obs.shape == obs_space[agent_id].shape
+    assert isinstance(reward, float)
+    assert isinstance(done, bool)
+    assert isinstance(info, float)
+
+    env.close()

--- a/smarts/env/wrappers/single_agent.py
+++ b/smarts/env/wrappers/single_agent.py
@@ -1,0 +1,72 @@
+# MIT License
+#
+# Copyright (C) 2021. Huawei Technologies Co., Ltd. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from typing import Any, Tuple
+
+import gym
+
+
+class SingleAgent(gym.Wrapper):
+    """Converts a single-agent SMARTS environment's step and reset output to be
+    compliant with gym spaces."""
+
+    def __init__(self, env: gym.Env):
+        """
+        Args:
+            env (gym.Env): Single-agent SMARTS environment to be wrapped.
+        """
+        super(SingleAgent, self).__init__(env)
+
+        agent_ids = list(env.agent_specs.keys())
+        assert (
+            len(agent_ids) == 1
+        ), f"Expected env to have a single agent, but got {len(agent_ids)} agents."
+        self._agent_id = agent_ids[0]
+
+        if self.observation_space:
+            self.observation_space = self.observation_space[self._agent_id]
+
+    def step(self, action: Any) -> Tuple[Any, float, bool, Any]:
+        """Steps a single-agent SMARTS environment.
+
+        Args:
+            action (Any): Agent's action
+
+        Returns:
+            Tuple[Any, float, bool, Any]: Agent's observation, reward, done, and info
+        """
+        obs, reward, done, info = self.env.step({self._agent_id: action})
+        return (
+            obs[self._agent_id],
+            reward[self._agent_id],
+            done[self._agent_id],
+            info[self._agent_id],
+        )
+
+    def reset(self) -> Any:
+        """Resets a single-agent SMARTS environment.
+
+        Returns:
+            Any: Agent's observation
+        """
+        obs = self.env.reset()
+        return obs[self._agent_id]


### PR DESCRIPTION
1. Converts a single-agent SMARTS environment's `step` and `reset` output to be compliant with gym spaces.
2. Helps users to easily train or evaluate SMARTS with existing single-agent reinforcement-learning algorithms.