### PR TITLE
removed accidentally-added extra parameter to road.shape() call

### DIFF
--- a/smarts/core/sumo_road_network.py
+++ b/smarts/core/sumo_road_network.py
@@ -833,7 +833,7 @@ class SumoRoadNetwork(RoadMap):
             return [
                 list(
                     road.shape(
-                        sum([lane._width for lane in road.lanes]), 1.0
+                        sum([lane._width for lane in road.lanes])
                     ).exterior.coords
                 )
                 for road in self.roads


### PR DESCRIPTION
this bug got introduced accidentally with PR #1106.