### PR TITLE
Pybullet Step Fix

### DIFF
--- a/examples/history_vehicles_replacement_for_imitation_learning.py
+++ b/examples/history_vehicles_replacement_for_imitation_learning.py
@@ -141,6 +141,7 @@ def main(
             agents = {}
             dones = {}
             ego_missions = {}
+            sample = {}
 
             if scenario.traffic_history.dataset_source == "Waymo":
                 # For Waymo, we only hijack the vehicle that was autonomous in the dataset

--- a/smarts/core/smarts.py
+++ b/smarts/core/smarts.py
@@ -712,11 +712,11 @@ class SMARTS:
         return provider_state
 
     def _nondynamic_provider_step(
-        self, agent_actions, step_pybullet: bool
+        self, agent_actions, stepped_pybullet: bool
     ) -> ProviderState:
         self._perform_agent_actions(agent_actions)
 
-        if step_pybullet:
+        if not stepped_pybullet:
             self._step_pybullet()
 
         self._process_collisions()

--- a/smarts/core/smarts.py
+++ b/smarts/core/smarts.py
@@ -675,27 +675,17 @@ class SMARTS:
                 vehicle.chassis.reapply_last_control()
             self._bullet_client.stepSimulation()
 
-    def _pybullet_provider_step(self, agent_actions) -> ProviderState:
-        self._perform_agent_actions(agent_actions)
-
-        self._check_ground_plane()
-
-        self._step_pybullet()
-
-        self._process_collisions()
-
-        provider_state = ProviderState()
-        pybullet_agent_ids = {
+    def _get_provider_state(self, source: str, action_space_pred) -> ProviderState:
+        agent_ids = {
             agent_id
             for agent_id, interface in self._agent_manager.agent_interfaces.items()
-            if interface.action_space in self._dynamic_action_spaces
+            if action_space_pred(interface.action_space)
         }
-
+        provider_state = ProviderState()
         for vehicle_id in self._vehicle_index.agent_vehicle_ids():
             agent_id = self._vehicle_index.actor_id_from_vehicle_id(vehicle_id)
-            if agent_id not in pybullet_agent_ids:
+            if agent_id not in agent_ids:
                 continue
-
             vehicle = self._vehicle_index.vehicle_by_id(vehicle_id)
             vehicle.step(self._elapsed_sim_time)
             provider_state.vehicles.append(
@@ -705,48 +695,9 @@ class SMARTS:
                     pose=vehicle.pose,
                     dimensions=vehicle.chassis.dimensions,
                     speed=vehicle.speed,
-                    source="PYBULLET",
+                    source=source,
                 )
             )
-
-        return provider_state
-
-    def _nondynamic_provider_step(
-        self, agent_actions, stepped_pybullet: bool
-    ) -> ProviderState:
-        self._perform_agent_actions(agent_actions)
-
-        if not stepped_pybullet:
-            self._step_pybullet()
-
-        self._process_collisions()
-
-        provider_state = ProviderState()
-        nondynamic_agent_ids = {
-            agent_id
-            for agent_id, interface in self._agent_manager.agent_interfaces.items()
-            if interface.action_space not in self._dynamic_action_spaces
-        }
-
-        for vehicle_id in self._vehicle_index.agent_vehicle_ids():
-            agent_id = self._vehicle_index.actor_id_from_vehicle_id(vehicle_id)
-            if agent_id not in nondynamic_agent_ids:
-                continue
-
-            vehicle = self._vehicle_index.vehicle_by_id(vehicle_id)
-            assert isinstance(vehicle.chassis, BoxChassis)
-            vehicle.step(self._elapsed_sim_time)
-            provider_state.vehicles.append(
-                VehicleState(
-                    vehicle_id=vehicle.id,
-                    vehicle_config_type="passenger",
-                    pose=vehicle.pose,
-                    dimensions=vehicle.chassis.dimensions,
-                    speed=vehicle.speed,
-                    source="OTHER",
-                )
-            )
-
         return provider_state
 
     @property
@@ -818,14 +769,26 @@ class SMARTS:
             elif matches_no_provider_action_space(agent_id):
                 other_actions[agent_id] = action
 
-        if pybullet_actions:
-            accumulated_provider_state.merge(
-                self._pybullet_provider_step(pybullet_actions)
-            )
-        if other_actions:
-            accumulated_provider_state.merge(
-                self._nondynamic_provider_step(other_actions, bool(pybullet_actions))
-            )
+        if pybullet_actions or other_actions:
+            self._perform_agent_actions(pybullet_actions)
+            self._perform_agent_actions(other_actions)
+            self._check_ground_plane()
+            self._step_pybullet()
+            self._process_collisions()
+            if pybullet_actions:
+                as_pred = (
+                    lambda action_space: action_space in self._dynamic_action_spaces
+                )
+                accumulated_provider_state.merge(
+                    self._get_provider_state("PYBULLET", as_pred)
+                )
+            if other_actions:
+                as_pred = (
+                    lambda action_space: action_space not in self._dynamic_action_spaces
+                )
+                accumulated_provider_state.merge(
+                    self._get_provider_state("OTHER", as_pred)
+                )
 
         for provider in self.providers:
             provider_state = self._step_provider(provider, actions)

--- a/smarts/core/utils/bullet.py
+++ b/smarts/core/utils/bullet.py
@@ -102,6 +102,7 @@ class BulletBoxShape:
         )
 
         self._height = height
+        # XXX: we might want to give these more mass...
         self._bullet_id = self._client.createMultiBody(1, collision_box)
 
     def reset_pose(self, pose: Pose):


### PR DESCRIPTION
Fixed a simple, but annoying logic bug causing `pybullet` to not be stepped.  This should fix issues #969 and #1137.

Also added a unit test for ensuring that collisions between two `BoxChassis` vehicles are detected too.