### PR TITLE
relative import fix

### DIFF
--- a/examples/ego_open_agent.py
+++ b/examples/ego_open_agent.py
@@ -19,7 +19,12 @@ except ModuleNotFoundError as e:
         f"Ensure that the open-agent has been installed with `pip install open-agent"
     )
 
-from argument_parser import default_argument_parser
+# The following ugliness was made necessary because the `aiohttp` #
+# dependency has an "examples" module too.  (See PR #1120.)
+if __name__ == "__main__":
+    from argument_parser import default_argument_parser
+else:
+    from .argument_parser import default_argument_parser
 
 logging.basicConfig(level=logging.INFO)
 

--- a/examples/ego_open_agent.py
+++ b/examples/ego_open_agent.py
@@ -19,7 +19,7 @@ except ModuleNotFoundError as e:
         f"Ensure that the open-agent has been installed with `pip install open-agent"
     )
 
-from .argument_parser import default_argument_parser
+from argument_parser import default_argument_parser
 
 logging.basicConfig(level=logging.INFO)
 

--- a/examples/egoless.py
+++ b/examples/egoless.py
@@ -4,7 +4,7 @@ import gym
 
 from smarts.core.utils.episodes import episodes
 
-from .argument_parser import default_argument_parser
+from argument_parser import default_argument_parser
 
 logging.basicConfig(level=logging.INFO)
 

--- a/examples/egoless.py
+++ b/examples/egoless.py
@@ -4,7 +4,12 @@ import gym
 
 from smarts.core.utils.episodes import episodes
 
-from argument_parser import default_argument_parser
+# The following ugliness was made necessary because the `aiohttp` #
+# dependency has an "examples" module too.  (See PR #1120.)
+if __name__ == "__main__":
+    from argument_parser import default_argument_parser
+else:
+    from .argument_parser import default_argument_parser
 
 logging.basicConfig(level=logging.INFO)
 

--- a/examples/history_vehicles_replacement_for_imitation_learning.py
+++ b/examples/history_vehicles_replacement_for_imitation_learning.py
@@ -15,7 +15,7 @@ from smarts.core.smarts import SMARTS
 from smarts.core.traffic_history_provider import TrafficHistoryProvider
 from smarts.core.utils.math import rounder_for_dt
 
-from .argument_parser import default_argument_parser
+from argument_parser import default_argument_parser
 
 logging.basicConfig(level=logging.INFO)
 

--- a/examples/history_vehicles_replacement_for_imitation_learning.py
+++ b/examples/history_vehicles_replacement_for_imitation_learning.py
@@ -15,7 +15,12 @@ from smarts.core.smarts import SMARTS
 from smarts.core.traffic_history_provider import TrafficHistoryProvider
 from smarts.core.utils.math import rounder_for_dt
 
-from argument_parser import default_argument_parser
+# The following ugliness was made necessary because the `aiohttp` #
+# dependency has an "examples" module too.  (See PR #1120.)
+if __name__ == "__main__":
+    from argument_parser import default_argument_parser
+else:
+    from .argument_parser import default_argument_parser
 
 logging.basicConfig(level=logging.INFO)
 

--- a/examples/human_in_the_loop.py
+++ b/examples/human_in_the_loop.py
@@ -7,7 +7,12 @@ from smarts.core.agent import Agent, AgentSpec
 from smarts.core.agent_interface import AgentInterface, AgentType
 from smarts.core.utils.episodes import episodes
 
-from argument_parser import default_argument_parser
+# The following ugliness was made necessary because the `aiohttp` #
+# dependency has an "examples" module too.  (See PR #1120.)
+if __name__ == "__main__":
+    from argument_parser import default_argument_parser
+else:
+    from .argument_parser import default_argument_parser
 
 logging.basicConfig(level=logging.INFO)
 

--- a/examples/human_in_the_loop.py
+++ b/examples/human_in_the_loop.py
@@ -7,7 +7,7 @@ from smarts.core.agent import Agent, AgentSpec
 from smarts.core.agent_interface import AgentInterface, AgentType
 from smarts.core.utils.episodes import episodes
 
-from .argument_parser import default_argument_parser
+from argument_parser import default_argument_parser
 
 logging.basicConfig(level=logging.INFO)
 

--- a/examples/multi_agent.py
+++ b/examples/multi_agent.py
@@ -4,7 +4,12 @@ from smarts.core.agent import Agent, AgentSpec
 from smarts.core.agent_interface import AgentInterface, AgentType
 from smarts.core.utils.episodes import episodes
 
-from argument_parser import default_argument_parser
+# The following ugliness was made necessary because the `aiohttp` #
+# dependency has an "examples" module too.  (See PR #1120.)
+if __name__ == "__main__":
+    from argument_parser import default_argument_parser
+else:
+    from .argument_parser import default_argument_parser
 
 N_AGENTS = 4
 AGENT_IDS = ["Agent %i" % i for i in range(N_AGENTS)]

--- a/examples/multi_agent.py
+++ b/examples/multi_agent.py
@@ -4,7 +4,7 @@ from smarts.core.agent import Agent, AgentSpec
 from smarts.core.agent_interface import AgentInterface, AgentType
 from smarts.core.utils.episodes import episodes
 
-from .argument_parser import default_argument_parser
+from argument_parser import default_argument_parser
 
 N_AGENTS = 4
 AGENT_IDS = ["Agent %i" % i for i in range(N_AGENTS)]

--- a/examples/observation_collection_for_imitation_learning.py
+++ b/examples/observation_collection_for_imitation_learning.py
@@ -13,7 +13,7 @@ from smarts.core.smarts import SMARTS
 from smarts.core.sumo_traffic_simulation import SumoTrafficSimulation
 from smarts.core.utils.math import radians_to_vec
 
-from .argument_parser import default_argument_parser
+from argument_parser import default_argument_parser
 
 logging.basicConfig(level=logging.INFO)
 

--- a/examples/observation_collection_for_imitation_learning.py
+++ b/examples/observation_collection_for_imitation_learning.py
@@ -13,7 +13,12 @@ from smarts.core.smarts import SMARTS
 from smarts.core.sumo_traffic_simulation import SumoTrafficSimulation
 from smarts.core.utils.math import radians_to_vec
 
-from argument_parser import default_argument_parser
+# The following ugliness was made necessary because the `aiohttp` #
+# dependency has an "examples" module too.  (See PR #1120.)
+if __name__ == "__main__":
+    from argument_parser import default_argument_parser
+else:
+    from .argument_parser import default_argument_parser
 
 logging.basicConfig(level=logging.INFO)
 

--- a/examples/parallel_environment.py
+++ b/examples/parallel_environment.py
@@ -12,7 +12,7 @@ from smarts.env.hiway_env import HiWayEnv
 from smarts.env.wrappers.frame_stack import FrameStack
 from smarts.env.wrappers.parallel_env import ParallelEnv
 
-from .argument_parser import default_argument_parser
+from argument_parser import default_argument_parser
 
 
 class ChaseViaPointsAgent(Agent):

--- a/examples/parallel_environment.py
+++ b/examples/parallel_environment.py
@@ -12,7 +12,12 @@ from smarts.env.hiway_env import HiWayEnv
 from smarts.env.wrappers.frame_stack import FrameStack
 from smarts.env.wrappers.parallel_env import ParallelEnv
 
-from argument_parser import default_argument_parser
+# The following ugliness was made necessary because the `aiohttp` #
+# dependency has an "examples" module too.  (See PR #1120.)
+if __name__ == "__main__":
+    from argument_parser import default_argument_parser
+else:
+    from .argument_parser import default_argument_parser
 
 
 class ChaseViaPointsAgent(Agent):

--- a/examples/ray_multi_instance.py
+++ b/examples/ray_multi_instance.py
@@ -20,7 +20,13 @@ from smarts.core.agent import Agent, AgentSpec
 from smarts.core.agent_interface import AgentInterface, AgentType
 from smarts.core.utils.episodes import episodes
 
-from argument_parser import default_argument_parser
+# The following ugliness was made necessary because the `aiohttp` #
+# dependency has an "examples" module too.  (See PR #1120.)
+if __name__ == "__main__":
+    from argument_parser import default_argument_parser
+else:
+    from .argument_parser import default_argument_parser
+
 
 logging.basicConfig(level=logging.INFO)
 

--- a/examples/ray_multi_instance.py
+++ b/examples/ray_multi_instance.py
@@ -20,7 +20,7 @@ from smarts.core.agent import Agent, AgentSpec
 from smarts.core.agent_interface import AgentInterface, AgentType
 from smarts.core.utils.episodes import episodes
 
-from .argument_parser import default_argument_parser
+from argument_parser import default_argument_parser
 
 logging.basicConfig(level=logging.INFO)
 

--- a/examples/single_agent.py
+++ b/examples/single_agent.py
@@ -8,7 +8,7 @@ from smarts.core.sensors import Observation
 from smarts.core.utils.episodes import episodes
 from smarts.env.wrappers.single_agent import SingleAgent
 
-from .argument_parser import default_argument_parser
+from examples.argument_parser import default_argument_parser
 
 logging.basicConfig(level=logging.INFO)
 

--- a/examples/single_agent.py
+++ b/examples/single_agent.py
@@ -8,7 +8,12 @@ from smarts.core.sensors import Observation
 from smarts.core.utils.episodes import episodes
 from smarts.env.wrappers.single_agent import SingleAgent
 
-from examples.argument_parser import default_argument_parser
+# The following ugliness was made necessary because the `aiohttp` #
+# dependency has an "examples" module too.  (See PR #1120.)
+if __name__ == "__main__":
+    from argument_parser import default_argument_parser
+else:
+    from .argument_parser import default_argument_parser
 
 logging.basicConfig(level=logging.INFO)
 

--- a/examples/trajectory_tracking_agent.py
+++ b/examples/trajectory_tracking_agent.py
@@ -6,7 +6,12 @@ from smarts.core.agent import Agent, AgentSpec
 from smarts.core.agent_interface import AgentInterface, AgentType
 from smarts.core.utils.episodes import episodes
 
-from argument_parser import default_argument_parser
+# The following ugliness was made necessary because the `aiohttp` #
+# dependency has an "examples" module too.  (See PR #1120.)
+if __name__ == "__main__":
+    from argument_parser import default_argument_parser
+else:
+    from .argument_parser import default_argument_parser
 
 logging.basicConfig(level=logging.INFO)
 

--- a/examples/trajectory_tracking_agent.py
+++ b/examples/trajectory_tracking_agent.py
@@ -6,7 +6,7 @@ from smarts.core.agent import Agent, AgentSpec
 from smarts.core.agent_interface import AgentInterface, AgentType
 from smarts.core.utils.episodes import episodes
 
-from .argument_parser import default_argument_parser
+from argument_parser import default_argument_parser
 
 logging.basicConfig(level=logging.INFO)
 


### PR DESCRIPTION
Fix all relative imports of `argument_parser`, which cause problems when running our example scripts from the command line.
(These were made relative in PR #1120 due to a dependency having an `examples` module.)