### PR TITLE
Flexible ParallelEnv wrapper

### DIFF
--- a/examples/parallel_environment.py
+++ b/examples/parallel_environment.py
@@ -59,8 +59,8 @@ def main(
         for agent_id in agent_ids
     }
 
-    # Create a callable env constructor. Here, for illustration purposes, each 
-    # environment is wrapped with a FrameStack wrapper which returns stacked 
+    # Create a callable env constructor. Here, for illustration purposes, each
+    # environment is wrapped with a FrameStack wrapper which returns stacked
     # observations for each environment.
     env_frame_stack = lambda env: FrameStack(
         env=env,
@@ -76,7 +76,9 @@ def main(
             headless=headless,
         )
     )
-    env_constructors = [lambda : env_constructor(sim_name+f"_{ind}") for ind in num_env]
+    env_constructors = [
+        lambda: env_constructor(sim_name + f"_{ind}") for ind in num_env
+    ]
 
     # Build multiple agents
     agents = {

--- a/examples/parallel_environment.py
+++ b/examples/parallel_environment.py
@@ -2,7 +2,10 @@ import gym
 
 gym.logger.set_level(40)
 
+from functools import partial
 from typing import Dict, Sequence, Tuple
+
+from argument_parser import default_argument_parser
 
 from smarts.core.agent import Agent, AgentSpec
 from smarts.core.agent_interface import AgentInterface
@@ -11,13 +14,6 @@ from smarts.core.sensors import Observation
 from smarts.env.hiway_env import HiWayEnv
 from smarts.env.wrappers.frame_stack import FrameStack
 from smarts.env.wrappers.parallel_env import ParallelEnv
-
-# The following ugliness was made necessary because the `aiohttp` #
-# dependency has an "examples" module too.  (See PR #1120.)
-if __name__ == "__main__":
-    from argument_parser import default_argument_parser
-else:
-    from .argument_parser import default_argument_parser
 
 
 class ChaseViaPointsAgent(Agent):
@@ -78,7 +74,7 @@ def main(
     )
     # A list of env constructors of type `Callable[[], gym.Env]`
     env_constructors = [
-        lambda ind=ind: env_constructor(f"{sim_name}_{ind}") for ind in range(num_env)
+        partial(env_constructor, sim_name=f"{sim_name}_{ind}") for ind in range(num_env)
     ]
 
     # Build multiple agents
@@ -221,7 +217,7 @@ if __name__ == "__main__":
     if not args.sim_name:
         args.sim_name = "par_env"
 
-    print("\nParallel environments with asynchronous episodes.\n")
+    print("\nParallel environments with asynchronous episodes.")
     main(
         scenarios=args.scenarios,
         sim_name=args.sim_name,
@@ -241,7 +237,7 @@ if __name__ == "__main__":
         sim_name=args.sim_name,
         headless=args.headless,
         seed=args.seed,
-        num_agents=args.num_agents,
+        num_agents=args.num_agents + 1,
         num_stack=args.num_stack,
         num_env=args.num_env,
         auto_reset=False,

--- a/examples/parallel_environment.py
+++ b/examples/parallel_environment.py
@@ -59,12 +59,15 @@ def main(
         for agent_id in agent_ids
     }
 
-    # Create a callable env constructor. Here, for illustration purposes, each environment is
-    # wrapped with a FrameStack wrapper which returns stacked observations for each environment.
+    # Create a callable env constructor. Here, for illustration purposes, each 
+    # environment is wrapped with a FrameStack wrapper which returns stacked 
+    # observations for each environment.
     env_frame_stack = lambda env: FrameStack(
         env=env,
         num_stack=num_stack,
     )
+    # Unique `sim_name` is required by each HiWayEnv in order to be displayed
+    # in Envision.
     env_constructor = lambda sim_name: env_frame_stack(
         HiWayEnv(
             scenarios=scenarios,
@@ -73,6 +76,7 @@ def main(
             headless=headless,
         )
     )
+    env_constructors = [lambda : env_constructor(sim_name+f"_{ind}") for ind in num_env]
 
     # Build multiple agents
     agents = {
@@ -82,8 +86,7 @@ def main(
 
     # Create parallel environments
     env = ParallelEnv(
-        env_constructors=[env_constructor] * num_env,
-        sim_name=sim_name,
+        env_constructors=env_constructors,
         auto_reset=auto_reset,
         seed=seed,
     )

--- a/examples/parallel_environment.py
+++ b/examples/parallel_environment.py
@@ -220,7 +220,7 @@ if __name__ == "__main__":
     print("\nParallel environments with asynchronous episodes.")
     main(
         scenarios=args.scenarios,
-        sim_name=args.sim_name,
+        sim_name=f"{args.sim_name}_async",
         headless=args.headless,
         seed=args.seed,
         num_agents=args.num_agents,
@@ -234,10 +234,10 @@ if __name__ == "__main__":
     print("\nParallel environments with synchronous episodes.\n")
     main(
         scenarios=args.scenarios,
-        sim_name=args.sim_name,
+        sim_name=f"{args.sim_name}_sync",
         headless=args.headless,
         seed=args.seed,
-        num_agents=args.num_agents + 1,
+        num_agents=args.num_agents,
         num_stack=args.num_stack,
         num_env=args.num_env,
         auto_reset=False,

--- a/smarts/core/sumo_road_network.py
+++ b/smarts/core/sumo_road_network.py
@@ -29,11 +29,9 @@ import numpy as np
 import trimesh
 import trimesh.scene
 from cached_property import cached_property
-from functools import lru_cache
-from shapely.geometry import Polygon
 from shapely.geometry import Point as shPoint
+from shapely.geometry import Polygon
 from shapely.ops import nearest_points, snap, triangulate
-from subprocess import check_output
 from trimesh.exchange import gltf
 
 from .coordinates import BoundingBox, Heading, Point, Pose, RefLinePoint

--- a/smarts/env/tests/test_parallel_env.py
+++ b/smarts/env/tests/test_parallel_env.py
@@ -58,10 +58,10 @@ def single_env_actions(agent_specs):
 
 @pytest.fixture(scope="module")
 def env_constructor(agent_specs):
-    env_constructor = lambda sim_name: HiWayEnv(
+    env_constructor = lambda : HiWayEnv(
         scenarios=["scenarios/loop"],
         agent_specs=agent_specs,
-        sim_name=sim_name,
+        sim_name="Test_env",
         headless=True,
     )
     return env_constructor
@@ -69,8 +69,8 @@ def env_constructor(agent_specs):
 
 def test_non_callable_env_constructors(env_constructor):
     env_constructed = [
-        env_constructor(sim_name="Test"),
-        env_constructor(sim_name="Test"),
+        env_constructor(),
+        env_constructor(),
     ]
     with pytest.raises(TypeError):
         env = ParallelEnv(env_constructors=env_constructed, auto_reset=True)
@@ -88,7 +88,7 @@ def _make_parallel_env(env_constructor, num_env, auto_reset=True, seed=42):
 
 @pytest.mark.parametrize("num_env", [2])
 def test_spaces(env_constructor, num_env):
-    single_env = env_constructor(sim_name="Test")
+    single_env = env_constructor()
     env = _make_parallel_env(env_constructor, num_env)
 
     assert env.batch_size == num_env
@@ -123,7 +123,7 @@ def _compare_observations(num_env, batched_observations, single_observations):
 
 @pytest.mark.parametrize("num_env", [2])
 def test_reset(env_constructor, num_env):
-    single_env = env_constructor(sim_name="Test")
+    single_env = env_constructor()
     single_observations = single_env.reset()
     single_env.close()
 
@@ -137,7 +137,7 @@ def test_reset(env_constructor, num_env):
 @pytest.mark.parametrize("num_env", [2])
 @pytest.mark.parametrize("auto_reset", [True])
 def test_step(env_constructor, single_env_actions, num_env, auto_reset):
-    single_env = env_constructor(sim_name="Test")
+    single_env = env_constructor()
     single_env.reset()
     single_observations, _, _, _ = single_env.step(single_env_actions)
     single_env.close()

--- a/smarts/env/tests/test_parallel_env.py
+++ b/smarts/env/tests/test_parallel_env.py
@@ -58,7 +58,7 @@ def single_env_actions(agent_specs):
 
 @pytest.fixture(scope="module")
 def env_constructor(agent_specs):
-    env_constructor = lambda : HiWayEnv(
+    env_constructor = lambda: HiWayEnv(
         scenarios=["scenarios/loop"],
         agent_specs=agent_specs,
         sim_name="Test_env",

--- a/smarts/env/wrappers/parallel_env.py
+++ b/smarts/env/wrappers/parallel_env.py
@@ -33,7 +33,7 @@ import gym
 __all__ = ["ParallelEnv"]
 
 
-EnvConstructor = Callable[[str], gym.Env]
+EnvConstructor = Callable[[], gym.Env]
 
 
 class _Message(Enum):
@@ -60,7 +60,6 @@ class ParallelEnv(object):
         self,
         env_constructors: Sequence[EnvConstructor],
         auto_reset: bool,
-        sim_name: Optional[str] = None,
         seed: int = 42,
     ):
         """The environments can be different but must use the same action and
@@ -69,7 +68,6 @@ class ParallelEnv(object):
         Args:
             env_constructors (Sequence[EnvConstructor]): List of callables that create environments.
             auto_reset (bool): Automatically resets an environment when episode ends.
-            sim_name (Optional[str], optional): Simulation name prefix. Defaults to None.
             seed (int, optional): Seed for the first environment. Defaults to 42.
 
         Raises:
@@ -108,8 +106,6 @@ class ParallelEnv(object):
                 target=_worker,
                 name=f"Worker-<{type(self).__name__}>-<{idx}>",
                 args=(
-                    idx,
-                    sim_name,
                     cloudpickle.dumps(env_constructor),
                     auto_reset,
                     child_pipe,
@@ -270,8 +266,6 @@ class ParallelEnv(object):
 
 
 def _worker(
-    index: int,
-    sim_name: str,
     env_constructor: bytes,
     auto_reset: bool,
     pipe: mp.connection.Connection,
@@ -282,8 +276,6 @@ def _worker(
     the environment, and returns the observations.
 
     Args:
-        index (int): Environment index number.
-        sim_name (str): Simulation name.
         env_constructor (bytes): Cloudpickled callable which constructs the environment.
         auto_reset (bool): If True, auto resets environment when episode ends.
         pipe (mp.connection.Connection): Child's end of the pipe.
@@ -292,10 +284,7 @@ def _worker(
     Raises:
         KeyError: If unknown message type is received.
     """
-    name = f"env_{index}"
-    if sim_name:
-        name = sim_name + "_" + name
-    env = cloudpickle.loads(env_constructor)(sim_name=name)
+    env = cloudpickle.loads(env_constructor)()
     pipe.send((_Message.RESULT, None))
 
     try:


### PR DESCRIPTION
1) Modified env constructor type from `Callable[[str], gym.Env]` to `Callable[[], gym.Env]`.
2) Improved parallel environment example in order to be more appealing to the user.