### PR TITLE
avoid ambiguous exception handling in creating road map

### DIFF
--- a/smarts/core/default_map_factory.py
+++ b/smarts/core/default_map_factory.py
@@ -48,7 +48,7 @@ def create_road_map(
     if not os.path.isfile(map_path):
         map_path = os.path.join(map_source, "map.net.xml")
         if not os.path.exists(map_path):
-            raise Exception(f"Unable to find map in map_source={map_source}.")
+            raise FileNotFoundError(f"Unable to find map in map_source={map_source}.")
 
     # Keep this a conditional import so Sumo does not have to be
     # imported if not necessary:

--- a/smarts/core/scenario.py
+++ b/smarts/core/scenario.py
@@ -598,7 +598,7 @@ class Scenario:
         # just make sure we can load the map
         try:
             road_map, _ = create_road_map(scenario_root)
-        except:
+        except FileNotFoundError:
             return False
         return road_map is not None
 


### PR DESCRIPTION
The general exception handling will catch all errors and report "Unable to find map in map_source", which might hide some problems other than file not found. For example, when I switch to a new machine and did not setup SUMO properly, the ImportError of SumoRoadNetwork was raised, however this error will also be caught by the outer 'catch'.