### PR TITLE
Raise warning message for building scenarios without map.net.xml file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
     - Removed the `AgentBehavior` class and the `agent_behavior` parameter to `AgentInterface`.
     - Moved the definition of `Waypoint` from `smarts.core.mission_planner` to `smarts.core.road_map`.
     - Moved the definition of `Mission` and `Goal` classes from `smarts.core.scenario` to `smarts.core.plan`.
+- Raised a warning message for building scenarios without `map.net.xml` file. See PR #1161.
 ### Fixed
 - Logic fixes to the `_snap_internal_holes` and `_snap_external_holes` methods in `smarts.core.sumo_road_network.py` for crude geometry holes of sumo road map. Re-adjusted the entry position of vehicles in `smarts.sstudio.genhistories.py` to avoid false positive events. See PR #992. 
 - Prevent `test_notebook.ipynb` cells from timing out by increasing time to unlimited using `/metadata/execution/timeout=-1` within the notebook for regular uses, and `pytest` call with `--nb-exec-timeout -1` option for tests. See for more details: "https://jupyterbook.org/content/execute.html#setting-execution-timeout" and "https://pytest-notebook.readthedocs.io/en/latest/user_guide/tutorial_intro.html#pytest-fixture".

--- a/cli/studio.py
+++ b/cli/studio.py
@@ -65,6 +65,13 @@ def _build_single_scenario(clean, allow_offset_map, scenario):
 
     scenario_root = Path(scenario)
     map_net = str(scenario_root / "map.net.xml")
+    if not os.path.isfile(map_net):
+        click.echo(
+            "FILENOTFOUND: no reference to map.net.xml was found in {}.  "
+            "Please make sure the path passed is a valid SUMO scenario with SUMO network file (map.net.xml) required "
+            "for scenario building.".format(str(scenario_root))
+        )
+        return
     if not allow_offset_map or scenario.traffic_histories:
         SumoRoadNetwork.from_file(map_net, shift_to_origin=True)
     elif os.path.isfile(SumoRoadNetwork.shifted_net_file_path(map_net)):
@@ -141,7 +148,9 @@ def build_all_scenarios(clean, allow_offset_maps, scenarios):
     builder_threads = {}
     for scenarios_path in scenarios:
         path = Path(scenarios_path)
-        for p in path.rglob("*.net.xml"):
+        # We search along directories having reference to file map.net.xml and not .net.xml to prevent calling build
+        # command on files having the offset-map network file but not the original file
+        for p in path.rglob("*map.net.xml"):
             scenario = f"{scenarios_path}/{p.parent.relative_to(scenarios_path)}"
             if scenario == f"{scenarios_path}/waymo":
                 continue
@@ -177,6 +186,7 @@ def _clean(scenario):
         "traffic/*",
         "history_mission.pkl",
         "*.shf",
+        "*-AUTOGEN.net.xml",
     ]
     p = Path(scenario)
     for file_name in to_be_removed:


### PR DESCRIPTION
See Issue #1159 and #1153. This also prevents building scenarios with shifted map offset network file but not the main `map.net.xml` file.