### PR TITLE
backout optimization that reused the same Pose object

### DIFF
--- a/smarts/core/chassis.py
+++ b/smarts/core/chassis.py
@@ -471,7 +471,6 @@ class AckermannChassis(Chassis):
         )
 
     def set_pose(self, pose: Pose):
-        self._pose = pose
         position, orientation = pose.as_bullet()
         self._client.resetBasePositionAndOrientation(
             self._bullet_id, position, orientation

--- a/smarts/core/chassis.py
+++ b/smarts/core/chassis.py
@@ -461,16 +461,14 @@ class AckermannChassis(Chassis):
     def pose(self) -> Pose:
         pos, orn = self._client.getBasePositionAndOrientation(self._bullet_id)
         heading = Heading(yaw_from_quaternion(orn))
-        if not self._pose:
-            self._pose = Pose.from_explicit_offset(
-                [0, 0, 0],
-                np.array(pos),
-                heading,
-                local_heading=Heading(0),
-            )
-        else:
-            self._pose.reset_with(pos, heading)
-        return self._pose
+        # NOTE: we're inefficiently creating a new Pose object on every call here,
+        # but it's too risky to change this because our clients now rely on this behavior.
+        return Pose.from_explicit_offset(
+            [0, 0, 0],
+            np.array(pos),
+            heading,
+            local_heading=Heading(0),
+        )
 
     def set_pose(self, pose: Pose):
         self._pose = pose


### PR DESCRIPTION
Undo a problematic/risky optimization made in PR #1132.

There I tried to reuse the same Pose object to avoid having to create a new one on each call to the `Chassis`  `pose` property.  However, there are too many places in our code where we rely on this pose object being "static" (un-mutable) instead of making a copy of it.  (For example, when creating our Waypoints, in the `DrivenPathSensor`, and anywhere else where we might compare the current pose or position to a previous one....)

I'm still not exactly sure how this created non-determinism in our test results, but for example, in the test that is now failing as a result of #1132 (`test_data_replay`), the problem when it fails is due to not making a copy of the positions in `DrivenPathSensor`.   (Oddly, it doesn't fail for me locally, though.)

At least I think we can still keep the `@cached_property` optimization added to `pose` in #1132, which means we only have to make the API calls when necessary (i.e., once per step), thanks to the `_clear_step_cache()` method.  We're just losing the part of the optmization that avoided (seemingly) unnecessary creation of new `Pose` objects.