### PR TITLE
Bug Fix lane vector for lane offset >= lane's length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Changed the type hint for `EgoVehicleObservation`: it returns a numpy array (and always has).
 - Raised a warning message for building scenarios without `map.net.xml` file. See PR #1161.
 ### Fixed
+- Fix lane vector for the unique cases of lane offset >= lane's length. See PR #1173.
 - Logic fixes to the `_snap_internal_holes` and `_snap_external_holes` methods in `smarts.core.sumo_road_network.py` for crude geometry holes of sumo road map. Re-adjusted the entry position of vehicles in `smarts.sstudio.genhistories.py` to avoid false positive events. See PR #992.
 - Prevent `test_notebook.ipynb` cells from timing out by increasing time to unlimited using `/metadata/execution/timeout=-1` within the notebook for regular uses, and `pytest` call with `--nb-exec-timeout -1` option for tests. See for more details: "https://jupyterbook.org/content/execute.html#setting-execution-timeout" and "https://pytest-notebook.readthedocs.io/en/latest/user_guide/tutorial_intro.html#pytest-fixture".
 - Stop `multiprocessing.queues.Queue` from throwing an error by importing `multiprocessing.queues` in `envision/utils/multiprocessing_queue.py`.

--- a/smarts/core/road_map.py
+++ b/smarts/core/road_map.py
@@ -301,6 +301,7 @@ class RoadMap:
             else:
                 s_offset = start_offset
                 end_offset = start_offset + 1  # a little further down the lane
+            s_offset = max(s_offset, 0)
             p1 = self.from_lane_coord(RefLinePoint(s=s_offset))
             p2 = self.from_lane_coord(RefLinePoint(s=end_offset))
             return np.array(p2) - np.array(p1)

--- a/smarts/core/road_map.py
+++ b/smarts/core/road_map.py
@@ -60,7 +60,7 @@ class RoadMap:
         return 1.0
 
     def to_glb(self, at_path):
-        """ build a glb file for camera rendering and envision """
+        """build a glb file for camera rendering and envision"""
         raise NotImplementedError()
 
     def surface_by_id(self, surface_id: str) -> RoadMap.Surface:
@@ -93,7 +93,7 @@ class RoadMap:
         via: Sequence[RoadMap.Road] = None,
         max_to_gen: int = 1,
     ) -> List[RoadMap.Route]:
-        """ Routes will be returned in order of increasing length """
+        """Routes will be returned in order of increasing length"""
         raise NotImplementedError()
 
     def random_route(self, max_route_len: int = 10) -> RoadMap.Route:
@@ -290,14 +290,18 @@ class RoadMap:
         def edges_at_point(self, point: Point) -> Tuple[Point, Point]:
             offset = self.offset_along_lane(point)
             width = self.width_at_offset(offset)
-            left_edge = RefLanePoint(s=offset, t=width / 2)
-            right_edge = RefLanePoint(s=offset, t=-width / 2)
-            return (self.from_lane_coord(left_edge), self.from_lane_coord(right_edge))
+            left_edge = RefLinePoint(s=offset, t=width / 2)
+            right_edge = RefLinePoint(s=offset, t=-width / 2)
+            return self.from_lane_coord(left_edge), self.from_lane_coord(right_edge)
 
         def vector_at_offset(self, start_offset: float) -> np.ndarray:
-            add_offset = 1  # a little further down the lane
-            end_offset = start_offset + add_offset
-            p1 = self.from_lane_coord(RefLinePoint(s=start_offset))
+            if start_offset >= self.length:
+                s_offset = self.length - 1
+                end_offset = self.length
+            else:
+                s_offset = start_offset
+                end_offset = start_offset + 1  # a little further down the lane
+            p1 = self.from_lane_coord(RefLinePoint(s=s_offset))
             p2 = self.from_lane_coord(RefLinePoint(s=end_offset))
             return np.array(p2) - np.array(p1)
 

--- a/smarts/core/sumo_road_network.py
+++ b/smarts/core/sumo_road_network.py
@@ -324,16 +324,19 @@ class SumoRoadNetwork(RoadMap):
             if not nearby_lanes:
                 return result
             my_vect = self.vector_at_offset(offset)
-            my_norm = max(np.linalg.norm(my_vect), 1e-6)
+            my_norm = np.linalg.norm(my_vect)
+            if my_norm == 0:
+                return result
             threshold = -0.995562  # cos(175*pi/180)
             for lane, _ in nearby_lanes:
                 if lane == self:
                     continue
                 lane_refline_pt = lane.to_lane_coord(pt)
                 lv = lane.vector_at_offset(lane_refline_pt.s)
-                if np.array_equal(lv, np.array([0.0, 0.0, 0.0])):
+                lv_norm = np.linalg.norm(lv)
+                if lv_norm == 0:
                     continue
-                lane_angle = np.dot(my_vect, lv) / (my_norm * np.linalg.norm(lv))
+                lane_angle = np.dot(my_vect, lv) / (my_norm * lv_norm)
                 if lane_angle < threshold:
                     result.append(lane)
             return result

--- a/smarts/core/sumo_road_network.py
+++ b/smarts/core/sumo_road_network.py
@@ -178,7 +178,7 @@ class SumoRoadNetwork(RoadMap):
 
     @property
     def source(self) -> str:
-        """ This is the net.xml file that corresponds with our possibly-offset coordinates. """
+        """This is the net.xml file that corresponds with our possibly-offset coordinates."""
         return self._net_file
 
     @cached_property
@@ -195,7 +195,7 @@ class SumoRoadNetwork(RoadMap):
         return self._default_lane_width / SumoRoadNetwork.DEFAULT_LANE_WIDTH
 
     def to_glb(self, at_path):
-        """ build a glb file for camera rendering and envision """
+        """build a glb file for camera rendering and envision"""
         polys = self._compute_road_polygons()
         glb = self._make_glb_from_polys(polys)
         glb.write_glb(at_path)
@@ -327,7 +327,10 @@ class SumoRoadNetwork(RoadMap):
             my_norm = np.linalg.norm(my_vect)
             threshold = -0.995562  # cos(175*pi/180)
             for lane, _ in nearby_lanes:
-                lv = lane.vector_at_offset(offset)
+                if lane == self:
+                    continue
+                lane_refline_pt = lane.to_lane_coord(pt)
+                lv = lane.vector_at_offset(lane_refline_pt.s)
                 lane_angle = np.dot(my_vect, lv) / (my_norm * np.linalg.norm(lv))
                 if lane_angle < threshold:
                     result.append(lane)

--- a/smarts/core/sumo_road_network.py
+++ b/smarts/core/sumo_road_network.py
@@ -324,13 +324,15 @@ class SumoRoadNetwork(RoadMap):
             if not nearby_lanes:
                 return result
             my_vect = self.vector_at_offset(offset)
-            my_norm = np.linalg.norm(my_vect)
+            my_norm = max(np.linalg.norm(my_vect), 1e-6)
             threshold = -0.995562  # cos(175*pi/180)
             for lane, _ in nearby_lanes:
                 if lane == self:
                     continue
                 lane_refline_pt = lane.to_lane_coord(pt)
                 lv = lane.vector_at_offset(lane_refline_pt.s)
+                if np.array_equal(lv, np.array([0.0, 0.0, 0.0])):
+                    continue
                 lane_angle = np.dot(my_vect, lv) / (my_norm * np.linalg.norm(lv))
                 if lane_angle < threshold:
                     result.append(lane)

--- a/smarts/core/tests/test_map.py
+++ b/smarts/core/tests/test_map.py
@@ -21,6 +21,7 @@
 # THE SOFTWARE.
 import math
 
+import numpy as np
 import pytest
 
 from smarts.core.default_map_factory import create_road_map
@@ -45,6 +46,7 @@ def test_sumo_map(scenario):
     assert lane.road.contains_point(point)
     assert lane.is_drivable
     assert len(lane.shape()) >= 2
+    assert lane.length == 55.6
 
     right_lane, direction = lane.lane_to_right
     assert not right_lane
@@ -93,6 +95,10 @@ def test_sumo_map(scenario):
     assert "edge-east-EW_0" in foe_set  # engering from east
     assert "edge-north-NS_0" in foe_set  # entering from north
     assert ":junction-intersection_5_0" in foe_set  # crossing from east-to-west
+
+    # Test the lane vector for a refline point outside lane
+    lane_heading_at_offset = lane.vector_at_offset(55.7)
+    assert np.array_equal(lane_heading_at_offset, np.array([0.0, -1.0, 0.0]))
 
     r1 = road_map.road_by_id("edge-north-NS")
     assert r1


### PR DESCRIPTION
See Issue #1171. 
We set the offset in `vector_at_offset` method to lane's length if it is greater than road's length.