### PR TITLE
delete example ray multi-instance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,6 @@ sanity-test: build-all-scenarios
 		./smarts/core/tests/test_sensors.py::test_waypoints_sensor \
 		./smarts/core/tests/test_smarts.py::test_smarts_doesnt_leak_tasks_after_reset \
 		./examples/tests/test_examples.py::test_examples[multi_agent] \
-		./examples/tests/test_examples.py::test_ray_multi_instance_example \
 		./smarts/env/tests/test_social_agent.py::test_social_agents
 
 .PHONY: test-learning


### PR DESCRIPTION
The multi-instance example is deleted while run 'make sanity-test' in the set up phase. Another related issue is created for #1181 