### PR TITLE
Map Creation Fixes

### DIFF
--- a/cli/studio.py
+++ b/cli/studio.py
@@ -75,7 +75,7 @@ def _build_single_scenario(clean, allow_offset_map, scenario):
     if not allow_offset_map or scenario.traffic_histories:
         from smarts.sstudio.types import MapSpec
 
-        map_spec = MapSpec(source=road_network_path)
+        map_spec = MapSpec(map_net)
         SumoRoadNetwork.from_spec(map_spec, shift_to_origin=True)
     elif os.path.isfile(SumoRoadNetwork.shifted_net_file_path(map_net)):
         click.echo(

--- a/cli/studio.py
+++ b/cli/studio.py
@@ -73,7 +73,10 @@ def _build_single_scenario(clean, allow_offset_map, scenario):
         )
         return
     if not allow_offset_map or scenario.traffic_histories:
-        SumoRoadNetwork.from_file(map_net, shift_to_origin=True)
+        from smarts.sstudio.types import MapSpec
+
+        map_spec = MapSpec(source=road_network_path)
+        SumoRoadNetwork.from_spec(map_spec, shift_to_origin=True)
     elif os.path.isfile(SumoRoadNetwork.shifted_net_file_path(map_net)):
         click.echo(
             "WARNING: {} already exists.  Remove it if you want to use unshifted/offset map.net.xml instead.".format(

--- a/smarts/core/default_map_builder.py
+++ b/smarts/core/default_map_builder.py
@@ -18,6 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+from dataclasses import replace
 import os
 from typing import NamedTuple, Tuple
 
@@ -58,23 +59,19 @@ def get_road_map(map_spec) -> Tuple[RoadMap, str]:
         _existing_map = None
         gc.collect()
 
-    map_path = map_spec.source
-    if not os.path.isfile(map_path):
+    if not os.path.isfile(map_spec.source):
         map_path = os.path.join(map_spec.source, "map.net.xml")
         if not os.path.exists(map_path):
             raise FileNotFoundError(
                 f"Unable to find map in map_source={map_spec.source}."
             )
+        map_spec = replace(map_spec, source=map_path)
 
     # Keep this a conditional import so Sumo does not have to be
     # imported if not necessary:
     from smarts.core.sumo_road_network import SumoRoadNetwork
 
-    road_map = SumoRoadNetwork.from_file(
-        map_path,
-        default_lane_width=map_spec.default_lane_width,
-        lanepoint_spacing=map_spec.lanepoint_spacing,
-    )
+    road_map = SumoRoadNetwork.from_spec(map_spec)
 
     road_map_hash = file_md5_hash(road_map.source)
 

--- a/smarts/core/scenario.py
+++ b/smarts/core/scenario.py
@@ -36,7 +36,6 @@ from cached_property import cached_property
 
 from smarts.core.coordinates import Dimensions, Heading, Pose, RefLinePoint
 from smarts.core.data_model import SocialAgent
-from smarts.core.default_map_builder import get_road_map
 from smarts.core.plan import (
     EndlessGoal,
     LapMission,

--- a/smarts/core/sumo_road_network.py
+++ b/smarts/core/sumo_road_network.py
@@ -139,7 +139,7 @@ class SumoRoadNetwork(RoadMap):
 
     @classmethod
     def from_spec(cls, map_spec: MapSpec, shift_to_origin: bool = False):
-        net_file = map_spec.source
+        net_file = SumoRoadNetwork._map_path(map_spec)
 
         # Connections to internal lanes are implicit. If `withInternal=True` is
         # set internal junctions and the connections from internal lanes are
@@ -177,18 +177,17 @@ class SumoRoadNetwork(RoadMap):
             else SumoRoadNetwork.DEFAULT_LANE_WIDTH
         )
 
+    @staticmethod
+    def _map_path(map_spec: MapSpec) -> str:
+        if os.path.isdir(map_spec.source):
+            # map.net.xml is the default Sumo map name; try that:
+            return os.path.join(map_spec.source, "map.net.xml")
+        return map_spec.source
+
     def is_same_map(self, map_spec: MapSpec) -> bool:
         if map_spec.source != self._map_spec.source:
-            cur_source = (
-                map_spec.source
-                if os.path.isfile(map_spec.source)
-                else os.path.join(map_spec.source, "map.net.xml")
-            )
-            orig_source = (
-                self._map_spec.source
-                if os.path.isfile(self._map_spec.source)
-                else os.path.join(self._map_spec.source, "map.net.xml")
-            )
+            cur_source = SumoRoadNetwork._map_path(map_spec)
+            orig_source = SumoRoadNetwork._map_path(self._map_spec)
             if cur_source != orig_source:
                 return False
 

--- a/smarts/core/sumo_road_network.py
+++ b/smarts/core/sumo_road_network.py
@@ -81,26 +81,21 @@ class SumoRoadNetwork(RoadMap):
     # in North America (although US highway lanes are wider at ~3.7m).
     DEFAULT_LANE_WIDTH = 3.2
 
-    def __init__(
-        self, graph, net_file, default_lane_width=None, lanepoint_spacing=None
-    ):
+    def __init__(self, graph, net_file: str, map_spec: MapSpec):
         self._log = logging.getLogger(self.__class__.__name__)
         self._graph = graph
         self._net_file = net_file
-        self._default_lane_width = (
-            default_lane_width
-            if default_lane_width is not None
-            else SumoRoadNetwork.DEFAULT_LANE_WIDTH
-        )
+        self._map_spec = map_spec
+        self._default_lane_width = SumoRoadNetwork._spec_lane_width(map_spec)
         self._surfaces = {}
         self._lanes = {}
         self._roads = {}
         self._waypoints_cache = SumoRoadNetwork._WaypointsCache()
         self._lanepoints = None
-        if lanepoint_spacing is not None:
-            assert lanepoint_spacing > 0
+        if map_spec.lanepoint_spacing is not None:
+            assert map_spec.lanepoint_spacing > 0
             # XXX: this should be last here since SumoLanePoints() calls road_network methods immediately
-            self._lanepoints = SumoLanePoints(self, spacing=lanepoint_spacing)
+            self._lanepoints = SumoLanePoints(self, spacing=map_spec.lanepoint_spacing)
 
     @staticmethod
     def _check_net_origin(bbox):
@@ -143,13 +138,9 @@ class SumoRoadNetwork(RoadMap):
         return False
 
     @classmethod
-    def from_file(
-        cls,
-        net_file,
-        shift_to_origin=False,
-        default_lane_width=None,
-        lanepoint_spacing=None,
-    ):
+    def from_spec(cls, map_spec: MapSpec, shift_to_origin: bool = False):
+        net_file = map_spec.source
+
         # Connections to internal lanes are implicit. If `withInternal=True` is
         # set internal junctions and the connections from internal lanes are
         # loaded into the network graph.
@@ -171,32 +162,47 @@ class SumoRoadNetwork(RoadMap):
                 # coordinates are relative to the origin).
                 G._shifted_by_smarts = True
 
-        return cls(
-            G,
-            net_file,
-            default_lane_width=default_lane_width,
-            lanepoint_spacing=lanepoint_spacing,
-        )
+        return cls(G, net_file, map_spec)
 
     @property
     def source(self) -> str:
         """This is the net.xml file that corresponds with our possibly-offset coordinates."""
         return self._net_file
 
-    def is_same_map(self, map_spec: MapSpec) -> bool:
-        dlw = (
+    @staticmethod
+    def _spec_lane_width(map_spec: MapSpec) -> float:
+        return (
             map_spec.default_lane_width
             if map_spec.default_lane_width is not None
             else SumoRoadNetwork.DEFAULT_LANE_WIDTH
         )
-        return (
-            map_spec.source == self._net_file
-            and (
-                (not map_spec.lanepoint_spacing and not self._lanepoints)
-                or map_spec.lanepoint_spacing == self._lanepoints.spacing
+
+    def is_same_map(self, map_spec: MapSpec) -> bool:
+        if map_spec.source != self._map_spec.source:
+            cur_source = (
+                map_spec.source
+                if os.path.isfile(map_spec.source)
+                else os.path.join(map_spec.source, "map.net.xml")
             )
-            and dlw == self._default_lane_width
-        )
+            orig_source = (
+                self._map_spec.source
+                if os.path.isfile(self._map_spec.source)
+                else os.path.join(self._map_spec.source, "map.net.xml")
+            )
+            if cur_source != orig_source:
+                return False
+
+        if map_spec.lanepoint_spacing != self._map_spec.lanepoint_spacing:
+            return False
+
+        if (
+            map_spec.default_lane_width != self._map_spec.default_lane_width
+            and SumoRoadNetwork._spec_lane_width(map_spec)
+            != SumoRoadNetwork._spec_lane_width(self._map_spec)
+        ):
+            return False
+
+        return True
 
     @cached_property
     def bounding_box(self) -> BoundingBox:

--- a/smarts/core/sumo_road_network.py
+++ b/smarts/core/sumo_road_network.py
@@ -185,23 +185,19 @@ class SumoRoadNetwork(RoadMap):
         return map_spec.source
 
     def is_same_map(self, map_spec: MapSpec) -> bool:
-        if map_spec.source != self._map_spec.source:
-            cur_source = SumoRoadNetwork._map_path(map_spec)
-            orig_source = SumoRoadNetwork._map_path(self._map_spec)
-            if cur_source != orig_source:
-                return False
-
-        if map_spec.lanepoint_spacing != self._map_spec.lanepoint_spacing:
-            return False
-
-        if (
-            map_spec.default_lane_width != self._map_spec.default_lane_width
-            and SumoRoadNetwork._spec_lane_width(map_spec)
-            != SumoRoadNetwork._spec_lane_width(self._map_spec)
-        ):
-            return False
-
-        return True
+        return (
+            (
+                map_spec.source == self._map_spec.source
+                or SumoRoadNetwork._map_path(map_spec)
+                == SumoRoadNetwork._map_path(self._map_spec)
+            )
+            and map_spec.lanepoint_spacing == self._map_spec.lanepoint_spacing
+            and (
+                map_spec.default_lane_width == self._map_spec.default_lane_width
+                or SumoRoadNetwork._spec_lane_width(map_spec)
+                == SumoRoadNetwork._spec_lane_width(self._map_spec)
+            )
+        )
 
     @cached_property
     def bounding_box(self) -> BoundingBox:

--- a/smarts/sstudio/generators.py
+++ b/smarts/sstudio/generators.py
@@ -260,7 +260,8 @@ class TrafficGenerator:
         if not self._road_network:
             from smarts.core.sumo_road_network import SumoRoadNetwork
 
-            self._road_network = SumoRoadNetwork.from_file(self._road_network_path)
+            map_spec = types.MapSpec(self._road_network_path)
+            self._road_network = SumoRoadNetwork.from_spec(map_spec)
 
     def resolve_edge_length(self, edge_id, lane_idx):
         self._cache_road_network()

--- a/smarts/sstudio/genscenario.py
+++ b/smarts/sstudio/genscenario.py
@@ -434,7 +434,8 @@ def gen_traffic_histories(scenario: str, histories_datasets, overwrite: bool):
     if os.path.exists(road_network_path):
         from smarts.core.sumo_road_network import SumoRoadNetwork
 
-        road_network = SumoRoadNetwork.from_file(road_network_path)
+        map_spec = types.MapSpec(road_network_path)
+        road_network = SumoRoadNetwork.from_spec(map_spec)
         if road_network._graph and getattr(
             road_network._graph, "_shifted_by_smarts", False
         ):

--- a/smarts/sstudio/genscenario.py
+++ b/smarts/sstudio/genscenario.py
@@ -130,6 +130,7 @@ def gen_scenario(
             scenario=output_dir,
             histories_datasets=scenario.traffic_histories,
             overwrite=overwrite,
+            map_spec=map_spec,
         )
 
 
@@ -427,14 +428,17 @@ def _validate_entry_tactic(mission):
             ), f"Zone edge `{z_edge}` is not the same edge as `types.Mission` route begin edge `{edge}`"
 
 
-def gen_traffic_histories(scenario: str, histories_datasets, overwrite: bool):
+def gen_traffic_histories(
+    scenario: str, histories_datasets, overwrite: bool, map_spec: types.MapSpec = None
+):
     # For SUMO maps, we need to check if the map was shifted and translate the vehicle positions if so
     xy_offset = None
-    road_network_path = os.path.join(scenario, "map.net.xml")
-    if os.path.exists(road_network_path):
+    if not map_spec:
+        road_network_path = os.path.join(scenario, "map.net.xml")
+        map_spec = types.MapSpec(road_network_path)
+    if os.path.exists(map_spec.source):
         from smarts.core.sumo_road_network import SumoRoadNetwork
 
-        map_spec = types.MapSpec(road_network_path)
         road_network = SumoRoadNetwork.from_spec(map_spec)
         if road_network._graph and getattr(
             road_network._graph, "_shifted_by_smarts", False

--- a/smarts/sstudio/sumo2mesh.py
+++ b/smarts/sstudio/sumo2mesh.py
@@ -20,10 +20,12 @@
 import argparse
 
 from smarts.core.sumo_road_network import SumoRoadNetwork
+from smarts.sstudio.types import MapSpec
 
 
 def generate_glb_from_sumo_network(sumo_net_file, out_glb_file):
-    road_network = SumoRoadNetwork.from_file(net_file=sumo_net_file)
+    map_spec = MapSpec(sumo_net_file)
+    road_network = SumoRoadNetwork.from_spec(map_spec)
     road_network.to_glb(out_glb_file)
 
 


### PR DESCRIPTION
As pointed out by @RutvikGupta , `is_same_map()` in `SumoRoadNetwork` objects did not always return `True` when it should (e.g, in cases where the `net_file` name was changed if it had been shifted, or when the `net_file`filename was filled in with the default).

This fixes that by keeping track of the `MapSpec` object used to create the map.
