### PR TITLE
Smooth headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Allow specifying "-latest" as a version suffix for zoo locator strings.
 - Added Base CI and dependencies requirement tests for the "darwin" platform (MacOS).
 - Extended Imitation Learning codebase to allow importing traffic histories from the Waymo motion dataset and replay in a SMARTS simulation. See PR #1060.
+- Added options for dealing with noise when inferring headings while importing traffic history data.  See PR #1219.
 - Added `ros` extension rule to `setup.py`.
 - Added a script to allow users to hijack history vehicles dynamically through a trigger event. See PR #1088.
 - Added a `-y` option to `utils/setup/install_deps.sh` to accept installation by default. See issue #1081.

--- a/smarts/sstudio/genhistories.py
+++ b/smarts/sstudio/genhistories.py
@@ -179,10 +179,10 @@ class _TrajectoryDataset:
                     float(self.column_val_in_row(row, "sim_time")) / 1000,
                     time_precision,
                 ),
-                float(self.column_val_in_row(row, "position_x"))
-                + x_offset * self.scale,
-                float(self.column_val_in_row(row, "position_y"))
-                + y_offset * self.scale,
+                (float(self.column_val_in_row(row, "position_x")) + x_offset)
+                * self.scale,
+                (float(self.column_val_in_row(row, "position_y")) + y_offset)
+                * self.scale,
                 float(self.column_val_in_row(row, "heading_rad")),
                 float(self.column_val_in_row(row, "speed")) * self.scale,
                 self.column_val_in_row(row, "lane_id"),
@@ -237,7 +237,7 @@ class Interaction(_TrajectoryDataset):
         super().check_dataset_spec(dataset_spec)
         hiw = dataset_spec.get("heading_inference_window", 2)
         if hiw != 2:
-            # Adding support fot this would require changing the rows() generator
+            # Adding support for this would require changing the rows() generator
             # (since we're not using Pandas here like we are for NGSIM).
             # So wait until if/when users request it...
             raise ValueError(
@@ -293,9 +293,7 @@ class Interaction(_TrajectoryDataset):
                 dx = float(self._next_row["x"]) - float(row["x"])
                 dy = float(self._next_row["y"]) - float(row["y"])
                 dm = np.linalg.norm((dx, dy))
-                if dm != 0.0 and (
-                    self._heading_min_speed is None or dm > self._heading_min_speed
-                ):
+                if dm != 0.0 and dm > self._heading_min_speed:
                     r = math.atan2(dy / dm, dx / dm)
                     new_heading = (r - math.pi / 2) % (2 * math.pi)
                     if self._max_angular_velocity:

--- a/smarts/sstudio/genhistories.py
+++ b/smarts/sstudio/genhistories.py
@@ -237,6 +237,9 @@ class Interaction(_TrajectoryDataset):
         super().check_dataset_spec(dataset_spec)
         hiw = dataset_spec.get("heading_inference_window", 2)
         if hiw != 2:
+            # Adding support fot this would require changing the rows() generator
+            # (since we're not using Pandas here like we are for NGSIM).
+            # So wait until if/when users request it...
             raise ValueError(
                 "heading_inference_window not yet supported for Interaction datasets."
             )
@@ -326,6 +329,7 @@ class NGSIM(_TrajectoryDataset):
     def check_dataset_spec(self, dataset_spec: Dict[str, Any]):
         super().check_dataset_spec(dataset_spec)
         hiw = dataset_spec.get("heading_inference_window", 2)
+        # 11 is a semi-arbitrary max just to keep things "sane".
         if hiw < 2 or hiw > 11:
             raise ValueError("heading_inference_window must be between 2 and 11")
 


### PR DESCRIPTION
This attempts to address issue #1214 by adding three different options to the dataset spec yaml file:
1. `max_angular_velocity` - if specified, near-instantaneous heading changes can be avoided;
2. `heading_inference_window` -  heading inference is calculated using a rolling window (moving average) across this many position changes;
3. `heading_inference_min_speed` - a speed threshold below which headings are assumed not to change.

Each of these addresses noise and imprecision issues in the NGSIM dataset in different ways, while allowing for the request that triggered PR #896 to be honored as well.

For example, I added it to my NGSIM yaml like this:
```yaml
trajectory_dataset:                                                                                                                                             
    name: i80_0400-0415
    source: NGSIM
    input_path: ./original/xy-trajectories/i80/trajectories-0400-0415.txt
 
    # 55mph is roughly 25m/s.  100km/h is roughly 28m/s.
    speed_limit_mps: 28
 
    flip_y: True
    swap_xy: True
 
    x_margin_px: 60
 
    # When inferring headings from positions, each vehicle's angular velocity
    # will be limited to be at most this amount (in rad/sec) to prevent lateral-coordinate
    # noise in the dataset from causing near-instantaneous heading changes.
    max_angular_velocity: 4

    # When inferring headings from positions, a sliding window (moving average)
    # of this size will be used to smooth inferred headings and reduce their dependency
    # on any individual position changes.  Defaults to 2 if not specified.
    heading_inference_window: 5 

    # Speed threshold below which a vehicle's heading is assumed not to change.
    # This is useful to prevent abnormal heading changes that may arise from 
    # noise in position estimates in a trajectory dataset dominating real position
    # changes in situations where the real position changes are very small. 
    # Defaults to .22 if not specified.
    heading_inference_min_speed:  .22

    map_net:
        # These are dimensions of the Sumo network in map.net.xml.
        # We map the coordinates in the input dataset onto this space.
        # max_y is required since flip_y is True.
        max_y: 25.02
 
        # The map width is used to filter position_x values
        # to ensure they're in range.
        width: 310.92
```

I'll update the Issue with instructions (and caveats) once this PR has been approved.