### PR TITLE
map building fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-This changelog is to adhere to the format given at [keepachangelog](keepachangelog.com/en/1.0.0/) 
+This changelog is to adhere to the format given at [keepachangelog](keepachangelog.com/en/1.0.0/)
 and should maintain [semantic versioning](semver.org).
 
-All text added must be human-readable. 
+All text added must be human-readable.
 
 Copy and pasting the git commit messages is __NOT__ enough.
 
@@ -12,7 +12,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 ### Added
 - Added `get_vehicle_start_time()` method for scenarios with traffic history data.  See Issue #1210.
 ### Changed
-- If more than one qualifying map file exists in a the `mapspec.source` folder, `get_road_map()` in `default_map_builder.py` will prefer to return the default files (`map.net.xml` or `map.xodr`) if they exist.
+- If more than one qualifying map file exists in a the `map_spec.source` folder, `get_road_map()` in `default_map_builder.py` will prefer to return the default files (`map.net.xml` or `map.xodr`) if they exist.
 ### Deprecated
 ### Fixed
 ### Removed
@@ -38,7 +38,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Added `smarts.core.utils.import_utils` to help with the dynamic import of modules.
 - Added `single_agent` env wrapper and unit test. The wrapper converts a single-agent SMARTS environment's step and reset output to be compliant with gym spaces.
 - Added `rgb_image` env wrapper and unit test. The wrapper filters SMARTS environment observation and returns only top-down RGB image as observation.
-- Extended the `RoadMap` API to support `OpenDRIVE` map format in `smarts/core/opendrive_road_network.py`. Added 3 new scenarios with `OpenDRIVE` maps. See PR #1186.  
+- Extended the `RoadMap` API to support `OpenDRIVE` map format in `smarts/core/opendrive_road_network.py`. Added 3 new scenarios with `OpenDRIVE` maps. See PR #1186.
 - Added a "ReplayAgent" wrapper to allow users to rerun an agent previously run by saving its configurations and inputs. See Issue #971.
 - Added `smarts.core.provider.ProviderRecoveryFlags` as flags to determine how `SMARTS` should handle failures in providers. They are as follows:
   - `NOT_REQUIRED`: Not needed for the current step. Error causes skip of provider if it should recover but cannot or should not recover.
@@ -51,12 +51,12 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Added recovery options to `smarts.core.smarts.SMARTS.add_provider()`
   - Add `recovery_flags` argument to configure the recovery options if the provider disconnects or throws an exception.
 - Added `driving_in_traffic` reinforcement learning example. An ego agent is trained using DreamerV2 to drive as far and as fast as possible in heavy traffic, without colliding or going off-road.
-- Added `smarts.core.smarts.SMARTSDestroyedError` which describes use of a destroyed `SMARTS` instance. 
+- Added `smarts.core.smarts.SMARTSDestroyedError` which describes use of a destroyed `SMARTS` instance.
 ### Changed
 - `test-requirements` github action job renamed to `check-requirements-change` and only checks for requirements changes without failing.
 - Moved examples tests to `examples` and used relative imports to fix a module collision with `aiohttp`'s `examples` module.
 - Made changes to log sections of the scenario step in `smarts.py` to help evaluate smarts performance problems. See Issue #661.
-- Introducted `RoadMap` class to abstract away from `SumoRoadNetwork` 
+- Introducted `RoadMap` class to abstract away from `SumoRoadNetwork`
   and allow for (eventually) supporting other map formats.  See Issue #830 and PR #1048.
   This had multiple cascading ripple effects (especially on Waypoint generation and caching,
   Missions/Plans/Routes and road/lane-related sensors).  These include:
@@ -70,7 +70,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Public `SMARTS` methods will throw `smarts.core.smarts.SMARTSDestroyedError` if `SMARTS.destroy()` has previously been called on the `SMARTS` instance.
 ### Fixed
 - Fix lane vector for the unique cases of lane offset >= lane's length. See PR #1173.
-- Logic fixes to the `_snap_internal_holes` and `_snap_external_holes` methods in `smarts.core.sumo_road_network.py` for crude geometry holes of sumo road map. Re-adjusted the entry position of vehicles in `smarts.sstudio.genhistories.py` to avoid false positive events. See PR #992. 
+- Logic fixes to the `_snap_internal_holes` and `_snap_external_holes` methods in `smarts.core.sumo_road_network.py` for crude geometry holes of sumo road map. Re-adjusted the entry position of vehicles in `smarts.sstudio.genhistories.py` to avoid false positive events. See PR #992.
 - Prevent `test_notebook.ipynb` cells from timing out by increasing time to unlimited using `/metadata/execution/timeout=65536` within the notebook for regular uses, and `pytest` call with `--nb-exec-timeout 65536` option for tests. See for more details: "https://jupyterbook.org/content/execute.html#setting-execution-timeout" and "https://pytest-notebook.readthedocs.io/en/latest/user_guide/tutorial_intro.html#pytest-fixture".
 - Stop `multiprocessing.queues.Queue` from throwing an error by importing `multiprocessing.queues` in `envision/utils/multiprocessing_queue.py`.
 - Prevent vehicle insertion on top of ignored social vehicles when the `TrapManager` defaults to emitting a vehicle for the ego to control. See PR #1043
@@ -80,7 +80,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Updated deprecated Shapely functionality.
 - Fixed the type of `position` (pose) fields emitted to envision to match the existing type hints of `tuple`.
 - Properly detect whether waypoint is present in mission route, while computing distance travelled by agents with missions in TripMeterSensor.
-- Fixed `test_notebook` timeout by setting `pytest --nb-exec-timeout 65536`. 
+- Fixed `test_notebook` timeout by setting `pytest --nb-exec-timeout 65536`.
 ### Deprecated
 - The `timestep_sec` property of SMARTS is being deprecated in favor of `fixed_timesep_sec`
   for clarity since we are adding the ability to have variable time steps.
@@ -91,7 +91,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Removed `route_waypoints` attribute from `smarts.core.sensors.RoadWaypoints`.
 
 ## [0.4.18] - 2021-07-22
-### Added 
+### Added
 - Dockerfile for headless machines.
 - Singularity definition file and instructions to build/run singularity containers.
 - Support multiple outgoing edges from SUMO maps.
@@ -104,16 +104,16 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Fix case where multiple outgoing edges could cause non-determinism.
 
 ## [0.4.17] - 2021-07-02
-### Added 
+### Added
 - Added `ActionSpace.Imitation` and a controller to support it.  See Issue #844.
 - Added a `TraverseGoal` goal for imitation learning agents.  See Issue #848.
-- Added `README_pypi.md` to update to the general user installation PyPI instructions. See Issue #828. 
+- Added `README_pypi.md` to update to the general user installation PyPI instructions. See Issue #828.
 - Added a new utility experiment file `cli/run.py` to replace the context given by `supervisord.conf`. See PR #911.
 - Added `scl zoo install` command to install zoo policy agents at the specified paths. See Issue #603.
 - Added a `FrameStack` wrapper which returns stacked observations for each agent.
 ### Changed
 - `history_vehicles_replacement_for_imitation_learning.py` now uses new Imitation action space. See Issue #844.
-- Updated and removed some package versions to ensure that Python3.8 is supported by SMARTS. See issue #266. 
+- Updated and removed some package versions to ensure that Python3.8 is supported by SMARTS. See issue #266.
 - Refactored `Waypoints` into `LanePoints` (static, map-based) and `Waypoints` (dynamic). See Issue #829.
 - Vehicles with a `BoxChassis` can now use an `AccelerometerSensor` too.
 - When importing NGSIM history data, vehicle speeds are recomputed.
@@ -141,7 +141,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Removed `supervisord.conf` and `supervisor` from dependencies and requirements. See Issue #802.
 
 ## [0.4.16] - 2021-05-11
-### Added 
+### Added
 - Added `sanity-test` script and asked new users to run `sanity-test` instead of `make test` to ease the setup
 process
 - Added `on_shoulder` as part of events in observation returned from each step of simulation
@@ -169,9 +169,9 @@ process
 ### Added
 - This CHANGELOG as a change log to help keep track of changes in the SMARTS project that can get easily lost.
 - Hosted Documentation on `readthedocs` and pointed to the smarts paper and useful parts of the documentation in the README.
-- Running imitation learning will now create a cached `history_mission.pkl` file in scenario folder that stores 
+- Running imitation learning will now create a cached `history_mission.pkl` file in scenario folder that stores
 the missions for all agents.
-- Added ijson as a dependency. 
+- Added ijson as a dependency.
 - Added `cached-property` as a dependency.
 ### Changed
 - Lowered CPU cost of waypoint generation. This will result in a small increase in memory usage.
@@ -188,9 +188,9 @@ the missions for all agents.
 - Fix envision error 15 by cleanly shutting down the envision worker process.
 
 ## [Format] - 2021-03-12
-### Added 
+### Added
 – Describe any new features that have been added since the last version was released.
-### Changed 
+### Changed
 – Note any changes to the software’s existing functionality.
 ### Deprecated
 – Note any features that were once stable but are no longer and have thus been removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 ### Added
 - Added `get_vehicle_start_time()` method for scenarios with traffic history data.  See Issue #1210.
 ### Changed
+- If more than one qualifying map file exists in a the `mapspec.sourc` folder, `get_road_map()` in `default_map_builder.py` will prefer to return the default files (`map.net.xml` or `map.xodr`) if they exist.
 ### Deprecated
 ### Fixed
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 ### Added
 - Added `get_vehicle_start_time()` method for scenarios with traffic history data.  See Issue #1210.
 ### Changed
-- If more than one qualifying map file exists in a the `mapspec.sourc` folder, `get_road_map()` in `default_map_builder.py` will prefer to return the default files (`map.net.xml` or `map.xodr`) if they exist.
+- If more than one qualifying map file exists in a the `mapspec.source` folder, `get_road_map()` in `default_map_builder.py` will prefer to return the default files (`map.net.xml` or `map.xodr`) if they exist.
 ### Deprecated
 ### Fixed
 ### Removed

--- a/cli/studio.py
+++ b/cli/studio.py
@@ -43,7 +43,7 @@ def scenario_cli():
     "--allow-offset-map",
     is_flag=True,
     default=False,
-    help="Allows Sumo's road network (map.net.xml) to be offset from the origin. if not specified, creates a network file that ends with AUTOGEN.net.xml if necessary.",
+    help="Allows road network to be offset from the origin. If not specified, creates a new network file if necessary.",
 )
 @click.argument("scenario", type=click.Path(exists=True), metavar="<scenario>")
 def build_scenario(clean, allow_offset_map, scenario):
@@ -56,55 +56,28 @@ def _build_single_scenario(clean, allow_offset_map, scenario):
         _clean(scenario)
 
     scenario_root = Path(scenario)
-    map_glb = scenario_root / "map.glb"
-    od_map_paths = list(scenario_root.rglob("*.xodr"))
-    sumo_map_paths = list(scenario_root.rglob("*.net.xml"))
-    if od_map_paths:
-        from smarts.sstudio.types import MapSpec
-        from smarts.core.opendrive_road_network import OpenDriveRoadNetwork
-
-        assert len(od_map_paths) == 1
-        map_xodr = str(od_map_paths[0])
-        map_spec = MapSpec(map_xodr)
-        od_road_network = OpenDriveRoadNetwork.from_spec(map_spec)
-        od_road_network.to_glb(str(map_glb))
-
-    elif sumo_map_paths:
-        from smarts.sstudio.sumo2mesh import generate_glb_from_sumo_file
-        from smarts.core.sumo_road_network import SumoRoadNetwork
-
-        map_net = None
-        for map_path in sumo_map_paths:
-            if not str(map_path).endswith("AUTOGEN.net.xml"):
-                map_net = str(map_path)
-                break
-
-        assert map_net is not None
-        if not allow_offset_map or scenario.traffic_histories:
-            from smarts.sstudio.types import MapSpec
-
-            map_spec = MapSpec(map_net)
-            SumoRoadNetwork.from_spec(map_spec, shift_to_origin=True)
-        elif os.path.isfile(SumoRoadNetwork.shifted_net_file_path(map_net)):
-            click.echo(
-                "WARNING: {} already exists.  Remove it if you want to use unshifted/offset map.net.xml instead.".format(
-                    SumoRoadNetwork.shifted_net_file_name
-                )
-            )
-        generate_glb_from_sumo_file(map_net, str(map_glb))
-    else:
-        click.echo(
-            "FILENOTFOUND: no reference to network file was found in {}.  "
-            "Please make sure the path passed is a valid Scenario with RoadNetwork file (map.net.xml or map.xodr) required "
-            "for scenario building.".format(str(scenario_root))
-        )
-        return
-
-    _install_requirements(scenario_root)
 
     scenario_py = scenario_root / "scenario.py"
     if scenario_py.exists():
+        _install_requirements(scenario_root)
         subprocess.check_call([sys.executable, scenario_py])
+
+    from smarts.core.scenario import Scenario
+
+    traffic_histories = Scenario.discover_traffic_histories(scenario_root)
+    shift_to_origin = not allow_offset_map or bool(traffic_histories)
+
+    map_spec = Scenario.discover_map(scenario_root, shift_to_origin=shift_to_origin)
+    road_map, _ = map_spec.builder_fn(map_spec)
+    if not road_map:
+        click.echo(
+            "No reference to a RoadNetwork file was found in {}, or one could not be created. "
+            "Please make sure the path passed is a valid Scenario with RoadNetwork file required "
+            "(or a way to create one) for scenario building.".format(str(scenario_root))
+        )
+        return
+
+    road_map.to_glb(os.path.join(scenario_root, "map.glb"))
 
 
 def _install_requirements(scenario_root):
@@ -144,6 +117,19 @@ def _install_requirements(scenario_root):
                 pip_index_proc.wait()
 
 
+def _is_scenario_folder_to_build(path: str) -> bool:
+    if os.path.exists(os.path.join(path, "waymo.yaml")):
+        # for now, don't try to build Waymo scenarios...
+        return False
+    if os.path.exists(os.path.join(path, "scenario.py")):
+        return True
+    from smarts.sstudio.types import MapSpec
+
+    map_spec = MapSpec(path)
+    road_map, _ = map_spec.builder_fn(map_spec)
+    return road_map is not None
+
+
 @scenario_cli.command(
     name="build-all",
     help="Generate all scenarios under the given directories",
@@ -158,7 +144,7 @@ def _install_requirements(scenario_root):
     "--allow-offset-maps",
     is_flag=True,
     default=False,
-    help="Allows Sumo's road networks (map.net.xml) to be offset from the origin. if not specified, creates creates a network file that ends with AUTOGEN.net.xml' if necessary.",
+    help="Allows road networks (maps) to be offset from the origin. If not specified, creates creates a new network file if necessary.",
 )
 @click.argument("scenarios", nargs=-1, metavar="<scenarios>")
 def build_all_scenarios(clean, allow_offset_maps, scenarios):
@@ -169,26 +155,16 @@ def build_all_scenarios(clean, allow_offset_maps, scenarios):
 
     builder_threads = {}
     for scenarios_path in scenarios:
-        path = Path(scenarios_path)
-
-        for p in path.rglob("*.xodr"):
-            scenario = f"{scenarios_path}/{p.parent.relative_to(scenarios_path)}"
-            builder_thread = Thread(
-                target=_build_single_scenario, args=(clean, False, scenario)
-            )
-            builder_thread.start()
-            builder_threads[p] = builder_thread
-
-        for p in path.rglob("*map.net.xml"):
-            scenario = f"{scenarios_path}/{p.parent.relative_to(scenarios_path)}"
-            if scenario == f"{scenarios_path}/waymo":
-                continue
-            builder_thread = Thread(
-                target=_build_single_scenario,
-                args=(clean, allow_offset_maps, scenario),
-            )
-            builder_thread.start()
-            builder_threads[p] = builder_thread
+        for subdir, _, _ in os.walk(scenarios_path):
+            if _is_scenario_folder_to_build(subdir):
+                p = Path(subdir)
+                scenario = f"{scenarios_path}/{p.relative_to(scenarios_path)}"
+                builder_thread = Thread(
+                    target=_build_single_scenario,
+                    args=(clean, allow_offset_maps, scenario),
+                )
+                builder_threads[p] = builder_thread
+                builder_thread.start()
 
     for scenario_path, builder_thread in builder_threads.items():
         click.echo(f"Waiting on {scenario_path} ...")

--- a/smarts/core/default_map_builder.py
+++ b/smarts/core/default_map_builder.py
@@ -72,7 +72,7 @@ def _find_mapfile_in_dir(map_dir: str) -> Tuple[int, str]:
         if f.endswith(".net.xml"):
             map_type = _SUMO_MAP
             map_path = os.path.join(map_dir, f)
-        if f.endswith(".xodr"):
+        elif f.endswith(".xodr"):
             map_type = _OPENDRIVE_MAP
             map_path = os.path.join(map_dir, f)
     return map_type, map_path
@@ -110,24 +110,24 @@ def get_road_map(map_spec) -> Tuple[RoadMap, str]:
     if map_type == _SUMO_MAP:
         from smarts.core.sumo_road_network import SumoRoadNetwork
 
-        clazz = SumoRoadNetwork
+        map_class = SumoRoadNetwork
 
     elif map_type == _OPENDRIVE_MAP:
         from smarts.core.opendrive_road_network import OpenDriveRoadNetwork
 
-        clazz = OpenDriveRoadNetwork
+        map_class = OpenDriveRoadNetwork
 
     else:
         return None, None
 
     if _existing_map:
-        if isinstance(_existing_map.obj, clazz) and _existing_map.obj.is_same_map(
+        if isinstance(_existing_map.obj, map_class) and _existing_map.obj.is_same_map(
             map_spec
         ):
             return _existing_map.obj, _existing_map.map_hash
         _clear_cache()
 
-    road_map = clazz.from_spec(map_spec)
+    road_map = map_class.from_spec(map_spec)
     if os.path.isfile(road_map.source):
         road_map_hash = file_md5_hash(road_map.source)
     else:

--- a/smarts/core/default_map_builder.py
+++ b/smarts/core/default_map_builder.py
@@ -23,7 +23,7 @@ from dataclasses import replace
 from typing import NamedTuple, Tuple
 from pathlib import Path
 from smarts.core.road_map import RoadMap
-from smarts.core.utils.file import file_md5_hash
+from smarts.core.utils.file import file_md5_hash, path2hash
 
 
 _existing_map = None
@@ -113,7 +113,7 @@ def get_road_map(map_spec) -> Tuple[RoadMap, str]:
         clazz = SumoRoadNetwork
 
     elif map_type == _OPENDRIVE_MAP:
-        from smarts.core.sumo_road_network import OpenDriveRoadNetwork
+        from smarts.core.opendrive_road_network import OpenDriveRoadNetwork
 
         clazz = OpenDriveRoadNetwork
 
@@ -128,7 +128,10 @@ def get_road_map(map_spec) -> Tuple[RoadMap, str]:
         _clear_cache()
 
     road_map = clazz.from_spec(map_spec)
-    road_map_hash = file_md5_hash(road_map.source)
+    if os.path.isfile(road_map.source):
+        road_map_hash = file_md5_hash(road_map.source)
+    else:
+        road_map_hash = path2hash(road_map.source)
     _cache_result(map_spec, road_map, road_map_hash)
 
     return road_map, road_map_hash

--- a/smarts/core/default_map_builder.py
+++ b/smarts/core/default_map_builder.py
@@ -49,7 +49,7 @@ def _clear_cache():
         # Try to only keep one map around at a time...
         del _existing_map
         _existing_map = None
-        gc.collect
+        gc.collect()
 
 
 _UNKNOWN_MAP = 0

--- a/smarts/core/default_map_builder.py
+++ b/smarts/core/default_map_builder.py
@@ -20,7 +20,7 @@
 
 import os
 from dataclasses import replace
-from typing import NamedTuple, Tuple
+from typing import NamedTuple, Optional, Tuple
 from pathlib import Path
 from smarts.core.road_map import RoadMap
 from smarts.core.utils.file import file_md5_hash, path2hash
@@ -86,7 +86,7 @@ def _find_mapfile_in_dir(map_dir: str) -> Tuple[int, str]:
 # map formats (by extending the RoadMap base class) can create their
 # own version of this to reference from a MapSpec within their
 # scenario folder(s) and shouldn't have to change much else.
-def get_road_map(map_spec) -> Tuple[RoadMap, str]:
+def get_road_map(map_spec) -> Tuple[Optional[RoadMap], Optional[str]]:
     """@return a RoadMap object and a hash
     that uniquely identifies it. Changes to the hash
     should signify that the map is different enough

--- a/smarts/core/opendrive_road_network.py
+++ b/smarts/core/opendrive_road_network.py
@@ -226,6 +226,11 @@ class OpenDriveRoadNetwork(RoadMap):
         cls,
         map_spec: MapSpec,
     ):
+        if map_spec.shift_to_origin:
+            logger = logging.getLogger(cls.__name__)
+            logger.warning(
+                "OpenDrive road networks do not yet support the 'shift_to_origin' option."
+            )
         xodr_file = OpenDriveRoadNetwork._map_path(map_spec)
         od_map = cls(xodr_file, map_spec)
         return od_map
@@ -600,6 +605,7 @@ class OpenDriveRoadNetwork(RoadMap):
                 or OpenDriveRoadNetwork._spec_lane_width(map_spec)
                 == OpenDriveRoadNetwork._spec_lane_width(self._map_spec)
             )
+            and map_spec.shift_to_origin == self._map_spec.shift_to_origin
         )
 
     def surface_by_id(self, surface_id: str) -> RoadMap.Surface:

--- a/smarts/core/scenario.py
+++ b/smarts/core/scenario.py
@@ -434,11 +434,17 @@ class Scenario:
         scenario_root: str,
         lanepoint_spacing: Optional[float] = None,
         default_lane_width: Optional[float] = None,
+        shift_to_origin: bool = False,
     ) -> MapSpec:
         path = os.path.join(scenario_root, "map_spec.pkl")
         if not os.path.exists(path):
             # Use our default map builder if none specified by scenario...
-            return MapSpec(scenario_root, lanepoint_spacing, default_lane_width)
+            return MapSpec(
+                scenario_root,
+                lanepoint_spacing,
+                default_lane_width,
+                shift_to_origin,
+            )
         with open(path, "rb") as f:
             road_map = cloudpickle.load(f)
             return road_map

--- a/smarts/core/sumo_road_network.py
+++ b/smarts/core/sumo_road_network.py
@@ -140,7 +140,7 @@ class SumoRoadNetwork(RoadMap):
         return False
 
     @classmethod
-    def from_spec(cls, map_spec: MapSpec, shift_to_origin: bool = False):
+    def from_spec(cls, map_spec: MapSpec):
         net_file = SumoRoadNetwork._map_path(map_spec)
 
         # Connections to internal lanes are implicit. If `withInternal=True` is
@@ -151,7 +151,8 @@ class SumoRoadNetwork(RoadMap):
         if not cls._check_net_origin(G.getBoundary()):
             shifted_net_file = cls.shifted_net_file_path(net_file)
             if os.path.isfile(shifted_net_file) or (
-                shift_to_origin and cls._shift_coordinates(net_file, shifted_net_file)
+                map_spec.shift_to_origin
+                and cls._shift_coordinates(net_file, shifted_net_file)
             ):
                 G = sumolib.net.readNet(shifted_net_file, withInternal=True)
                 assert cls._check_net_origin(G.getBoundary())
@@ -198,6 +199,10 @@ class SumoRoadNetwork(RoadMap):
                 map_spec.default_lane_width == self._map_spec.default_lane_width
                 or SumoRoadNetwork._spec_lane_width(map_spec)
                 == SumoRoadNetwork._spec_lane_width(self._map_spec)
+            )
+            and (
+                map_spec.shift_to_origin == self._map_spec.shift_to_origin
+                or (not map_spec.shift_to_origin and not self._graph._shifted_by_smarts)
             )
         )
 

--- a/smarts/core/utils/file.py
+++ b/smarts/core/utils/file.py
@@ -24,6 +24,10 @@ import shutil
 from contextlib import contextmanager
 
 
+def file_in_folder(filename: str, path: str) -> bool:
+    return os.path.exists(os.path.join(path, filename))
+
+
 # https://stackoverflow.com/a/2166841
 def isnamedtupleinstance(x):
     t = type(x)

--- a/smarts/sstudio/sumo2mesh.py
+++ b/smarts/sstudio/sumo2mesh.py
@@ -29,12 +29,6 @@ def generate_glb_from_sumo_file(sumo_net_file: str, out_glb_file: str):
     road_network.to_glb(out_glb_file)
 
 
-def generate_glb_from_sumo_network(
-    sumo_road_network: SumoRoadNetwork, out_glb_file: str
-):
-    sumo_road_network.to_glb(out_glb_file)
-
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         "sumo2mesh.py",

--- a/smarts/sstudio/types.py
+++ b/smarts/sstudio/types.py
@@ -278,8 +278,8 @@ class MapSpec:
     default_lane_width: Optional[float] = None
     """If specified, the default width (in meters) of lanes on this map."""
     shift_to_origin: bool = False
-    """If True, a map whose bounding-box does not intersect with the origin point (0,0)
-    whill be shifted such that it does upon creation."""
+    """If True, upon creation a map whose bounding-box does not intersect with
+    the origin point (0,0) will be shifted such that it does."""
     builder_fn: MapBuilder = get_road_map
     """If specified, this should return an object derived from the RoadMap base class
     and a hash that uniquely identifies it (changes to the hash should signify

--- a/smarts/sstudio/types.py
+++ b/smarts/sstudio/types.py
@@ -277,6 +277,9 @@ class MapSpec:
     """If specified, the default distance between pre-generated Lane Points (Waypoints)."""
     default_lane_width: Optional[float] = None
     """If specified, the default width (in meters) of lanes on this map."""
+    shift_to_origin: bool = False
+    """If True, a map whose bounding-box does not intersect with the origin point (0,0)
+    whill be shifted such that it does upon creation."""
     builder_fn: MapBuilder = get_road_map
     """If specified, this should return an object derived from the RoadMap base class
     and a hash that uniquely identifies it (changes to the hash should signify

--- a/smarts/sstudio/types.py
+++ b/smarts/sstudio/types.py
@@ -75,7 +75,7 @@ class _SumoParams(collections_abc.Mapping):
             w = word[0].upper() + word[1:]
             return "".join(x or "_" for x in w.split("_"))
 
-        func: function = snake_to_title
+        func: Callable[[str], str] = snake_to_title
         if mode == _SUMO_PARAMS_MODE.TITLE_CASE:
             pass
         elif mode == _SUMO_PARAMS_MODE.KEEP_SNAKE_CASE:
@@ -241,7 +241,7 @@ class SocialAgentActor(Actor):
     """Additional keyword arguments to be passed to the constructed class overriding the
     existing registered arguments.
     """
-    initial_speed: float = None
+    initial_speed: Optional[float] = None
     """Set the initial speed, defaults to 0."""
 
 
@@ -266,7 +266,9 @@ class BoidAgentActor(SocialAgentActor):
 # This function should be re-callable (although caching is up to the implementation).
 # The idea here is that anything in SMARTS that needs to use a RoadMap
 # can call this builder to get or create one as necessary.
-MapBuilder = NewType("MapBuilder", Callable[[Any], Tuple[RoadMap, str]])
+MapBuilder = NewType(
+    "MapBuilder", Callable[[Any], Tuple[Optional[RoadMap], Optional[str]]]
+)
 
 
 @dataclass(frozen=True)
@@ -448,7 +450,7 @@ class TrapEntryTactic(EntryTactic):
     """The zone of the hijack area"""
     exclusion_prefixes: Tuple[str, ...] = tuple()
     """The prefixes of vehicles to avoid hijacking"""
-    default_entry_speed: float = None
+    default_entry_speed: Optional[float] = None
     """The speed that the vehicle starts at when defaulting to emitting"""
 
 
@@ -467,7 +469,7 @@ class Mission:
     `entry_tactic`.
     """
 
-    entry_tactic: EntryTactic = None
+    entry_tactic: Optional[EntryTactic] = None
     """A specific tactic the mission should employ to start the mission."""
 
 
@@ -489,7 +491,7 @@ class EndlessMission:
     """Points on a road that an actor must pass through"""
     start_time: float = 0.1
     """The earliest simulation time that this mission starts"""
-    entry_tactic: EntryTactic = None
+    entry_tactic: Optional[EntryTactic] = None
     """A specific tactic the mission should employ to start the mission"""
 
 
@@ -507,7 +509,7 @@ class LapMission:
     """Points on a road that an actor must pass through"""
     start_time: float = 0.1
     """The earliest simulation time that this mission starts"""
-    entry_tactic: EntryTactic = None
+    entry_tactic: Optional[EntryTactic] = None
     """A specific tactic the mission should employ to start the mission"""
 
 
@@ -554,7 +556,7 @@ class MapZone(Zone):
     """
     length: float
     """The length of the geometry along the center of the lane. Also acceptable\\: 'max'"""
-    n_lanes: 2
+    n_lanes: int = 2
     """The number of lanes from right to left that this zone covers."""
 
     def to_geometry(self, road_map: RoadMap) -> Polygon:


### PR DESCRIPTION
- Changed so that if more than one qualifying map file exists in a the `map_spec.source` folder, `get_road_map()` in `default_map_builder.py` will prefer to return the default files (`map.net.xml` or `map.xodr`) if they exist.
- Cleaned up map building in scenario studio, including:
    - don't assume map filenames (use the `MapSpec` `builder_fn` instead) and honor custom map building from `scenario.py`
    - correctly handle the `shift_to_origin` parameter, which was broken before