### PR TITLE
[Bugfix] Secondary TraCI error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 ### Changed
 ### Deprecated
 ### Fixed
+- Fixed a secondary exception that the `SumoTrafficSimulation` will throw when attempting to close a TraCI connection that is closed by an error. 
 ### Removed
 ### Security
 

--- a/smarts/core/sumo_traffic_simulation.py
+++ b/smarts/core/sumo_traffic_simulation.py
@@ -295,14 +295,24 @@ class SumoTrafficSimulation(Provider):
         return self._compute_provider_state()
 
     def _close_traci_and_pipes(self):
+        """We should expect this method to always work without throwing"""
+
+        def __safe_close(conn):
+            try:
+                conn.close()
+            except:
+                pass
+
         if self._sumo_proc:
-            self._sumo_proc.stdin.close()
-            self._sumo_proc.stdout.close()
-            self._sumo_proc.stderr.close()
+            __safe_close(self._sumo_proc.stdin)
+            __safe_close(self._sumo_proc.stdout)
+            __safe_close(self._sumo_proc.stderr)
 
         if self._traci_conn:
-            self._traci_conn.close()
-            self._traci_conn = None
+            __safe_close(self._traci_conn__)
+
+        self._sumo_proc = None
+        self._traci_conn = None
 
     def _handle_traci_disconnect(self, e):
         logging.error(f"TraCI has disconnected with: {e}")

--- a/smarts/core/sumo_traffic_simulation.py
+++ b/smarts/core/sumo_traffic_simulation.py
@@ -309,7 +309,7 @@ class SumoTrafficSimulation(Provider):
             __safe_close(self._sumo_proc.stderr)
 
         if self._traci_conn:
-            __safe_close(self._traci_conn__)
+            __safe_close(self._traci_conn)
 
         self._sumo_proc = None
         self._traci_conn = None


### PR DESCRIPTION
A secondary error has showed up in which calling `traci_conn.close()` will throw an exception because `TraCI` automatically closes and invalidates the underlying connection object upon the initial exception.