### PR TITLE
Remove `python-dev` dependency for smarts

### DIFF
--- a/examples/driving_in_traffic/Dockerfile
+++ b/examples/driving_in_traffic/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update --fix-missing && \
         ffmpeg \
         libspatialindex-dev \
         python3.7 \
-        python3.7-dev \
         python3.7-venv \
         xorg && \
     apt-get autoremove -y && \

--- a/ultra/Dockerfile
+++ b/ultra/Dockerfile
@@ -43,7 +43,6 @@ RUN apt-get update --fix-missing && \
     apt-get install -y \
         wget \
         python3.7 \
-        python3.7-dev \
         python3.7-venv \
         sumo \
         sumo-tools \

--- a/ultra/install_deps.sh
+++ b/ultra/install_deps.sh
@@ -25,14 +25,14 @@ function do_install_for_linux {
          read -p "Install python3.7? [Yn]" should_add_python_3_7
          if [[ $should_add_python_3_7 =~ ^[yY\w]*$ ]]; then
               echo ""
-              printf "This will run the following commands:\n$ sudo apt-get update\n$ sudo apt-get install software-properties-common\n$ sudo add-apt-repository ppa:deadsnakes/ppa\n$ sudo apt-get install python3.7 python3.7-dev python3.7-tk python3.7-venv"
+              printf "This will run the following commands:\n$ sudo apt-get update\n$ sudo apt-get install software-properties-common\n$ sudo add-apt-repository ppa:deadsnakes/ppa\n$ sudo apt-get install python3.7 python3.7-tk python3.7-venv"
               echo ""
               read -p "WARNING. Is this OK? If you are unsure choose no. [Yn]" should_add_python_3_7
               # second check to make sure they really want to
               if [[ $should_add_python_3_7 =~ ^[yY\w]*$ ]]; then
                     sudo apt-get install software-properties-common
                     sudo add-apt-repository ppa:deadsnakes/ppa
-                    sudo apt-get install python3.7 python3.7-dev python3.7-tk python3.7-venv
+                    sudo apt-get install python3.7 python3.7-tk python3.7-venv
               fi
          fi
     fi

--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -20,7 +20,6 @@ RUN apt-get update --fix-missing && \
     apt-get install -y \
         libspatialindex-dev \
         python3.7 \
-        python3.7-dev \
         python3.7-venv \
         sumo \
         sumo-doc \

--- a/utils/docker/Dockerfile.minimal
+++ b/utils/docker/Dockerfile.minimal
@@ -21,7 +21,6 @@ RUN apt-get update --fix-missing && \
     apt-get install -y \
         libspatialindex-dev \
         python3.7 \
-        python3.7-dev \
         python3.7-venv \
         sumo \
         sumo-doc \

--- a/utils/setup/install_deps.sh
+++ b/utils/setup/install_deps.sh
@@ -43,7 +43,7 @@ function do_install_for_linux {
             read -p "Install python3.7? [Yn]" should_add_python_3_7
             if [[ $should_add_python_3_7 =~ ^[yY\w]*$ ]]; then
                 echo ""
-                printf "This will run the following commands:\n$ sudo apt-get update\n$ sudo apt-get install software-properties-common\n$ sudo add-apt-repository ppa:deadsnakes/ppa\n$ sudo apt-get install python3.7 python3.7-dev python3.7-tk python3.7-venv"
+                printf "This will run the following commands:\n$ sudo apt-get update\n$ sudo apt-get install software-properties-common\n$ sudo add-apt-repository ppa:deadsnakes/ppa\n$ sudo apt-get install python3.7 python3.7-tk python3.7-venv"
                 echo ""
                 read -p "WARNING. Is this OK? If you are unsure choose no. [Yn]" should_add_python_3_7
                 # second check to make sure they really want to

--- a/utils/setup/install_deps.sh
+++ b/utils/setup/install_deps.sh
@@ -12,7 +12,7 @@ function install_python_3_7 {
     echo "Installing python3.7"
     sudo apt-get install $1 software-properties-common
     sudo add-apt-repository $1 ppa:deadsnakes/ppa
-    sudo apt-get install $1 python3.7 python3.7-dev python3.7-tk python3.7-venv
+    sudo apt-get install $1 python3.7 python3.7-tk python3.7-venv
 }
 
 function set_SUMO_HOME {

--- a/utils/singularity/smarts.def
+++ b/utils/singularity/smarts.def
@@ -22,7 +22,6 @@ From: ubuntu:bionic
         apt-get install -y \
             libspatialindex-dev \
             python3.7 \
-            python3.7-dev \
             python3.7-venv \
             sumo \
             sumo-doc \


### PR DESCRIPTION
Remove `python-dev` dependency for lighter weight smarts
#1202 