### PR TITLE
Add introduction in readme.md for zsh user

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,18 +73,16 @@ source .venv/bin/activate
 # upgrade pip, a recent version of pip is needed for the version of tensorflow we depend on
 pip install --upgrade pip
 
-# for the following `pip install -e .[*]` commands, if you are a zsh user,
-# please add quotation marks ouside the square brackets and dot. e.g., `pip install -e '.[*]'`
 # install [train] version of python package with the rllib dependencies
-pip install -e .[train]
+pip install -e '.[train]'
 
 # install [camera-obs] version of python package with the panda3D dependencies if you want to run sanity tests or render camera sensor observations in your simulations
 # make sure to install [test] version of python package with the rllib dependencies so that you can run sanity-test (and verify they are passing)
-pip install -e .[camera-obs]  
+pip install -e '.[camera-obs]'  
 
 # make sure you install the [camera-obs] dependencies first and then can run sanity-test (and verify they are passing)
 # if tests fail, check './sanity_test_result.xml' for test report. 
-pip install -e .[test]
+pip install -e '.[test]'
 make sanity-test
 
 # then you can run a scenario, see following section for more details

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ source .venv/bin/activate
 # upgrade pip, a recent version of pip is needed for the version of tensorflow we depend on
 pip install --upgrade pip
 
+# for the following `pip install -e .[*]` commands, if you are a zsh user,
+# please add quotation marks ouside the square brackets and dot. e.g., `pip install -e '.[*]'`
 # install [train] version of python package with the rllib dependencies
 pip install -e .[train]
 


### PR DESCRIPTION
The current `pip install -e .[*]` does not work with zsh console. Instead, quotation marks are necessary outside the `.[*]`. Therefore additional introduction has been added in the readme.md.
