### PR TITLE
Update package

### DIFF
--- a/.github/workflows/ci-base-tests-linux.yml
+++ b/.github/workflows/ci-base-tests-linux.yml
@@ -39,7 +39,7 @@ jobs:
           . ${{env.venv_dir}}/bin/activate
           pip install --upgrade pip
           pip install --upgrade wheel
-          pip install -e .[train,test,camera-obs]
+          pip install -e .[camera-obs,test,train]
       - name: Run smoke tests
         run: |
           . ${{env.venv_dir}}/bin/activate

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
             "pytest-xdist>=2.4.0",
         ],
         "train": [
-            "opencv-python==4.1.2.30",
+            "opencv-contrib-python-headless==4.1.2.30",
             "ray[rllib]==1.0.1.post1",
             "tensorflow>=2.4.0",
             "torch==1.4.0",

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
             "pytest-xdist>=2.4.0",
         ],
         "train": [
-            "opencv-python-headless==4.1.2.30",
+            "opencv-python==4.1.2.30",
             "ray[rllib]==1.0.1.post1",
             "tensorflow>=2.4.0",
             "torch==1.4.0",

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "protobuf>=3.19.1",
         "PyYAML>=6.0",
         "twisted>=21.7.0",
-        "opendrive2lanelet",
+        "opendrive2lanelet>=1.2.1",
     ],
     extras_require={
         "camera-obs": ["Panda3D==1.10.9", "panda3d-gltf==0.13"],
@@ -76,17 +76,17 @@ setup(
         "ros": ["catkin_pkg", "rospkg"],
         "test": [
             # The following are for testing
-            "ipykernel>=6.5.0",
-            "jupyter-client==6.1.12",
+            "ipykernel>=6.8.0",
+            "jupyter-client>=7.1.2",
             "pytest>=6.2.5",
             "pytest-benchmark>=3.4.1",
             "pytest-cov>=3.0.0",
-            "pytest-notebook>=0.6.1",
+            "pytest-notebook>=0.7.0",
             "pytest-xdist>=2.4.0",
-            "ray[rllib]==1.0.1.post1",  # We use Ray for our multiprocessing needs
-            "tensorflow>=2.4.0",  # For rllib tests
         ],
         "train": [
+            "opencv-python==4.1.2.30",
+            "opencv-python-headless==4.1.2.30",
             "ray[rllib]==1.0.1.post1",
             "tensorflow>=2.4.0",
             "torch==1.4.0",

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,6 @@ setup(
             "pytest-xdist>=2.4.0",
         ],
         "train": [
-            "opencv-python==4.1.2.30",
             "opencv-python-headless==4.1.2.30",
             "ray[rllib]==1.0.1.post1",
             "tensorflow>=2.4.0",

--- a/smarts/core/utils/logging.py
+++ b/smarts/core/utils/logging.py
@@ -18,7 +18,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 import ctypes
-import logging
 import os
 import sys
 from contextlib import contextmanager
@@ -45,9 +44,9 @@ def timeit(name: str, logger):
 def isnotebook():
     """Determines if executing in ipython (Jupyter Notebook)"""
     try:
-        shell = get_ipython().__class__.__name__
+        shell = get_ipython().__class__.__name__ # pytype: disable=name-error
         if shell == "ZMQInteractiveShell" or "google.colab" in sys.modules:
-            return True  # Jupyter notebook or qtconsole
+            return True  # Jupyter notebook or qtconsole or Google Colab
     except NameError:
         pass
 


### PR DESCRIPTION
Some dependency versions were updated to fix the failing CI.

1) Pip dependency resolver took extra long time in backtracking, causing CI to hang. Hence, latest package versions were specified.
2) I am unsure which core dependency requires the opencv package, but the latest opencv package causes the rllib test to fail. Therefore, `opencv-python==4.1.2.30` and `opencv-python-headless==4.1.2.30` were needed to pass the rllib test.