### PR TITLE
Intersection-v0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 ### Added
 - Added `get_vehicle_start_time()` method for scenarios with traffic history data.  See Issue #1210.
 - Added `FormatObs` wrapper which converts SMARTS observations to gym-compliant RL-friendly vectorized observations and returns `StdObs`.
+- Added standard intersection environment, `intersection-v0`, for reinforcement learning where agents have to make a left turn in the presence of traffic.
 ### Changed
 - If more than one qualifying map file exists in a the `map_spec.source` folder, `get_road_map()` in `default_map_builder.py` will prefer to return the default files (`map.net.xml` or `map.xodr`) if they exist.
 - Moved the `smarts_ros` ROS node from the `examples` area into the `smarts.ros` module so that it can be distributed with SMARTS packages.

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,7 +1,3 @@
-import subprocess
-from typing import List
-
-
 class RayException(Exception):
     """An exception raised if ray package is required but not available."""
 
@@ -12,13 +8,3 @@ class RayException(Exception):
                You may not have installed the [train] or [test] dependencies required to run the ray dependent example.
                Install them first using the command `pip install -e .[train, test]` at the source directory to install the package ray[rllib]==1.0.1.post1"""
         )
-
-
-def build_scenario(scenario: List[str]):
-    """Build the given scenarios.
-
-    Args:
-        scenario (List[str]): Scenarios to build.
-    """
-    build_scenario = " ".join(["scl scenario build-all"] + scenario)
-    subprocess.call(build_scenario, shell=True)

--- a/examples/multi_agent.py
+++ b/examples/multi_agent.py
@@ -2,11 +2,11 @@ import pathlib
 
 import gym
 
-from examples import build_scenario
 from examples.argument_parser import default_argument_parser
 from smarts.core.agent import Agent, AgentSpec
 from smarts.core.agent_interface import AgentInterface, AgentType
 from smarts.core.utils.episodes import episodes
+from smarts.env import build_scenario
 
 N_AGENTS = 4
 AGENT_IDS = ["Agent %i" % i for i in range(N_AGENTS)]

--- a/examples/parallel_environment.py
+++ b/examples/parallel_environment.py
@@ -7,12 +7,12 @@ gym.logger.set_level(40)
 from functools import partial
 from typing import Dict, Sequence, Tuple
 
-from examples import build_scenario
 from examples.argument_parser import default_argument_parser
 from smarts.core.agent import Agent, AgentSpec
 from smarts.core.agent_interface import AgentInterface
 from smarts.core.controllers import ActionSpaceType
 from smarts.core.sensors import Observation
+from smarts.env import build_scenario
 from smarts.env.hiway_env import HiWayEnv
 from smarts.env.wrappers.frame_stack import FrameStack
 from smarts.env.wrappers.parallel_env import ParallelEnv

--- a/examples/single_agent.py
+++ b/examples/single_agent.py
@@ -3,12 +3,12 @@ import pathlib
 
 import gym
 
-from examples import build_scenario
 from examples.argument_parser import default_argument_parser
 from smarts.core.agent import Agent, AgentSpec
 from smarts.core.agent_interface import AgentInterface, AgentType
 from smarts.core.sensors import Observation
 from smarts.core.utils.episodes import episodes
+from smarts.env import build_scenario
 from smarts.env.wrappers.single_agent import SingleAgent
 
 logging.basicConfig(level=logging.INFO)

--- a/examples/single_agent_test.py
+++ b/examples/single_agent_test.py
@@ -1,0 +1,58 @@
+import time
+
+import gym
+import numpy as np
+
+from examples.argument_parser import default_argument_parser
+from smarts.core.agent import Agent
+from smarts.core.utils.episodes import episodes
+from smarts.env import build_scenario
+
+
+class ChaseWaypointsAgent(Agent):
+    def act(self, obs):
+        cur_lane_index = obs.ego["lane_index"]
+        next_lane_index = obs.waypoints["lane_index"][0, 0]
+
+        return (
+            obs.waypoints["speed_limit"][0, 0] / 5,
+            np.sign(next_lane_index - cur_lane_index),
+        )
+
+
+def main(headless, num_episodes):
+    env = gym.make(
+        "smarts.env:intersection-v0",
+        headless=True,
+        sumo_headless=False,
+    )
+
+    for episode in episodes(n=num_episodes):
+        agent = ChaseWaypointsAgent()
+        observation = env.reset()
+        episode.record_scenario(env.scenario_log)
+
+        tot_reward = 0
+        done = False
+        while not done:
+            agent_action = agent.act(observation)
+            observation, reward, done, info = env.step(agent_action)
+            episode.record_step(observation, reward, done, info)
+            tot_reward += reward
+            if tot_reward >= 100:
+                print("TOTAL REWARD EXCEEDED 100")
+                time.sleep(10)
+                break
+        print("Score==", info["score"], ", reward==", tot_reward)
+
+    env.close()
+
+
+if __name__ == "__main__":
+    parser = default_argument_parser("single-agent-example")
+    args = parser.parse_args()
+
+    main(
+        headless=args.headless,
+        num_episodes=args.episodes,
+    )

--- a/scenarios/intersections/2lane_left_turn/map.net.xml
+++ b/scenarios/intersections/2lane_left_turn/map.net.xml
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- generated on 2022-02-10 19:25:02 by Eclipse SUMO netedit Version 1.11.0
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/netconvertConfiguration.xsd">
+
+    <input>
+        <sumo-net-file value="/home/adai/workspaces/SMARTS/scenarios/intersections/2lane_left_turn/map.net.xml"/>
+    </input>
+
+    <output>
+        <output-file value="/home/adai/workspaces/SMARTS/scenarios/intersections/2lane_left_turn/map.net.xml"/>
+    </output>
+
+    <processing>
+        <geometry.min-radius.fix.railways value="false"/>
+        <geometry.max-grade.fix value="false"/>
+        <offset.disable-normalization value="true"/>
+        <lefthand value="false"/>
+    </processing>
+
+    <junctions>
+        <no-turnarounds value="true"/>
+        <junctions.corner-detail value="5"/>
+        <junctions.limit-turn-speed value="5.5"/>
+        <rectangular-lane-cut value="false"/>
+    </junctions>
+
+    <pedestrian>
+        <walkingareas value="false"/>
+    </pedestrian>
+
+    <report>
+        <aggregate-warnings value="5"/>
+    </report>
+
+</configuration>
+-->
+
+<net version="1.9" junctionCornerDetail="5" limitTurnSpeed="5.50" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/net_file.xsd">
+
+    <location netOffset="-630882.85,-4856133.12" convBoundary="-105.00,-50.00,50.00,105.00" origBoundary="-79.371708,43.846679,-79.369237,43.847436" projParameter="+proj=utm +zone=17 +ellps=WGS84 +datum=WGS84 +units=m +no_defs"/>
+
+    <type id="highway.bridleway" priority="1" numLanes="1" speed="2.78" allow="pedestrian" oneway="1" width="2.00"/>
+    <type id="highway.bus_guideway" priority="1" numLanes="1" speed="27.78" allow="bus" oneway="1"/>
+    <type id="highway.cycleway" priority="1" numLanes="1" speed="8.33" allow="bicycle" oneway="1" width="1.00"/>
+    <type id="highway.footway" priority="1" numLanes="1" speed="2.78" allow="pedestrian" oneway="1" width="2.00"/>
+    <type id="highway.ford" priority="1" numLanes="1" speed="2.78" allow="army" oneway="1"/>
+    <type id="highway.living_street" priority="2" numLanes="1" speed="2.78" disallow="tram rail_urban rail rail_electric ship" oneway="1"/>
+    <type id="highway.motorway" priority="14" numLanes="2" speed="39.44" allow="private emergency authority army vip passenger hov taxi bus coach delivery truck trailer motorcycle evehicle custom1 custom2" oneway="1"/>
+    <type id="highway.motorway_link" priority="9" numLanes="1" speed="22.22" allow="private emergency authority army vip passenger hov taxi bus coach delivery truck trailer motorcycle evehicle custom1 custom2" oneway="1"/>
+    <type id="highway.path" priority="1" numLanes="1" speed="2.78" allow="pedestrian bicycle" oneway="1" width="2.00"/>
+    <type id="highway.pedestrian" priority="1" numLanes="1" speed="2.78" allow="pedestrian" oneway="1" width="2.00"/>
+    <type id="highway.primary" priority="12" numLanes="2" speed="27.78" disallow="tram rail_urban rail rail_electric ship" oneway="1"/>
+    <type id="highway.primary_link" priority="7" numLanes="1" speed="22.22" disallow="tram rail_urban rail rail_electric ship" oneway="1"/>
+    <type id="highway.raceway" priority="15" numLanes="2" speed="83.33" allow="vip" oneway="1"/>
+    <type id="highway.residential" priority="3" numLanes="1" speed="13.89" disallow="tram rail_urban rail rail_electric ship" oneway="1"/>
+    <type id="highway.secondary" priority="11" numLanes="2" speed="27.78" disallow="tram rail_urban rail rail_electric ship" oneway="1"/>
+    <type id="highway.secondary_link" priority="6" numLanes="1" speed="22.22" disallow="tram rail_urban rail rail_electric ship" oneway="1"/>
+    <type id="highway.service" priority="1" numLanes="1" speed="5.56" allow="pedestrian delivery bicycle" oneway="1"/>
+    <type id="highway.stairs" priority="1" numLanes="1" speed="1.39" allow="pedestrian" oneway="1" width="2.00"/>
+    <type id="highway.step" priority="1" numLanes="1" speed="1.39" allow="pedestrian" oneway="1" width="2.00"/>
+    <type id="highway.steps" priority="1" numLanes="1" speed="1.39" allow="pedestrian" oneway="1" width="2.00"/>
+    <type id="highway.tertiary" priority="10" numLanes="1" speed="22.22" disallow="tram rail_urban rail rail_electric ship" oneway="1"/>
+    <type id="highway.tertiary_link" priority="5" numLanes="1" speed="22.22" disallow="tram rail_urban rail rail_electric ship" oneway="1"/>
+    <type id="highway.track" priority="1" numLanes="1" speed="5.56" disallow="tram rail_urban rail rail_electric ship" oneway="1"/>
+    <type id="highway.trunk" priority="13" numLanes="2" speed="27.78" disallow="pedestrian bicycle tram rail_urban rail rail_electric ship" oneway="1"/>
+    <type id="highway.trunk_link" priority="8" numLanes="1" speed="22.22" disallow="pedestrian bicycle tram rail_urban rail rail_electric ship" oneway="1"/>
+    <type id="highway.unclassified" priority="4" numLanes="1" speed="13.89" disallow="tram rail_urban rail rail_electric ship" oneway="1"/>
+    <type id="highway.unsurfaced" priority="1" numLanes="1" speed="8.33" disallow="tram rail_urban rail rail_electric ship" oneway="1"/>
+    <type id="railway.light_rail" priority="19" numLanes="1" speed="27.78" allow="rail_urban" oneway="1"/>
+    <type id="railway.preserved" priority="16" numLanes="1" speed="27.78" allow="rail" oneway="1"/>
+    <type id="railway.rail" priority="20" numLanes="1" speed="83.33" allow="rail rail_electric" oneway="1"/>
+    <type id="railway.subway" priority="18" numLanes="1" speed="27.78" allow="rail_urban" oneway="1"/>
+    <type id="railway.tram" priority="17" numLanes="1" speed="13.89" allow="tram" oneway="1"/>
+
+    <edge id=":junction-intersection_0" function="internal">
+        <lane id=":junction-intersection_0_0" index="0" speed="8.33" length="15.48" shape="-1.60,11.20 -2.20,7.00 -4.00,4.00 -7.00,2.20 -11.20,1.60"/>
+    </edge>
+    <edge id=":junction-intersection_1" function="internal">
+        <lane id=":junction-intersection_1_0" index="0" speed="13.00" length="22.40" shape="-1.60,11.20 -1.60,-11.20"/>
+    </edge>
+    <edge id=":junction-intersection_2" function="internal">
+        <lane id=":junction-intersection_2_0" index="0" speed="9.55" length="20.64" shape="-1.60,11.20 -0.80,5.60 1.60,1.60 5.60,-0.80 11.20,-1.60"/>
+    </edge>
+    <edge id=":junction-intersection_3" function="internal">
+        <lane id=":junction-intersection_3_0" index="0" speed="8.33" length="15.48" shape="11.20,1.60 7.00,2.20 4.00,4.00 2.20,7.00 1.60,11.20"/>
+    </edge>
+    <edge id=":junction-intersection_4" function="internal">
+        <lane id=":junction-intersection_4_0" index="0" speed="13.00" length="22.40" shape="11.20,1.60 -11.20,1.60"/>
+    </edge>
+    <edge id=":junction-intersection_5" function="internal">
+        <lane id=":junction-intersection_5_0" index="0" speed="9.55" length="20.64" shape="11.20,1.60 5.60,0.80 1.60,-1.60 -0.80,-5.60 -1.60,-11.20"/>
+    </edge>
+    <edge id=":junction-intersection_6" function="internal">
+        <lane id=":junction-intersection_6_0" index="0" speed="8.33" length="15.48" shape="1.60,-11.20 2.20,-7.00 4.00,-4.00 7.00,-2.20 11.20,-1.60"/>
+    </edge>
+    <edge id=":junction-intersection_7" function="internal">
+        <lane id=":junction-intersection_7_0" index="0" speed="13.00" length="22.40" shape="1.60,-11.20 1.60,11.20"/>
+    </edge>
+    <edge id=":junction-intersection_8" function="internal">
+        <lane id=":junction-intersection_8_0" index="0" speed="9.55" length="20.64" shape="1.60,-11.20 0.80,-5.60 -1.60,-1.60 -5.60,0.80 -11.20,1.60"/>
+    </edge>
+    <edge id=":junction-intersection_9" function="internal">
+        <lane id=":junction-intersection_9_0" index="0" speed="8.33" length="15.48" shape="-11.20,-1.60 -7.00,-2.20 -4.00,-4.00 -2.20,-7.00 -1.60,-11.20"/>
+    </edge>
+    <edge id=":junction-intersection_10" function="internal">
+        <lane id=":junction-intersection_10_0" index="0" speed="13.00" length="22.40" shape="-11.20,-1.60 11.20,-1.60"/>
+    </edge>
+    <edge id=":junction-intersection_11" function="internal">
+        <lane id=":junction-intersection_11_0" index="0" speed="9.55" length="20.64" shape="-11.20,-1.60 -5.60,-0.80 -1.60,1.60 0.80,5.60 1.60,11.20"/>
+    </edge>
+
+    <edge id="edge-east-EW" from="junction-east" to="junction-intersection" priority="-1" length="50.00">
+        <lane id="edge-east-EW_0" index="0" speed="13.00" length="50.00" shape="50.00,1.60 11.20,1.60"/>
+    </edge>
+    <edge id="edge-east-WE" from="junction-intersection" to="junction-east" priority="-1" length="50.00">
+        <lane id="edge-east-WE_0" index="0" speed="13.00" length="50.00" shape="11.20,-1.60 50.00,-1.60"/>
+    </edge>
+    <edge id="edge-north-NS" from="junction-north" to="junction-intersection" priority="-1" length="105.00">
+        <lane id="edge-north-NS_0" index="0" speed="13.00" length="105.00" shape="-1.60,105.00 -1.60,11.20"/>
+    </edge>
+    <edge id="edge-north-SN" from="junction-intersection" to="junction-north" priority="-1" length="105.00">
+        <lane id="edge-north-SN_0" index="0" speed="13.00" length="105.00" shape="1.60,11.20 1.60,105.00"/>
+    </edge>
+    <edge id="edge-south-NS" from="junction-intersection" to="junction-south" priority="-1" length="50.00">
+        <lane id="edge-south-NS_0" index="0" speed="13.00" length="50.00" shape="-1.60,-11.20 -1.60,-50.00"/>
+    </edge>
+    <edge id="edge-south-SN" from="junction-south" to="junction-intersection" priority="-1" length="50.00">
+        <lane id="edge-south-SN_0" index="0" speed="13.00" length="50.00" shape="1.60,-50.00 1.60,-11.20"/>
+    </edge>
+    <edge id="edge-west-EW" from="junction-intersection" to="junction-west" priority="-1" length="105.00">
+        <lane id="edge-west-EW_0" index="0" speed="13.00" length="105.00" shape="-11.20,1.60 -105.00,1.60"/>
+    </edge>
+    <edge id="edge-west-WE" from="junction-west" to="junction-intersection" priority="-1" length="105.00">
+        <lane id="edge-west-WE_0" index="0" speed="13.00" length="105.00" shape="-105.00,-1.60 -11.20,-1.60"/>
+    </edge>
+
+    <junction id="junction-east" type="dead_end" x="50.00" y="0.00" incLanes="edge-east-WE_0" intLanes="" shape="50.00,0.00 50.00,-3.20 50.00,0.00"/>
+    <junction id="junction-intersection" type="allway_stop" x="0.00" y="0.00" incLanes="edge-north-NS_0 edge-east-EW_0 edge-south-SN_0 edge-west-WE_0" intLanes=":junction-intersection_0_0 :junction-intersection_1_0 :junction-intersection_2_0 :junction-intersection_3_0 :junction-intersection_4_0 :junction-intersection_5_0 :junction-intersection_6_0 :junction-intersection_7_0 :junction-intersection_8_0 :junction-intersection_9_0 :junction-intersection_10_0 :junction-intersection_11_0" shape="-3.20,11.20 3.20,11.20 3.42,8.76 4.09,6.76 5.20,5.20 6.76,4.09 8.76,3.42 11.20,3.20 11.20,-3.20 8.76,-3.42 6.76,-4.09 5.20,-5.20 4.09,-6.76 3.42,-8.76 3.20,-11.20 -3.20,-11.20 -3.42,-8.76 -4.09,-6.76 -5.20,-5.20 -6.76,-4.09 -8.76,-3.42 -11.20,-3.20 -11.20,3.20 -8.76,3.42 -6.76,4.09 -5.20,5.20 -4.09,6.76 -3.42,8.76" radius="8.00">
+        <request index="0"  response="000100010000" foes="000100010000" cont="0"/>
+        <request index="1"  response="111100110000" foes="111100110000" cont="0"/>
+        <request index="2"  response="110011110000" foes="110011110000" cont="0"/>
+        <request index="3"  response="100010000000" foes="100010000000" cont="0"/>
+        <request index="4"  response="100110000111" foes="100110000111" cont="0"/>
+        <request index="5"  response="011110000110" foes="011110000110" cont="0"/>
+        <request index="6"  response="010000000100" foes="010000000100" cont="0"/>
+        <request index="7"  response="110000111100" foes="110000111100" cont="0"/>
+        <request index="8"  response="110000110011" foes="110000110011" cont="0"/>
+        <request index="9"  response="000000100010" foes="000000100010" cont="0"/>
+        <request index="10" response="000111100110" foes="000111100110" cont="0"/>
+        <request index="11" response="000110011110" foes="000110011110" cont="0"/>
+    </junction>
+    <junction id="junction-north" type="dead_end" x="0.00" y="105.00" incLanes="edge-north-SN_0" intLanes="" shape="0.00,105.00 3.20,105.00 0.00,105.00"/>
+    <junction id="junction-south" type="dead_end" x="0.00" y="-50.00" incLanes="edge-south-NS_0" intLanes="" shape="0.00,-50.00 -3.20,-50.00 0.00,-50.00"/>
+    <junction id="junction-west" type="dead_end" x="-105.00" y="0.00" incLanes="edge-west-EW_0" intLanes="" shape="-105.00,0.00 -105.00,3.20 -105.00,0.00"/>
+
+    <connection from="edge-east-EW" to="edge-north-SN" fromLane="0" toLane="0" via=":junction-intersection_3_0" dir="r" state="w"/>
+    <connection from="edge-east-EW" to="edge-west-EW" fromLane="0" toLane="0" via=":junction-intersection_4_0" dir="s" state="w"/>
+    <connection from="edge-east-EW" to="edge-south-NS" fromLane="0" toLane="0" via=":junction-intersection_5_0" dir="l" state="w"/>
+    <connection from="edge-north-NS" to="edge-west-EW" fromLane="0" toLane="0" via=":junction-intersection_0_0" dir="r" state="w"/>
+    <connection from="edge-north-NS" to="edge-south-NS" fromLane="0" toLane="0" via=":junction-intersection_1_0" dir="s" state="w"/>
+    <connection from="edge-north-NS" to="edge-east-WE" fromLane="0" toLane="0" via=":junction-intersection_2_0" dir="l" state="w"/>
+    <connection from="edge-south-SN" to="edge-east-WE" fromLane="0" toLane="0" via=":junction-intersection_6_0" dir="r" state="w"/>
+    <connection from="edge-south-SN" to="edge-north-SN" fromLane="0" toLane="0" via=":junction-intersection_7_0" dir="s" state="w"/>
+    <connection from="edge-south-SN" to="edge-west-EW" fromLane="0" toLane="0" via=":junction-intersection_8_0" dir="l" state="w"/>
+    <connection from="edge-west-WE" to="edge-south-NS" fromLane="0" toLane="0" via=":junction-intersection_9_0" dir="r" state="w"/>
+    <connection from="edge-west-WE" to="edge-east-WE" fromLane="0" toLane="0" via=":junction-intersection_10_0" dir="s" state="w"/>
+    <connection from="edge-west-WE" to="edge-north-SN" fromLane="0" toLane="0" via=":junction-intersection_11_0" dir="l" state="w"/>
+
+    <connection from=":junction-intersection_0" to="edge-west-EW" fromLane="0" toLane="0" dir="r" state="M"/>
+    <connection from=":junction-intersection_1" to="edge-south-NS" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":junction-intersection_2" to="edge-east-WE" fromLane="0" toLane="0" dir="l" state="M"/>
+    <connection from=":junction-intersection_3" to="edge-north-SN" fromLane="0" toLane="0" dir="r" state="M"/>
+    <connection from=":junction-intersection_4" to="edge-west-EW" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":junction-intersection_5" to="edge-south-NS" fromLane="0" toLane="0" dir="l" state="M"/>
+    <connection from=":junction-intersection_6" to="edge-east-WE" fromLane="0" toLane="0" dir="r" state="M"/>
+    <connection from=":junction-intersection_7" to="edge-north-SN" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":junction-intersection_8" to="edge-west-EW" fromLane="0" toLane="0" dir="l" state="M"/>
+    <connection from=":junction-intersection_9" to="edge-south-NS" fromLane="0" toLane="0" dir="r" state="M"/>
+    <connection from=":junction-intersection_10" to="edge-east-WE" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":junction-intersection_11" to="edge-north-SN" fromLane="0" toLane="0" dir="l" state="M"/>
+
+</net>

--- a/scenarios/intersections/2lane_left_turn/scenario.py
+++ b/scenarios/intersections/2lane_left_turn/scenario.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+
+from smarts.sstudio.genscenario import gen_scenario
+from smarts.sstudio.types import Flow, Mission, Route, Scenario, Traffic, TrafficActor
+
+scnr_path = str(Path(__file__).parent)
+
+intersection_car = TrafficActor(
+    name="car",
+)
+
+vertical_routes = [
+    ("north-NS", "south-NS"),
+    ("south-SN", "north-SN"),
+]
+
+horizontal_routes = [
+    ("west-WE", "east-WE"),
+    ("east-EW", "west-EW"),
+]
+
+turn_left_routes = [
+    ("south-SN", "west-EW"),
+    ("west-WE", "north-SN"),
+    ("north-NS", "east-WE"),
+    ("east-EW", "south-NS"),
+]
+
+turn_right_routes = [
+    ("south-SN", "east-WE"),
+    ("west-WE", "south-NS"),
+    ("north-NS", "west-EW"),
+    ("east-EW", "north-SN"),
+]
+
+traffic = {}
+for name, routes in {
+    # "vertical": vertical_routes,
+    "horizontal": horizontal_routes,
+    # "turn_left": turn_left_routes,
+    # "turn_right": turn_right_routes,
+    # "turns": turn_left_routes + turn_right_routes,
+    # "all": vertical_routes + horizontal_routes + turn_left_routes + turn_right_routes,
+}.items():
+    traffic[name] = Traffic(
+        flows=[
+            Flow(
+                route=Route(
+                    begin=(f"edge-{r[0]}", 0, "random"),
+                    end=(f"edge-{r[1]}", 0, "max"),
+                ),
+                rate=60 * 4,
+                end=60 * 60 * 1,
+                # Note: For an episode with maximum_episode_steps=3000 and step
+                # time=0.1s, maximum episode time=300s. Hence, traffic set to
+                # end at 3600s, which is greater than maximum episode time of
+                # 300s.
+                actors={intersection_car: 1},
+            )
+            for r in routes
+        ]
+    )
+
+
+ego_missions = [
+    Mission(
+        route=Route(begin=("edge-west-WE", 0, 55), end=("edge-north-SN", 0, 50)),
+    ),
+]
+
+gen_scenario(
+    scenario=Scenario(
+        traffic=traffic,
+        ego_missions=ego_missions,
+    ),
+    output_dir=scnr_path,
+)

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,8 @@ setup(
             "pytest-xdist>=2.4.0",
         ],
         "train": [
-            "opencv-contrib-python-headless==4.1.2.30",
+            "opencv-python==4.1.2.30",
+            "opencv-python-headless==4.1.2.30",
             "ray[rllib]==1.0.1.post1",
             "tensorflow>=2.4.0",
             "torch==1.4.0",

--- a/smarts/core/lidar.py
+++ b/smarts/core/lidar.py
@@ -69,7 +69,7 @@ class Lidar:
                     self._sensor_params.noise_mu, self._sensor_params.noise_sigma
                 )
             )
-        return np.array(static_lidar_noise, dtype=np.float)
+        return np.array(static_lidar_noise, dtype=float)
 
     def compute_point_cloud(
         self,

--- a/smarts/env/__init__.py
+++ b/smarts/env/__init__.py
@@ -17,9 +17,27 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
+import subprocess
+from typing import List
+
 from gym.envs.registration import register
 
 register(
     id="hiway-v0",
     entry_point="smarts.env.hiway_env:HiWayEnv",
 )
+
+register(
+    id="intersection-v0",
+    entry_point="smarts.env.intersection_env:intersection_env",
+)
+
+
+def build_scenario(scenario: List[str]):
+    """Build the given scenarios.
+
+    Args:
+        scenario (List[str]): Scenarios to build.
+    """
+    build_scenario = " ".join(["scl scenario build-all --clean"] + scenario)
+    subprocess.call(build_scenario, shell=True)

--- a/smarts/env/intersection_env.py
+++ b/smarts/env/intersection_env.py
@@ -1,0 +1,158 @@
+# Copyright (C) 2022. Huawei Technologies Co., Ltd. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import pathlib
+from typing import Optional
+
+from smarts.core.agent import AgentSpec
+from smarts.core.agent_interface import (
+    OGM,
+    RGB,
+    AgentInterface,
+    DoneCriteria,
+    DrivableAreaGridMap,
+    NeighborhoodVehicles,
+    Waypoints,
+)
+from smarts.core.controllers import ActionSpaceType
+from smarts.env import build_scenario
+from smarts.env.hiway_env import HiWayEnv
+from smarts.env.wrappers.format_obs import FormatObs
+from smarts.env.wrappers.single_agent import SingleAgent
+
+
+def intersection_env(
+    headless: bool = True,
+    visdom: bool = False,
+    sumo_headless: bool = True,
+    envision_record_data_replay_path: Optional[str] = None,
+):
+    """An intersection environment where a single agent needs to make an
+    unprotected left turn in the presence of traffic and without traffic
+    lights. Traffic vehicles stop before entering the junction.
+
+    Observation:
+        A `smarts.env.wrappers.format_obs.StdObs` dataclass, with all fields
+        enabled, is returned as observation.
+
+    Actions:
+        Type: gym.spaces.Box(
+            low=-1.0, high=1.0, shape=(3,), dtype=np.float32
+        )
+
+        Action     Value range
+        Throttle   [ 0, 1]
+        Brake      [ 0, 1]
+        Steering   [-1, 1]
+
+    Reward:
+        Reward is distance travelled (in meters) in each step, including the
+        termination step.
+
+    Episode termination:
+        Episode is terminated if any of the following is fulfilled.
+        Steps per episode exceed 3000.
+        Agent collides, drives off road, drives off route, or drives on shoulder.
+
+    Solved requirement:
+        Considered solved when the average `info["score"]` is greater than or
+        equal to 90.0 over 100 consecutive trials.
+
+    Args:
+        headless (bool, optional): If True, disables visualization in
+            Envision. Defaults to False.
+        visdom (bool, optional): If True, enables visualization of observed
+            RGB images in Visdom. Defaults to False.
+        sumo_headless (bool, optional): If True, disables visualization in
+            SUMO GUI. Defaults to True.
+        envision_record_data_replay_path (Optional[str], optional):
+            Envision's data replay output directory. Defaults to None.
+
+    Returns:
+        A single-agent unprotected left turn intersection environment.
+    """
+
+    scenario = [
+        str(
+            pathlib.Path(__file__).absolute().parents[2]
+            / "scenarios"
+            / "intersections"
+            / "2lane_left_turn"
+        )
+    ]
+    build_scenario(scenario)
+
+    done_criteria = DoneCriteria(
+        collision=False,  # Temporary. For testing purposes. To be changed later.
+        off_road=True,
+        off_route=True,
+        on_shoulder=True,
+        wrong_way=False,
+        not_moving=False,
+        agents_alive=None,
+    )
+    max_episode_steps = 3000
+    img_meters = 100
+    img_pixels = 256
+    agent_specs = {
+        "LeftTurnAgent": AgentSpec(
+            interface=AgentInterface(
+                accelerometer=True,
+                # action=ActionSpaceType.Continuous,  # Temporary. For testing purposes. To be changed later.
+                action=ActionSpaceType.LaneWithContinuousSpeed,  # Temporary. For testing purposes. To be changed later.
+                done_criteria=done_criteria,
+                drivable_area_grid_map=DrivableAreaGridMap(
+                    width=img_pixels,
+                    height=img_pixels,
+                    resolution=img_meters / img_pixels,
+                ),
+                lidar=True,
+                max_episode_steps=max_episode_steps,
+                neighborhood_vehicles=NeighborhoodVehicles(img_meters),
+                ogm=OGM(
+                    width=img_pixels,
+                    height=img_pixels,
+                    resolution=img_meters / img_pixels,
+                ),
+                rgb=RGB(
+                    width=img_pixels,
+                    height=img_pixels,
+                    resolution=img_meters / img_pixels,
+                ),
+                road_waypoints=False,
+                waypoints=Waypoints(lookahead=img_meters),
+            ),
+        )
+    }
+
+    env = HiWayEnv(
+        scenarios=scenario,
+        agent_specs=agent_specs,
+        sim_name="LeftTurn",
+        headless=headless,
+        visdom=visdom,
+        sumo_headless=sumo_headless,
+        endless_traffic=False,
+        envision_record_data_replay_path=envision_record_data_replay_path,
+    )
+    env = FormatObs(env=env)
+    env = SingleAgent(env=env)
+
+    return env

--- a/smarts/env/wrappers/parallel_env.py
+++ b/smarts/env/wrappers/parallel_env.py
@@ -25,7 +25,7 @@ import sys
 import traceback
 import warnings
 from enum import Enum
-from typing import Any, Callable, Dict, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, Sequence, Tuple
 
 import cloudpickle
 import gym


### PR DESCRIPTION
Standard left turn environment `intersection-v0` is added in `smarts.env.intersection_env.intersection_env`. 

A few things to consider:
1) An all-way stop is used for the traffic.
2) Image resolution for `rgb`, `ogm`, and `dagm`, is currently 0.39m/pixel = 100m/256pixel .
3) Endless traffic is set to `false`. Traffic end time is set to 3600s, which is longer than the maximum episode time of 300s.
4) The roads are of length: Left - 105m, North - 105m, Right - 50m, South - 50m.
5) Mission route: agent starts at 55m mark on Left road and ends at 50m mark on North road. Total travel distance should be around 100m.
6) `reward` per step is the distance travelled per step. 
7) `info["score"]` is the total distance travelled.
8)  To test the `intersection-v0`, run the temporarily added `examples.single_agent_test.py` file by executing `python3.7 ./examples/single_agent_test.py` command.
9)  Score calculation in smarts might need to be checked. The score (i.e., cumulative distance travelled) appears to exceed 100 when the agent has merely reached the intersection which is actually way before the expected 100m mark. This can be visualised by running the test file `python3.7 ./examples/single_agent_test.py`. The 100m mark should ideally be reached once the agent turns left and completes driving 50m into the North road.