### PR TITLE
history position fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         "click>=8.0.3",  # used in scl
         "eclipse-sumo==1.10.0",  # sumo
         "gym==0.19.0",
-        "numpy>=1.20.0",
+        "numpy>=1.19.5",  # required for tf 2.4 below
         "pandas>=1.3.4",
         "psutil>=5.8.0",
         "pybullet==3.0.6",

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         "click>=8.0.3",  # used in scl
         "eclipse-sumo==1.10.0",  # sumo
         "gym==0.19.0",
-        "numpy>=1.19.5",
+        "numpy>=1.20.0",
         "pandas>=1.3.4",
         "psutil>=5.8.0",
         "pybullet==3.0.6",

--- a/smarts/sstudio/genhistories.py
+++ b/smarts/sstudio/genhistories.py
@@ -446,11 +446,10 @@ class NGSIM(_TrajectoryDataset):
         df["speed"] *= METERS_PER_FOOT
         df["acceleration"] *= METERS_PER_FOOT
         df["spacing"] *= METERS_PER_FOOT
+        df["position_x"] *= METERS_PER_FOOT
         df["position_y"] *= METERS_PER_FOOT
-        # SMARTS uses center not front
-        df["position_x"] = (
-            df["position_x"] * METERS_PER_FOOT - 0.5 * df["length"] - x_margin
-        )
+        if x_margin:
+            df["position_x"] = df["position_x"] - x_margin
         if y_margin:
             df["position_x"] = df["position_y"] - y_margin
 
@@ -498,6 +497,15 @@ class NGSIM(_TrajectoryDataset):
                 for values in stride(v, (d0 - 2, 3, d1), (s0, s0, s1))
             ]
             df.loc[same_car, "speed_discrete"] = speeds + [None, None]
+
+        # since SMARTS' positions are the vehicle centerpoints, but NGSIM's are at the front,
+        # now adjust the vehicle position to its centerpoint based on its angle (+y = 0 rad)
+        df["position_x"] = df["position_x"] - 0.5 * df["length"] * np.cos(
+            df["heading_rad"] + 0.5 * math.pi
+        )
+        df["position_y"] = df["position_y"] - 0.5 * df["length"] * np.sin(
+            df["heading_rad"] + 0.5 * math.pi
+        )
 
         map_width = self._dataset_spec["map_net"].get("width")
         if map_width:


### PR DESCRIPTION
This PR has two things in it:

1) A fix for a bug in `genhistories.py` with how it shifts vehicle positions from the front of the car to the center (Issue #1316).  This depends on heading, but the original code just assumed the car was oriented in the x-direction.  (This worked originally b/c the original i-80 map was oriented along the x-axis.)

2) Increasing the minimum version of `numpy` that's required in `setup.py` because one of the APIs we use in `genhistories.py` (`sliding_window_view()`) wasn't introduced until version `1.20`.