### PR TITLE
support for extra columns in NGSIM data files

### DIFF
--- a/smarts/sstudio/genhistories.py
+++ b/smarts/sstudio/genhistories.py
@@ -85,7 +85,7 @@ class _TrajectoryDataset:
         if "input_path" not in dataset_spec:
             errmsg = "'input_path' field is required in dataset yaml."
         elif dataset_spec.get("flip_y"):
-            if dataset_spec.get("source") != "NGSIM":
+            if not dataset_spec.get("source").startswith("NGSIM"):
                 errmsg = "'flip_y' option only supported for NGSIM datasets."
             elif not dataset_spec.get("map_net", {}).get("max_y"):
                 errmsg = "'map_net:max_y' is required if 'flip_y' option used."
@@ -407,33 +407,39 @@ class NGSIM(_TrajectoryDataset):
 
     def _transform_all_data(self):
         self._log.debug("transforming NGSIM data")
-        df = pd.read_csv(
-            self._path,
-            sep=r"\s+",
-            header=None,
-            names=(
-                "vehicle_id",
-                "frame_id",  # 1 frame per .1s
-                "total_frames",
-                "global_time",  # msecs
-                # front center in feet from left lane edge
-                "position_x" if not self._swap_xy else "position_y",
-                # front center in feet from entry edge
-                "position_y" if not self._swap_xy else "position_x",
-                "global_x" if not self._swap_xy else "global_y",  # front center in feet
-                "global_y" if not self._swap_xy else "global_x",  # front center in feet
-                "length",  # feet
-                "width",  # feet
-                "type",  # 1 = motorcycle, 2 = auto, 3 = truck
-                "speed",  # feet / sec
-                "acceleration",  # feet / sec^2
-                "lane_id",  # lower is further left
-                "preceding_vehicle_id",
-                "following_vehicle_id",
-                "spacing",  # feet
-                "headway",  # secs
-            ),
+        cols = (
+            "vehicle_id",
+            "frame_id",  # 1 frame per .1s
+            "total_frames",
+            "global_time",  # msecs
+            # front center in feet from left lane edge
+            "position_x" if not self._swap_xy else "position_y",
+            # front center in feet from entry edge
+            "position_y" if not self._swap_xy else "position_x",
+            "global_x" if not self._swap_xy else "global_y",  # front center in feet
+            "global_y" if not self._swap_xy else "global_x",  # front center in feet
+            "length",  # feet
+            "width",  # feet
+            "type",  # 1 = motorcycle, 2 = auto, 3 = truck
+            "speed",  # feet / sec
+            "acceleration",  # feet / sec^2
+            "lane_id",  # lower is further left
+            "preceding_vehicle_id",
+            "following_vehicle_id",
+            "spacing",  # feet
+            "headway",  # secs
         )
+        if self._dataset_spec.get("source") == "NGSIM2":
+            extra_cols = (
+                "origin_zone",
+                "destination_zone",
+                "intersection",
+                "section",
+                "direction",
+                "movement",
+            )
+            cols = cols[:16] + extra_cols + cols[16:]
+        df = pd.read_csv(self._path, sep=r"\s+", header=None, names=cols)
 
         df["sim_time"] = df["global_time"] - min(df["global_time"])
 
@@ -823,7 +829,7 @@ if __name__ == "__main__":
         dataset_spec["y_offset"] = args.y_offset
 
     source = dataset_spec.get("source", "NGSIM")
-    if source == "NGSIM":
+    if source == "NGSIM" or source == "NGSIM2":
         dataset = NGSIM(dataset_spec, args.output)
     elif source == "Waymo":
         dataset = Waymo(dataset_spec, args.output)


### PR DESCRIPTION
There appear to be two NGSIM datafile schemas:  one used by `i80` and `us101` that has 18 columns and one used by `peach` and `lanker` which has 6 extra columns (24 total).  All of the other columns seem to be the same.  Annoyingly though, the 6 extra columns are not just appended to the end of the row, but rather inserted into the middle of it!

If you try to read the latter into a data frame, it screws things up and columns are misaligned.  So this adds an "NGSIM2" type to the dataspec yaml for the `peach` and `lanker` cases to read these files with the extra columns.  