### PR TITLE
gitattributes for line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,54 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+# This should catch all files with no extension or not listed below.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.txt text
+*.py text
+*.md text
+*.rst text
+*.sh text
+*.bash text
+*.js text
+*.json text
+*.css text
+*.ipynb text
+*.xml text
+*.urdf text
+*.yml text
+*.yaml text
+*.proto text
+*.msg text
+*.srv text
+*.launch text
+*.c text
+*.cpp text
+*.h text
+*.hpp text
+*.pl text
+*.vert text
+*.frag text
+*.log text
+*.cfg text
+*.docker text
+Dockerfile* text
+Makefile* text
+MANIFEST.in
+*NOTICE text
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.svg binary
+*.glb binary
+*.blend binary
+*.pkl binary
+*.pdf binary
+
+# Declare files that will always have CRLF line endings on checkout.
+#map.net.xml text eol=crlf
+#*.sln text eol=crlf
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -47,6 +47,10 @@ MANIFEST.in
 *.blend binary
 *.pkl binary
 *.pdf binary
+*.gz binary
+*.zip binary
+*.tar binary
+*.tgz binary
 
 # Declare files that will always have CRLF line endings on checkout.
 #map.net.xml text eol=crlf


### PR DESCRIPTION
This PR adds `.gitattributes` to help us normalize our line-ending behaviour.

By doing this, when people check out files into a non-Unix filesystem, they will have appropriate line endings (such as CRLF for Windows) added locally to any file marked as a text file, but these alternative endings will not be pushed back into the repo.

See [here](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings) for some documentation of our options in the `.gitattributes` file.