### PR TITLE
PyType on branch only

### DIFF
--- a/.github/workflows/ci-format.yml
+++ b/.github/workflows/ci-format.yml
@@ -52,11 +52,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Install pytest
+      - name: Install SMARTS
         run: |
           python3.7 -m venv ${{env.venv_dir}}
           . ${{env.venv_dir}}/bin/activate
           pip install --upgrade pip wheel
+          pip install .[camera-obs,dev,extras,opendrive,ros,test,train]
+          # install the specific version we want for pytest, just in case...
           pip install pytype==2022.1.13
       - name: Get changed files on branch since branching
         id: changed-files

--- a/.github/workflows/ci-format.yml
+++ b/.github/workflows/ci-format.yml
@@ -52,19 +52,22 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Install SMARTS
+      - name: Install pytest
         run: |
           python3.7 -m venv ${{env.venv_dir}}
           . ${{env.venv_dir}}/bin/activate
           pip install --upgrade pip wheel
-          pip install .[camera-obs,dev,extras,opendrive,ros,test,train]
-      - name: Get changed files
+          pip install pytype==2022.1.13
+      - name: Get changed files on branch since branching
         id: changed-files
-        uses: tj-actions/changed-files@v13.2  
-        with:
-          base_sha: origin/develop     
+        shell: bash
+        run: |
+          cd $GITHUB_WORKSPACE
+          CHANGED=$(git diff --diff-filter="AM" --name-only --ignore-submodules=all origin/develop... | awk -v d=" " '{s=(NR==1?s:s d)$0}END{print s}')
+          echo "::set-output name=changed_files::$CHANGED"
       - name: Check types
-        if: contains(steps.changed-files.outputs.all_changed_files, '.py')
+        if: contains(steps.changed-files.outputs.changed_files, '.py')
         run: |
           . ${{env.venv_dir}}/bin/activate
-          pytype --disable=pyi-error ${{steps.changed-files.outputs.all_changed_files}}
+          pytype --disable=pyi-error ${{steps.changed-files.outputs.changed_files}}
+

--- a/.github/workflows/ci-format.yml
+++ b/.github/workflows/ci-format.yml
@@ -57,9 +57,7 @@ jobs:
           python3.7 -m venv ${{env.venv_dir}}
           . ${{env.venv_dir}}/bin/activate
           pip install --upgrade pip wheel
-          pip install .[camera-obs,dev,extras,opendrive,ros,test,train]
-          # install the specific version we want for pytest, just in case...
-          pip install pytype==2022.1.13
+          pip install .[dev]
       - name: Get changed files on branch since branching
         id: changed-files
         shell: bash
@@ -71,5 +69,5 @@ jobs:
         if: contains(steps.changed-files.outputs.changed_files, '.py')
         run: |
           . ${{env.venv_dir}}/bin/activate
-          pytype --disable=pyi-error ${{steps.changed-files.outputs.changed_files}}
+          pytype -d pyi-error import-error ${{steps.changed-files.outputs.changed_files}}
 


### PR DESCRIPTION
Per our discussions from earlier Wednesday, this change constrains the files on which `pytype` will be run during CI to those that have been changed on the branch being merged since it was branched.

(So, for example, files changed and independently merged into `develop` in the meantime will not be checked if they were not changed on this branch.)

May address Issue #1335.
 