### PR TITLE
Add sumo vtype override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,15 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Added `Pose.as_position2d()` method which converts the pose to an [x,y] position array.
 - Added `EventConfiguration` dataclass in the agent interface to allow users to configure the conditions in which events are triggered
 - Added scenarios for "importing" the i80 and us101 NGSIM trajectory history datasets
+- Added `smarts.sstudio.SumoVTypeOverride` and `smarts.sstudio.TrafficActor`'s `model_overrides` attribute that expose SUMO `<vType>` configuration for `TrafficActor`s.
 ### Changed
 - If more than one qualifying map file exists in a the `map_spec.source` folder, `get_road_map()` in `default_map_builder.py` will prefer to return the default files (`map.net.xml` or `map.xodr`) if they exist.
 - Moved the `smarts_ros` ROS node from the `examples` area into the `smarts.ros` module so that it can be distributed with SMARTS packages.
 - Use `Process` to replace `Thread` to speed up the `scl scenario build-all --clean <scenario_dir>` runtime.
 - Modified the repository's front page to be more informative and better organised.
 ### Deprecated
+- Deprecated `sstudio.types.LaneChangeModel` and `sstudio.types.JunctionModel` because they are SUMO specific but abstract SUMO.
+- Deprecated `sstudio.types.TrafficActor`'s `lane_change_model` and `junction_model` attributes.
 ### Fixed
 - Fixed a secondary exception that the `SumoTrafficSimulation` will throw when attempting to close a TraCI connection that is closed by an error.
 - Ensure that `smarts.core.coordinates.Pose` attribute `position` is an [x, y, z] numpy array, and attribute `orientation` is a quaternion length 4 numpy array. 

--- a/baselines/marl_benchmark/scenarios/double_merge/cross/scenario.py
+++ b/baselines/marl_benchmark/scenarios/double_merge/cross/scenario.py
@@ -34,13 +34,13 @@ missions = [
 impatient_car = t.TrafficActor(
     name="car",
     speed=t.Distribution(sigma=0.2, mean=1.0),
-    lane_changing_model=t.LaneChangingModel(impatience=1, cooperative=0.25),
+    model_overrides=(t.SumoVTypeOverride(impatience=1, lcCooperative=0.25),),
 )
 
 patient_car = t.TrafficActor(
     name="car",
     speed=t.Distribution(sigma=0.2, mean=0.8),
-    lane_changing_model=t.LaneChangingModel(impatience=0, cooperative=0.5),
+    model_overrides=(t.SumoVTypeOverride(impatience=0, lcCooperative=0.5),),
 )
 
 

--- a/baselines/marl_benchmark/scenarios/intersections/4lane_sv/scenario.py
+++ b/baselines/marl_benchmark/scenarios/intersections/4lane_sv/scenario.py
@@ -34,17 +34,28 @@ missions = [
 impatient_car = t.TrafficActor(
     name="car",
     speed=t.Distribution(sigma=0.2, mean=1.0),
-    lane_changing_model=t.LaneChangingModel(impatience=1, cooperative=0.25),
-    junction_model=t.JunctionModel(
-        drive_after_red_time=1.5, drive_after_yellow_time=1.0, impatience=1.0
+    model_overrides=(
+        t.SumoVTypeOverride(
+            lcImpatience=1,
+            lcCooperative=0.25,
+            jmDriveAfterRedTime=1.5,
+            jmDriveAfterYellowTime=1.0,
+            impatience=1.0,
+        ),
     ),
 )
 
 patient_car = t.TrafficActor(
     name="car",
     speed=t.Distribution(sigma=0.2, mean=0.8),
-    lane_changing_model=t.LaneChangingModel(impatience=0, cooperative=0.5),
-    junction_model=t.JunctionModel(drive_after_yellow_time=1.0, impatience=0.5),
+    model_overrides=(
+        t.SumoVTypeOverride(
+            lcImpatience=0,
+            lcCooperative=0.5,
+            jmDriveAfterYellowTime=1.0,
+            impatience=0.5,
+        ),
+    ),
 )
 
 vertical_routes = [("north-NS", "south-NS"), ("south-SN", "north-SN")]

--- a/baselines/marl_benchmark/scenarios/two_ways/bid_sv/scenario.py
+++ b/baselines/marl_benchmark/scenarios/two_ways/bid_sv/scenario.py
@@ -35,17 +35,28 @@ missions = [
 impatient_car = t.TrafficActor(
     name="car",
     speed=t.Distribution(sigma=0.2, mean=1.0),
-    lane_changing_model=t.LaneChangingModel(impatience=1, cooperative=0.25),
-    junction_model=t.JunctionModel(
-        drive_after_red_time=1.5, drive_after_yellow_time=1.0, impatience=1.0
+    model_overrides=(
+        t.SumoVTypeOverride(
+            lcImpatience=1,
+            lcCooperative=0.25,
+            jmDriveAfterRedTime=1.5,
+            jmDriveAfterYellowTime=1.0,
+            impatience=1.0,
+        ),
     ),
 )
 
 patient_car = t.TrafficActor(
     name="car",
     speed=t.Distribution(sigma=0.2, mean=0.8),
-    lane_changing_model=t.LaneChangingModel(impatience=0, cooperative=0.5),
-    junction_model=t.JunctionModel(drive_after_yellow_time=1.0, impatience=0.5),
+    model_overrides=(
+        t.SumoVTypeOverride(
+            lcImpatience=0,
+            lcCooperative=0.5,
+            jmDriveAfterYellowTime=1.0,
+            impatience=0.5,
+        ),
+    ),
 )
 
 traffic = {

--- a/scenarios/intersections/2lane/scenario.py
+++ b/scenarios/intersections/2lane/scenario.py
@@ -4,8 +4,7 @@ from smarts.sstudio import gen_traffic
 from smarts.sstudio.types import (
     Distribution,
     Flow,
-    JunctionModel,
-    LaneChangingModel,
+    SumoVTypeOverride,
     Route,
     Traffic,
     TrafficActor,
@@ -16,17 +15,28 @@ scenario = os.path.dirname(os.path.realpath(__file__))
 impatient_car = TrafficActor(
     name="car",
     speed=Distribution(sigma=0.2, mean=1.0),
-    lane_changing_model=LaneChangingModel(impatience=1, cooperative=0.25),
-    junction_model=JunctionModel(
-        drive_after_red_time=1.5, drive_after_yellow_time=1.0, impatience=1.0
+    model_overrides=(
+        SumoVTypeOverride(
+            lcImpatience=1,
+            lcCooperative=0.25,
+            jmDriveAfterRedTime=1.5,
+            jmDriveAfterYellowTime=1.0,
+            impatience=1.0,
+        ),
     ),
 )
 
 patient_car = TrafficActor(
     name="car",
     speed=Distribution(sigma=0.2, mean=0.8),
-    lane_changing_model=LaneChangingModel(impatience=0, cooperative=0.5),
-    junction_model=JunctionModel(drive_after_yellow_time=1.0, impatience=0.5),
+    model_overrides=(
+        SumoVTypeOverride(
+            lcImpatience=0,
+            lcCooperative=0.5,
+            jmDriveAfterYellowTime=1.0,
+            impatience=0.5,
+        ),
+    ),
 )
 
 vertical_routes = [

--- a/scenarios/loop/scenario.py
+++ b/scenarios/loop/scenario.py
@@ -11,7 +11,13 @@ traffic = t.Traffic(
         t.Flow(
             route=t.RandomRoute(),
             rate=60 * 60,
-            actors={t.TrafficActor(name="car", vehicle_type=vehicle_type): 1},
+            actors={
+                t.TrafficActor(
+                    name="car",
+                    model_overrides=(t.SumoVTypeOverride(impatience="100"),),
+                    vehicle_type=vehicle_type,
+                ): 1
+            },
         )
         for vehicle_type in [
             "passenger",

--- a/scenarios/zoo_intersection/scenario.py
+++ b/scenarios/zoo_intersection/scenario.py
@@ -6,7 +6,7 @@ from smarts.sstudio.types import (
     Distribution,
     EndlessMission,
     Flow,
-    LaneChangingModel,
+    SumoVTypeOverride,
     Mission,
     RandomRoute,
     Route,
@@ -26,13 +26,23 @@ car = TrafficActor(
 cooperative_car = TrafficActor(
     name="cooperative_car",
     speed=Distribution(sigma=0.2, mean=1.0),
-    lane_changing_model=LaneChangingModel(impatience=0.1, cooperative=1),
+    model_overrides=(
+        SumoVTypeOverride(
+            lcImpatience=0.1,
+            lcCooperative=1,
+        ),
+    ),
 )
 
 aggressive_car = TrafficActor(
     name="aggressive_car",
     speed=Distribution(sigma=0.2, mean=1.0),
-    lane_changing_model=LaneChangingModel(impatience=1, cooperative=0.1),
+    model_overrides=(
+        SumoVTypeOverride(
+            lcImpatience=1,
+            lcCooperative=0.1,
+        ),
+    ),
 )
 
 horizontal_routes = [("west-WE", "east-WE"), ("east-EW", "west-EW")]

--- a/smarts/sstudio/generators.py
+++ b/smarts/sstudio/generators.py
@@ -216,6 +216,13 @@ class TrafficGenerator:
             for actor in {
                 actor for flow in traffic.flows for actor in flow.actors.keys()
             }:
+
+                model_override = (
+                    actor.model_override
+                    if isinstance(actor.model_override, types.SumoActorModelOverride)
+                    else {}
+                )
+
                 sigma = min(1, max(0, actor.imperfection.sample()))  # range [0,1]
                 min_gap = max(0, actor.min_gap.sample())  # range >= 0
                 doc.stag(
@@ -231,6 +238,7 @@ class TrafficGenerator:
                     maxSpeed=actor.max_speed,
                     **actor.lane_changing_model,
                     **actor.junction_model,
+                    **model_override,
                 )
 
             # Make sure all routes are "resolved" (e.g. `RandomRoute` are converted to

--- a/smarts/sstudio/tests/test_generate.py
+++ b/smarts/sstudio/tests/test_generate.py
@@ -31,8 +31,7 @@ from smarts.sstudio import gen_map, gen_missions, gen_traffic
 from smarts.sstudio.types import (
     Distribution,
     Flow,
-    JunctionModel,
-    LaneChangingModel,
+    SumoVTypeOverride,
     MapSpec,
     Mission,
     Route,
@@ -50,8 +49,14 @@ def traffic() -> Traffic:
     car2 = TrafficActor(
         name="car",
         speed=Distribution(sigma=0.2, mean=0.8),
-        lane_changing_model=LaneChangingModel(impatience=1, cooperative=0.25),
-        junction_model=JunctionModel(drive_after_yellow_time=1.0, impatience=0.5),
+        model_overrides=(
+            SumoVTypeOverride(
+                lcImpatience=1,
+                lcCooperative=0.25,
+                jmDriveAfterYellowTime=1.0,
+                impatience=0.5,
+            ),
+        ),
     )
 
     return Traffic(

--- a/smarts/sstudio/types.py
+++ b/smarts/sstudio/types.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass, field
 from enum import IntEnum
 from sys import maxsize
 from typing import Any, Callable, Dict, NewType, Optional, Sequence, Tuple, Union
+import warnings
 
 import numpy as np
 from shapely.geometry import (
@@ -111,6 +112,10 @@ class LaneChangingModel(_SumoParams):
     """Models how the actor acts with respect to lane changes."""
 
     def __init__(self, **kwargs):
+        warnings.warn(
+            f"The LaneChangingModel has has replaced by {SumoVTypeOverride.__name__}. Instantiating this object type is deprecated.",
+            DeprecationWarning,
+        )
         super().__init__("lc", mode=_SUMO_PARAMS_MODE.KEEP_SNAKE_CASE, **kwargs)
 
 
@@ -118,16 +123,18 @@ class JunctionModel(_SumoParams):
     """Models how the actor acts with respect to waiting at junctions."""
 
     def __init__(self, **kwargs):
+        warnings.warn(
+            f"The JunctionModel has replaced by {SumoVTypeOverride.__name__}. Instantiating this object type is deprecated.",
+            DeprecationWarning,
+        )
         super().__init__("jm", whitelist=["impatience"], **kwargs)
 
 
-class SumoActorModelOverride(_SumoParams):
+class SumoVTypeOverride(_SumoParams):
     """Allows overriding vehicle configuration."""
 
-    def __init__(
-        self, prefix="", whitelist=[], mode=_SUMO_PARAMS_MODE.SAME_AS_SUMO, **kwargs
-    ):
-        super().__init__(prefix, whitelist, mode, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__("", [], _SUMO_PARAMS_MODE.SAME_AS_SUMO, **kwargs)
 
 
 @dataclass(frozen=True)
@@ -221,15 +228,13 @@ class TrafficActor(Actor):
     """The vehicle's maximum velocity (in m/s), defaults 200 km/h for vehicles"""
     vehicle_type: str = "passenger"
     """The configured vehicle type this actor will perform as. ("passenger", "bus", "coach", "truck", "trailer")"""
-    lane_changing_model: LaneChangingModel = field(
+    lane_changing_model: _SumoParams = field(
         default_factory=LaneChangingModel, hash=False
     )
     """Configure sumo options for the lane changing model."""
-    junction_model: JunctionModel = field(default_factory=JunctionModel, hash=False)
+    junction_model: _SumoParams = field(default_factory=JunctionModel, hash=False)
     """Configure sumo options for the junction model."""
-    model_override: Optional[SumoActorModelOverride] = field(
-        default_factory=SumoActorModelOverride, hash=False
-    )
+    model_overrides: Tuple[_SumoParams] = field(default_factory=tuple, hash=False)
     """Configure any sumo options."""
 
     def __hash__(self) -> int:

--- a/zoo/policies/cross-rl-agent/cross_rl_agent/train/scenarios/4lane_left_turn/scenario.py
+++ b/zoo/policies/cross-rl-agent/cross_rl_agent/train/scenarios/4lane_left_turn/scenario.py
@@ -24,7 +24,7 @@ from smarts.sstudio.genscenario import gen_scenario
 from smarts.sstudio.types import (
     Distribution,
     Flow,
-    LaneChangingModel,
+    SumoVTypeOverride,
     Mission,
     RandomRoute,
     Route,
@@ -46,7 +46,11 @@ ego_missions = [
 left_traffic_actor = TrafficActor(
     name="car",
     speed=Distribution(sigma=0.2, mean=1),
-    lane_changing_model=LaneChangingModel(impatience=0),
+    model_overrides=(
+        SumoVTypeOverride(
+            lcImpatience=0,
+        ),
+    ),
 )
 scenario = Scenario(
     traffic={

--- a/zoo/policies/cross-rl-agent/cross_rl_agent/train/scenarios/4lane_right_turn/scenario.py
+++ b/zoo/policies/cross-rl-agent/cross_rl_agent/train/scenarios/4lane_right_turn/scenario.py
@@ -25,7 +25,7 @@ from smarts.sstudio.genscenario import gen_scenario
 from smarts.sstudio.types import (
     Distribution,
     Flow,
-    LaneChangingModel,
+    SumoVTypeOverride,
     Mission,
     RandomRoute,
     Route,
@@ -45,7 +45,11 @@ ego_missions = [
 right_traffic_actor = TrafficActor(
     name="car",
     speed=Distribution(sigma=0.2, mean=1),
-    lane_changing_model=LaneChangingModel(impatience=0),
+    model_overrides=(
+        SumoVTypeOverride(
+            lcImpatience=0,
+        ),
+    ),
 )
 scenario = Scenario(
     traffic={

--- a/zoo/policies/cross-rl-agent/cross_rl_agent/train/scenarios/4lane_straight/scenario.py
+++ b/zoo/policies/cross-rl-agent/cross_rl_agent/train/scenarios/4lane_straight/scenario.py
@@ -25,8 +25,7 @@ from smarts.sstudio.genscenario import gen_scenario
 from smarts.sstudio.types import (
     Distribution,
     Flow,
-    JunctionModel,
-    LaneChangingModel,
+    SumoVTypeOverride,
     Mission,
     RandomRoute,
     Route,
@@ -46,9 +45,13 @@ ego_missions = [
 stright_traffic_actor = TrafficActor(
     name="car",
     speed=Distribution(sigma=0.2, mean=1),
-    lane_changing_model=LaneChangingModel(impatience=0),
-    junction_model=JunctionModel(
-        drive_after_red_time=1.5, drive_after_yellow_time=1.0, impatience=0.5
+    model_overrides=(
+        SumoVTypeOverride(
+            lcImpatience=0,
+            jmDriveAfterRedTime=1.5,
+            jmDriveAfterYellowTime=1.0,
+            impatience=0.5,
+        ),
     ),
 )
 scenario = Scenario(

--- a/zoo/policies/cross-rl-agent/cross_rl_agent/train/trained_model_and_scenarios/good_scenarios/scenarios/4lane_left_turn/scenario.py
+++ b/zoo/policies/cross-rl-agent/cross_rl_agent/train/trained_model_and_scenarios/good_scenarios/scenarios/4lane_left_turn/scenario.py
@@ -25,7 +25,7 @@ from smarts.sstudio.genscenario import gen_scenario
 from smarts.sstudio.types import (
     Distribution,
     Flow,
-    LaneChangingModel,
+    SumoVTypeOverride,
     Mission,
     RandomRoute,
     Route,
@@ -47,9 +47,13 @@ ego_missions = [
 left_traffic_actor = TrafficActor(
     name="car",
     speed=Distribution(sigma=0.2, mean=1),
-    lane_changing_model=LaneChangingModel(impatience=0),
-    # junction_model=JunctionModel(
-    #     drive_after_yellow_time=1.0, impatience=0)
+    model_overrides=(
+        SumoVTypeOverride(
+            lcImpatience=0,
+            # jmDriveAfterYellowTime=1.0,
+            # impatience=0,
+        ),
+    ),
 )
 scenario = Scenario(
     traffic={

--- a/zoo/policies/cross-rl-agent/cross_rl_agent/train/trained_model_and_scenarios/good_scenarios/scenarios/4lane_right_turn/scenario.py
+++ b/zoo/policies/cross-rl-agent/cross_rl_agent/train/trained_model_and_scenarios/good_scenarios/scenarios/4lane_right_turn/scenario.py
@@ -25,7 +25,7 @@ from smarts.sstudio.genscenario import gen_scenario
 from smarts.sstudio.types import (
     Distribution,
     Flow,
-    LaneChangingModel,
+    SumoVTypeOverride,
     Mission,
     RandomRoute,
     Route,
@@ -45,7 +45,11 @@ ego_missions = [
 right_traffic_actor = TrafficActor(
     name="car",
     speed=Distribution(sigma=0.2, mean=1),
-    lane_changing_model=LaneChangingModel(impatience=0),
+    model_overrides=(
+        SumoVTypeOverride(
+            lcImpatience=0,
+        ),
+    ),
 )
 scenario = Scenario(
     traffic={

--- a/zoo/policies/cross-rl-agent/cross_rl_agent/train/trained_model_and_scenarios/good_scenarios/scenarios/4lane_straight/scenario.py
+++ b/zoo/policies/cross-rl-agent/cross_rl_agent/train/trained_model_and_scenarios/good_scenarios/scenarios/4lane_straight/scenario.py
@@ -25,8 +25,7 @@ from smarts.sstudio.genscenario import gen_scenario
 from smarts.sstudio.types import (
     Distribution,
     Flow,
-    JunctionModel,
-    LaneChangingModel,
+    SumoVTypeOverride,
     Mission,
     RandomRoute,
     Route,
@@ -46,9 +45,13 @@ ego_missions = [
 stright_traffic_actor = TrafficActor(
     name="car",
     speed=Distribution(sigma=0.2, mean=1),
-    lane_changing_model=LaneChangingModel(impatience=0),
-    junction_model=JunctionModel(
-        drive_after_red_time=1.5, drive_after_yellow_time=1.0, impatience=0.5
+    model_overrides=(
+        SumoVTypeOverride(
+            lcImpatience=0,
+            jmDriveAfterRedTime=1.5,
+            jmDriveAfterYellowTime=1.0,
+            impatience=0.5,
+        ),
     ),
 )
 scenario = Scenario(


### PR DESCRIPTION
This will allow overriding `<vType/>` params in `sumo` traffic generation. Leaves open having other overrides for later uses of `TrafficActor` with other traffic generators.