### PR TITLE
Fix click package version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         #   50.0 is broken: https://github.com/pypa/setupatools/issues/2353
         "setuptools>=41.0.0,!=50.0",
         "cached-property>=1.5.2",
-        "click>=8.0.3",  # used in scl
+        "click==8.0.4",  # used in scl
         "eclipse-sumo==1.10.0",  # sumo
         "gym==0.19.0",
         "numpy>=1.19.5",  # required for tf 2.4 below

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         #   50.0 is broken: https://github.com/pypa/setupatools/issues/2353
         "setuptools>=41.0.0,!=50.0",
         "cached-property>=1.5.2",
-        "click==8.0.4",  # used in scl
+        "click~=8.0",  # used in scl
         "eclipse-sumo==1.10.0",  # sumo
         "gym==0.19.0",
         "numpy>=1.19.5",  # required for tf 2.4 below


### PR DESCRIPTION
The `auto-commit-linux.yml` appears to fail at the `isort, Black, and prettier` step. 

See https://github.com/huawei-noah/SMARTS/runs/5727774588?check_suite_focus=true

```
Traceback (most recent call last):
  File "/__w/SMARTS/SMARTS/.venv/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/__w/SMARTS/SMARTS/.venv/lib/python3.7/site-packages/black/__init__.py", line 6606, in patched_main
    patch_click()
  File "/__w/SMARTS/SMARTS/.venv/lib/python3.7/site-packages/black/__init__.py", line 6595, in patch_click
    from click import _unicodefun  # type: ignore
ImportError: cannot import name '_unicodefun' from 'click' (/__w/SMARTS/SMARTS/.venv/lib/python3.7/site-packages/click/__init__.py)
```

A new `click` package was released about 4 hours ago, thus updating the `click` package from `8.0.4` to `8.1.0`. Setting click package to `8.0.4` enables the auto-commit-linux.yml to finish successfully.

Hence, here we set the `click` package version to `8.0.4` in `setup.py`.