### PR TITLE
CI Correction

### DIFF
--- a/.github/workflows/ci-format.yml
+++ b/.github/workflows/ci-format.yml
@@ -5,6 +5,8 @@ on:
     branches-ignore:
       - master
   pull_request:
+    branches-ignore:
+      - master
 
 env:
   venv_dir: .venv
@@ -40,7 +42,7 @@ jobs:
             -s n \
             --ignore marl_benchmark,examples,scenarios,docs,manager_pb2_grpc.py,worker_pb2_grpc.py \
             --msg-template='{path}: line {line}: {msg_id}: {msg}' \
-            ./smarts ./envision
+            ./smarts ./envision ./baselines
 
   test-types:
     runs-on: ubuntu-18.04

--- a/.github/workflows/ci-format.yml
+++ b/.github/workflows/ci-format.yml
@@ -1,12 +1,6 @@
 name: SMARTS CI Format
 
-on: 
-  push:
-    branches-ignore:
-      - master
-  pull_request:
-    branches-ignore:
-      - master
+on: [push, pull_request]
 
 env:
   venv_dir: .venv
@@ -46,7 +40,7 @@ jobs:
 
   test-types:
     runs-on: ubuntu-18.04
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository) && (github.ref != 'refs/heads/master')
     container: huaweinoah/smarts:v0.4.18-minimal
     steps:
       - name: Install packages

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SMARTS
 [![SMARTS CI Base Tests Linux](https://github.com/huawei-noah/SMARTS/actions/workflows/ci-base-tests-linux.yml/badge.svg?branch=master)](https://github.com/huawei-noah/SMARTS/actions/workflows/ci-base-tests-linux.yml?query=branch%3Amaster) 
-[![SMARTS CI Format](https://github.com/huawei-noah/SMARTS/actions/workflows/ci-format.yml/badge.svg?branch=master)](https://github.com/huawei-noah/SMARTS/actions/workflows/ci-format.yml)
+[![SMARTS CI Format](https://github.com/huawei-noah/SMARTS/actions/workflows/ci-format.yml/badge.svg?branch=master)](https://github.com/huawei-noah/SMARTS/actions/workflows/ci-format.yml?query=branch%3Amaster)
 ![Code style](https://img.shields.io/badge/code%20style-black-000000.svg) 
 
 SMARTS (Scalable Multi-Agent RL Training School) is a simulation platform for reinforcement learning (RL) and multi-agent research on autonomous driving. Its focus is on realistic and diverse interactions. It is part of the [XingTian](https://github.com/huawei-noah/xingtian/) suite of RL platforms from Huawei Noah's Ark Lab.


### PR DESCRIPTION
1. `test-type` test, instead of the entire workflow, is conditoned on the branch. This should help fix the github action badge colour.
2.  Add docstring check on baselines folder (excluding the existing `marl_benchmark` baseline) to make future code additions user friendly.