### PR TITLE
Suppress `stderr` output in notebook test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Fixed a secondary exception that the `SumoTrafficSimulation` will throw when attempting to close a TraCI connection that is closed by an error.
 - Ensure that `smarts.core.coordinates.Pose` attribute `position` is an [x, y, z] numpy array, and attribute `orientation` is a quaternion length 4 numpy array. 
 - Update social vehicle pose in Bullet when no active agents are present.
+- Take full control over TraCI SUMO reconnect to prevent unclosed file `stderr` output.
 ### Removed
 - Removed the unconditional import of `Renderer` from `smarts/core/vehicle.py` to make `Panda3D` optional dependency regression. See Issue #1310.
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Fixed a secondary exception that the `SumoTrafficSimulation` will throw when attempting to close a TraCI connection that is closed by an error.
 - Ensure that `smarts.core.coordinates.Pose` attribute `position` is an [x, y, z] numpy array, and attribute `orientation` is a quaternion length 4 numpy array. 
 - Update social vehicle pose in Bullet when no active agents are present.
-- Take full control over TraCI SUMO reconnect to prevent unclosed file `stderr` output.
+- Fix suppression of `stderr` and `stdout` on `ipython` platforms via `suppress_output(..)`.
 ### Removed
 - Removed the unconditional import of `Renderer` from `smarts/core/vehicle.py` to make `Panda3D` optional dependency regression. See Issue #1310.
 ### Security

--- a/smarts/core/sumo_traffic_simulation.py
+++ b/smarts/core/sumo_traffic_simulation.py
@@ -149,7 +149,7 @@ class SumoTrafficSimulation(Provider):
         """Does not show TraCI visualization."""
         return self._headless
 
-    def _initialize_traci_conn(self, num_retries=500):
+    def _initialize_traci_conn(self, num_retries=5):
         # TODO: inline sumo or process pool
         # the retries are to deal with port collisions
         #   since the way we start sumo here has a race condition on
@@ -181,7 +181,7 @@ class SumoTrafficSimulation(Provider):
                 with suppress_output(stdout=False):
                     self._traci_conn = traci.connect(
                         sumo_port,
-                        numRetries=0,
+                        numRetries=100,
                         proc=self._sumo_proc,
                         waitBetweenRetries=0.05,
                     )  # SUMO must be ready within 5 seconds

--- a/smarts/core/sumo_traffic_simulation.py
+++ b/smarts/core/sumo_traffic_simulation.py
@@ -149,12 +149,12 @@ class SumoTrafficSimulation(Provider):
         """Does not show TraCI visualization."""
         return self._headless
 
-    def _initialize_traci_conn(self, num_retries=5):
+    def _initialize_traci_conn(self, num_retries=500):
         # TODO: inline sumo or process pool
         # the retries are to deal with port collisions
         #   since the way we start sumo here has a race condition on
         #   each spawned process claiming a port
-        for _ in range(num_retries*100):
+        for _ in range(num_retries):
             self._close_traci_and_pipes()
 
             sumo_port = self._sumo_port
@@ -204,9 +204,7 @@ class SumoTrafficSimulation(Provider):
                 self._close_traci_and_pipes()
                 continue
             except:
-                logging.debug(
-                    "Retrying TraCI connection..."
-                )
+                logging.debug("Retrying TraCI connection...")
                 self._close_traci_and_pipes()
                 continue
             break

--- a/smarts/core/sumo_traffic_simulation.py
+++ b/smarts/core/sumo_traffic_simulation.py
@@ -191,12 +191,13 @@ class SumoTrafficSimulation(Provider):
                         self._traci_conn.getVersion()[0] >= 20
                     ), "TraCI API version must be >= 20 (SUMO 1.5.0)"
                 # We will retry since this is our first sumo command
-                except FatalTraCIError as e:
-                    logging.debug("TraCI connection closed unexpectedly.")
-                    raise e
+                except FatalTraCIError:
+                    logging.debug("Connection closed. Retrying...")
+                    self._close_traci_and_pipes()
+                    continue
                 except TraCIException as e:
                     logging.debug(f"Unknown connection issue has occurred: {e}")
-                    raise e
+                    self._close_traci_and_pipes()
             except ConnectionRefusedError:
                 logging.debug(
                     "Connection refused. Tried to connect to unpaired TraCI client."

--- a/smarts/core/tests/test_notebook.py
+++ b/smarts/core/tests/test_notebook.py
@@ -112,6 +112,9 @@ def test_notebook1(nb_regression: nb.NBRegressionFixture, notebook):
         ), f"pynotebook `{NOTEBOOK_NAME}` timed out after {nb_regression.exec_timeout}s during test: {te}.\nFor more details see: https://jupyterbook.org/content/execute.html#setting-execution-timeout"
     ## Run notebook against generated
     ## ignore output for now
-    nb_regression.diff_ignore = ("/cells/*/outputs/*/text",)
+    nb_regression.diff_ignore = (
+        "/cells/*/outputs/*/text",
+        "/metadata/language_info/version",
+    )
     nb_regression.force_regen = False
     nb_regression.check(notebook)

--- a/smarts/core/tests/test_notebook.py
+++ b/smarts/core/tests/test_notebook.py
@@ -93,8 +93,10 @@ def notebook():
     with open(tmppath, "w") as f:
         import smarts.core.tests
 
+        # pytype: disable=module-attr
         traversable = importlib_resources.files(smarts.core.tests)
         f.write(traversable.joinpath(NOTEBOOK_NAME).read_text())
+        # pytype: enable=module-attr
     yield tmppath
     os.remove(tmppath)
 

--- a/smarts/core/tests/test_notebook.py
+++ b/smarts/core/tests/test_notebook.py
@@ -93,9 +93,8 @@ def notebook():
     with open(tmppath, "w") as f:
         import smarts.core.tests
 
-        # pytype: disable=module-attr
-        f.write(importlib_resources.read_text(smarts.core.tests, NOTEBOOK_NAME))
-        # pytype: enable=module-attr
+        traversable = importlib_resources.files(smarts.core.tests)
+        f.write(traversable.joinpath(NOTEBOOK_NAME).read_text())
     yield tmppath
     os.remove(tmppath)
 

--- a/smarts/core/utils/logging.py
+++ b/smarts/core/utils/logging.py
@@ -101,8 +101,17 @@ def _suppress_fileout(stdname):
     except UnsupportedOperation as e:
         if not isnotebook():
             raise e
-        ## This case is notebook which does not have issues with the c_printf
-        return None
+        old_stderr = sys.stderr
+        sys.stderr = open(os.devnull, os.O_WRONLY)
+
+        def cleanup(_):
+            nonlocal old_stderr
+            sys.stderr.flush()
+            os.close(sys.stderr)
+            sys.stderr = old_stderr
+
+        ## This case is notebook
+        return cleanup
 
     dup_std_fno = os.dup(original_std_fno)
     devnull_fno = os.open(os.devnull, os.O_WRONLY)

--- a/smarts/core/utils/logging.py
+++ b/smarts/core/utils/logging.py
@@ -23,7 +23,6 @@ import sys
 from contextlib import contextmanager
 from io import UnsupportedOperation
 from time import time
-from unittest.mock import Mock
 
 
 @contextmanager
@@ -110,11 +109,11 @@ def _suppress_fileout(stdname):
             nonlocal old_std, stdname
             new_std = getattr(sys, stdname)
             new_std.flush()
-            # Dummy attributes because of https://github.com/ipython/ipykernel/issues/867
+            # Ensure attributes exist because of https://github.com/ipython/ipykernel/issues/867
             if not hasattr(new_std, "watch_fd_thread"):
-                setattr(new_std, "watch_fd_thread", Mock())
+                setattr(new_std, "watch_fd_thread", None)
             if not hasattr(new_std, "_exc"):
-                setattr(new_std, "_exc", False)
+                setattr(new_std, "_exc", None)
             new_std.close()
             setattr(sys, stdname, old_std)
 


### PR DESCRIPTION
Attempt a fix so that the `test_notebook` test does not output an unclosed file to stderr.