### PR TITLE
Set goal position to same location as ego if endless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Copy and pasting the git commit messages is __NOT__ enough.
 
 # [Unreleased]
 
+### Fixed
+- Gracefully handle `EndlessGoal` missions in the MaRL benchmark. Relative goal distance with `EndlessGoal` will be now always be 0.
+
 ### [0.6.1rc0] 15-04-16
 ### Added
 - Added `get_vehicle_start_time()` method for scenarios with traffic history data.  See Issue #1210.

--- a/baselines/marl_benchmark/common.py
+++ b/baselines/marl_benchmark/common.py
@@ -171,10 +171,11 @@ class CalObs:
 
         ego_state = env_obs.ego_vehicle_state
         goal = ego_state.mission.goal
-        assert isinstance(goal, PositionalGoal), goal
 
         ego_pos = ego_state.position[:2]
-        goal_pos = goal.position  # the position of mission goal is 2-dimensional.
+        goal_pos = getattr(
+            goal, "position", ego_pos
+        )  # the position of mission goal is 2-dimensional.
         vector = np.asarray([goal_pos[0] - ego_pos[0], goal_pos[1] - ego_pos[1]])
         # space = SPACE_LIB["goal_relative_pos"](None)
         # return vector / (space.high - space.low)

--- a/baselines/marl_benchmark/metrics/basic_handler.py
+++ b/baselines/marl_benchmark/metrics/basic_handler.py
@@ -41,8 +41,8 @@ def agent_info_adapter(env_obs, shaped_reward: float, raw_info: dict):
     info["collision"] = 1 if len(env_obs.events.collisions) > 0 else 0
 
     goal = env_obs.ego_vehicle_state.mission.goal
-    goal_pos = goal.position
     ego_2d_pos = env_obs.ego_vehicle_state.position[:2]
+    goal_pos = getattr(goal, "position", ego_2d_pos)
 
     info["distance_to_goal"] = distance.euclidean(ego_2d_pos, goal_pos)
     info["distance_to_center"] = CalObs.cal_distance_to_center(env_obs, "")

--- a/baselines/marl_benchmark/wrappers/rllib/frame_stack.py
+++ b/baselines/marl_benchmark/wrappers/rllib/frame_stack.py
@@ -234,20 +234,14 @@ class FrameStack(Wrapper):
             # ======== Penalty: distance to goal =========
             goal = last_env_obs.ego_vehicle_state.mission.goal
             ego_2d_position = last_env_obs.ego_vehicle_state.position[:2]
-            if hasattr(goal, "position"):
-                goal_position = goal.position
-            else:
-                goal_position = ego_2d_position
+            goal_position = getattr(goal, "position", ego_2d_position)
             goal_dist = distance.euclidean(ego_2d_position, goal_position)
             penalty += -0.01 * goal_dist
 
             old_obs = env_obs_seq[-2]
             old_goal = old_obs.ego_vehicle_state.mission.goal
             old_ego_2d_position = old_obs.ego_vehicle_state.position[:2]
-            if hasattr(old_goal, "position"):
-                old_goal_position = old_goal.position
-            else:
-                old_goal_position = old_ego_2d_position
+            old_goal_position = getattr(old_goal, "position", old_ego_2d_position)
             old_goal_dist = distance.euclidean(old_ego_2d_position, old_goal_position)
             penalty += 0.1 * (old_goal_dist - goal_dist)  # 0.05
 


### PR DESCRIPTION
This is to fix issues with the MaRL benchmark scoring `EndlessGoal` scenarios.

Closes #1387 