### PR TITLE
Unpack `dataclass` attributes with `unpack(..)` utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Copy and pasting the git commit messages is __NOT__ enough.
 ### Changed
 - Updated license to 2022 version.
 
+### Fixed
+- Unpack utility now unpacks dataclass attributes.
+
 ### [0.6.1rc1] 15-04-18
 ### Fixed
 - Gracefully handle `EndlessGoal` missions in the MaRL benchmark. Relative goal distance with `EndlessGoal` will be now always be 0.

--- a/smarts/core/utils/file.py
+++ b/smarts/core/utils/file.py
@@ -64,9 +64,9 @@ def unpack(obj):
     elif isinstance(obj, list):
         return [unpack(value) for value in obj]
     elif isnamedtupleinstance(obj):
-        return {key: unpack(value) for key, value in obj._asdict().items()}
+        return unpack(obj._asdict())
     elif isdataclass(obj):
-        return dataclasses.asdict(obj)
+        return unpack(dataclasses.asdict(obj))
     elif isinstance(obj, tuple):
         return tuple(unpack(value) for value in obj)
     else:


### PR DESCRIPTION
This addresses an inconsistency with `unpack` of dataclasses that skipped converting attribute value dataclasses and named tuples.