### PR TITLE
Expose Reference Line coordinate system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 
 ### Changed
 - Updated license to 2022 version.
+- Add `lane_offset` to `Waypoint` class and `lane_postion` to both `EgoVehicleObservation` and `VehicleObservation` classes to expose ref-line coordinate system.
 
 ### Fixed
 - Unpack utility now unpacks dataclass attributes.

--- a/smarts/core/opendrive_road_network.py
+++ b/smarts/core/opendrive_road_network.py
@@ -1680,6 +1680,7 @@ class OpenDriveRoadNetwork(RoadMap):
             "headings",
             "lane_width",
             "speed_limit",
+            "lane_offset",
         ]
         discrete_variables = ["lane_id", "lane_index"]
 
@@ -1740,6 +1741,10 @@ class OpenDriveRoadNetwork(RoadMap):
 
             ref_lanepoints_coordinates["lane_width"].append(width_at_offset)
 
+            ref_lanepoints_coordinates["lane_offset"].append(
+                lanepoint.lp.lane.offset_along_lane(lanepoint.lp.pose.point)
+            )
+
             ref_lanepoints_coordinates["speed_limit"].append(
                 lanepoint.lp.lane.speed_limit
             )
@@ -1782,6 +1787,7 @@ class OpenDriveRoadNetwork(RoadMap):
                     speed_limit=lp.lane.speed_limit,
                     lane_id=lp.lane.lane_id,
                     lane_index=lp.lane.index,
+                    lane_offset=lp.lane.offset_along_lane(lp.pose.point),
                 )
             ]
 
@@ -1845,6 +1851,7 @@ class OpenDriveRoadNetwork(RoadMap):
                     speed_limit=evenly_spaced_coordinates["speed_limit"][idx],
                     lane_id=evenly_spaced_coordinates["lane_id"][idx],
                     lane_index=evenly_spaced_coordinates["lane_index"][idx],
+                    lane_offset=evenly_spaced_coordinates["lane_offset"][idx],
                 )
             )
 

--- a/smarts/core/road_map.py
+++ b/smarts/core/road_map.py
@@ -567,6 +567,7 @@ class Waypoint:
     lane_width: float  # Width of lane at this point (meters)
     speed_limit: float  # Lane speed in m/s
     lane_index: int  # Index of the lane this waypoint is over. 0 is the outer(right) most lane
+    lane_offset: float  # longitudinal distance along lane centerline of this waypoint
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, Waypoint):
@@ -578,6 +579,7 @@ class Waypoint:
             and self.speed_limit == other.speed_limit
             and self.lane_id == other.lane_id
             and self.lane_index == other.lane_index
+            and self.lane_offset == other.lane_offset
         )
 
     def __hash__(self):
@@ -589,6 +591,7 @@ class Waypoint:
                 self.speed_limit,
                 self.lane_id,
                 self.lane_index,
+                self.lane_offset,
             )
         )
 

--- a/smarts/core/sensors.py
+++ b/smarts/core/sensors.py
@@ -60,6 +60,9 @@ class VehicleObservation(NamedTuple):
     """The identifier for the lane nearest to this vehicle."""
     lane_index: int
     """The index of the nearest lane on the road nearest to this vehicle."""
+    lane_position: RefLinePoint
+    """(s,t,h) coordinates within the lane, where s is the longitudinal offset along the lane, t is the lateral displacement from the lane center, and h (not yet supported) is the vertical displacement from the lane surface.
+    See the Reference Line coordinate system in OpenDRIVE here: https://www.asam.net/index.php?eID=dumpFile&t=f&f=4089&token=deea5d707e2d0edeeb4fccd544a973de4bc46a09#_coordinate_systems """
 
 
 class EgoVehicleObservation(NamedTuple):
@@ -85,6 +88,9 @@ class EgoVehicleObservation(NamedTuple):
     """The identifier for the lane nearest to this vehicle."""
     lane_index: int
     """The index of the nearest lane on the road nearest to this vehicle."""
+    lane_position: RefLinePoint
+    """(s,t,h) coordinates within the lane, where s is the longitudinal offset along the lane, t is the lateral displacement from the lane center, and h (not yet supported) is the vertical displacement from the lane surface.
+    See the Reference Line coordinate system in OpenDRIVE here: https://www.asam.net/index.php?eID=dumpFile&t=f&f=4089&token=deea5d707e2d0edeeb4fccd544a973de4bc46a09#_coordinate_systems """
     mission: Mission
     """A field describing the vehicle plotted route"""
     linear_velocity: np.ndarray
@@ -248,10 +254,12 @@ class Sensors:
                     nv_road_id = nv_lane.road.road_id
                     nv_lane_id = nv_lane.lane_id
                     nv_lane_index = nv_lane.index
+                    nv_lane_pos = nv_lane.to_lane_coord(nv.pose.point)
                 else:
                     nv_road_id = None
                     nv_lane_id = None
                     nv_lane_index = None
+                    nv_lane_pos = None
                 neighborhood_vehicles.append(
                     VehicleObservation(
                         id=nv.vehicle_id,
@@ -262,6 +270,7 @@ class Sensors:
                         road_id=nv_road_id,
                         lane_id=nv_lane_id,
                         lane_index=nv_lane_index,
+                        lane_position=TODO_STEVE,
                     )
                 )
 
@@ -279,10 +288,12 @@ class Sensors:
             ego_lane_id = closest_lane.lane_id
             ego_lane_index = closest_lane.index
             ego_road_id = closest_lane.road.road_id
+            ego_lane_pos = closest_lane.to_lane_coord(vehicle.pose.point)
         else:
             ego_lane_id = None
             ego_lane_index = None
             ego_road_id = None
+            ego_lane_pos = None
         ego_vehicle_state = vehicle.state
 
         acceleration_params = {
@@ -322,6 +333,7 @@ class Sensors:
             road_id=ego_road_id,
             lane_id=ego_lane_id,
             lane_index=ego_lane_index,
+            lane_position=ego_lane_pos,
             mission=sensor_state.plan.mission,
             linear_velocity=ego_vehicle_state.linear_velocity,
             angular_velocity=ego_vehicle_state.angular_velocity,

--- a/smarts/core/sumo_road_network.py
+++ b/smarts/core/sumo_road_network.py
@@ -1324,6 +1324,7 @@ class SumoRoadNetwork(RoadMap):
             "headings",
             "lane_width",
             "speed_limit",
+            "lane_offset",
         ]
         discrete_variables = ["lane_id", "lane_index"]
 
@@ -1345,6 +1346,9 @@ class SumoRoadNetwork(RoadMap):
             ref_lanepoints_coordinates["lane_id"].append(lanepoint.lp.lane.lane_id)
             ref_lanepoints_coordinates["lane_index"].append(lanepoint.lp.lane.index)
             ref_lanepoints_coordinates["lane_width"].append(lanepoint.lp.lane._width)
+            ref_lanepoints_coordinates["lane_offset"].append(
+                lanepoint.lp.lane.offset_along_lane(lanepoint.lp.pose.point)
+            )
             ref_lanepoints_coordinates["speed_limit"].append(
                 lanepoint.lp.lane.speed_limit
             )
@@ -1386,6 +1390,7 @@ class SumoRoadNetwork(RoadMap):
                     speed_limit=lp.lane.speed_limit,
                     lane_id=lp.lane.lane_id,
                     lane_index=lp.lane.index,
+                    lane_offset=lp.lane.offset_along_lane(lp.pose.point),
                 )
             ]
 
@@ -1431,6 +1436,7 @@ class SumoRoadNetwork(RoadMap):
                     speed_limit=evenly_spaced_coordinates["speed_limit"][idx],
                     lane_id=evenly_spaced_coordinates["lane_id"][idx],
                     lane_index=evenly_spaced_coordinates["lane_index"][idx],
+                    lane_offset=evenly_spaced_coordinates["lane_offset"][idx],
                 )
             )
 

--- a/smarts/core/utils/tests/fixtures.py
+++ b/smarts/core/utils/tests/fixtures.py
@@ -26,7 +26,7 @@ import pytest
 
 import smarts.sstudio.types as t
 from smarts.core.controllers import ActionSpaceType
-from smarts.core.coordinates import Dimensions, Heading
+from smarts.core.coordinates import Dimensions, Heading, ReflinePoint
 from smarts.core.events import Events
 from smarts.core.plan import EndlessGoal, Mission, Start
 from smarts.core.road_map import Waypoint
@@ -71,6 +71,7 @@ def large_observation():
             road_id="east",
             lane_id="east_2",
             lane_index=2,
+            lane_position=RefLinePoint(161.23485529, 0.0, 0.0),
             mission=Mission(
                 start=Start(
                     position=np.array([163.07485529, 3.2]),
@@ -106,6 +107,7 @@ def large_observation():
                 road_id="west",
                 lane_id="west_0",
                 lane_index=0,
+                lane_position=RefLinePoint(-1.33354215, 0.0, 0.0),
             ),
             VehicleObservation(
                 id="car-flow-route-west_1_0-east_1_max--852708111940723884--7266489842092764092--1-0.0",
@@ -116,6 +118,7 @@ def large_observation():
                 road_id="west",
                 lane_id="west_1",
                 lane_index=1,
+                lane_position=RefLinePoint(-1.47159011, 0.0, 0.0),
             ),
         ],
         waypoint_paths=[
@@ -127,6 +130,7 @@ def large_observation():
                     lane_width=3.2,
                     speed_limit=5.0,
                     lane_index=0,
+                    lane_offset=192.00733923,
                 ),
                 Waypoint(
                     pos=np.array([193.0, -3.2]),
@@ -135,6 +139,7 @@ def large_observation():
                     lane_width=3.2,
                     speed_limit=5.0,
                     lane_index=0,
+                    lane_offset=193.0,
                 ),
             ],
             [
@@ -145,6 +150,7 @@ def large_observation():
                     lane_width=3.2,
                     speed_limit=5.0,
                     lane_index=1,
+                    lane_offset=192.00733923,
                 ),
                 Waypoint(
                     pos=np.array([193.0, 0.0]),
@@ -153,6 +159,7 @@ def large_observation():
                     lane_width=3.2,
                     speed_limit=5.0,
                     lane_index=1,
+                    lane_offset=193.0,
                 ),
             ],
         ],
@@ -273,6 +280,7 @@ def large_observation():
                             lane_width=3.2,
                             speed_limit=5.0,
                             lane_index=0,
+                            lane_offset=180.00587138,
                         ),
                         Waypoint(
                             pos=np.array([181.0, -3.2]),
@@ -281,6 +289,7 @@ def large_observation():
                             lane_width=3.2,
                             speed_limit=5.0,
                             lane_index=0,
+                            lane_offset=181.0,
                         ),
                     ]
                 ],
@@ -293,6 +302,7 @@ def large_observation():
                             lane_width=3.2,
                             speed_limit=5.0,
                             lane_index=1,
+                            lane_offset=180.00587138,
                         ),
                         Waypoint(
                             pos=np.array([181.0, 0.0]),
@@ -301,6 +311,7 @@ def large_observation():
                             lane_width=3.2,
                             speed_limit=5.0,
                             lane_index=1,
+                            lane_offset=181.0,
                         ),
                     ]
                 ],


### PR DESCRIPTION
Here we add a vehicle's position in terms of its current lane to its `{Ego}VehicleObservation` object.  We also add a waypoint's offset along the lane (its `s` coordinate) to the `Waypoint` object.

Meant to address Issue #1375 and Issue #1364.