### PR TITLE
support random seed in examples

### DIFF
--- a/examples/argument_parser.py
+++ b/examples/argument_parser.py
@@ -32,7 +32,12 @@ def default_argument_parser(program: Optional[str] = None):
     parser.add_argument(
         "--headless", help="Run the simulation in headless mode.", action="store_true"
     )
-    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--seed",
+        help="A seed to use for all random numbers in the simulation.  Using the same seed value should lead to the same results.",
+        type=int,
+        default=42,
+    )
     parser.add_argument(
         "--sim-name",
         help="Simulation name.",

--- a/examples/egoless.py
+++ b/examples/egoless.py
@@ -1,7 +1,7 @@
 import logging
 
 import gym
-from typing import Sequence
+from typing import Optional, Sequence
 
 from examples.argument_parser import default_argument_parser
 from smarts.core.utils.episodes import episodes
@@ -14,7 +14,7 @@ def main(
     headless: bool,
     num_episodes: int,
     seed: int,
-    max_episode_steps: int = None,
+    max_episode_steps: Optional[int] = None,
 ):
     env = gym.make(
         "smarts.env:hiway-v0",

--- a/examples/egoless.py
+++ b/examples/egoless.py
@@ -1,6 +1,7 @@
 import logging
 
 import gym
+from typing import Sequence
 
 from examples.argument_parser import default_argument_parser
 from smarts.core.utils.episodes import episodes
@@ -8,13 +9,20 @@ from smarts.core.utils.episodes import episodes
 logging.basicConfig(level=logging.INFO)
 
 
-def main(scenarios, headless, num_episodes, max_episode_steps=None):
+def main(
+    scenarios: Sequence[str],
+    headless: bool,
+    num_episodes: int,
+    seed: int,
+    max_episode_steps: int = None,
+):
     env = gym.make(
         "smarts.env:hiway-v0",
         scenarios=scenarios,
         agent_specs={},
         headless=headless,
         sumo_headless=True,
+        seed=seed,
     )
 
     if max_episode_steps is None:
@@ -39,4 +47,5 @@ if __name__ == "__main__":
         scenarios=args.scenarios,
         headless=args.headless,
         num_episodes=args.episodes,
+        seed=args.seed,
     )

--- a/examples/multi_agent.py
+++ b/examples/multi_agent.py
@@ -1,7 +1,7 @@
 import pathlib
 
 import gym
-from typing import Sequence
+from typing import Optional, Sequence
 
 from examples.argument_parser import default_argument_parser
 from smarts.core.agent import Agent
@@ -24,7 +24,7 @@ def main(
     headless: bool,
     num_episodes: int,
     seed: int,
-    max_episode_steps: int = None,
+    max_episode_steps: Optional[int] = None,
 ):
     agent_specs = {
         agent_id: AgentSpec(

--- a/examples/multi_agent.py
+++ b/examples/multi_agent.py
@@ -1,6 +1,7 @@
 import pathlib
 
 import gym
+from typing import Sequence
 
 from examples.argument_parser import default_argument_parser
 from smarts.core.agent import Agent
@@ -18,7 +19,13 @@ class KeepLaneAgent(Agent):
         return "keep_lane"
 
 
-def main(scenarios, headless, num_episodes, max_episode_steps=None):
+def main(
+    scenarios: Sequence[str],
+    headless: bool,
+    num_episodes: int,
+    seed: int,
+    max_episode_steps: int = None,
+):
     agent_specs = {
         agent_id: AgentSpec(
             interface=AgentInterface.from_type(
@@ -35,6 +42,7 @@ def main(scenarios, headless, num_episodes, max_episode_steps=None):
         agent_specs=agent_specs,
         headless=headless,
         sumo_headless=True,
+        seed=seed,
     )
 
     for episode in episodes(n=num_episodes):
@@ -73,4 +81,5 @@ if __name__ == "__main__":
         scenarios=args.scenarios,
         headless=args.headless,
         num_episodes=args.episodes,
+        seed=args.seed,
     )

--- a/examples/observation_collection_for_imitation_learning.py
+++ b/examples/observation_collection_for_imitation_learning.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, Sequence
 
 from envision.client import Client as Envision
 from examples.argument_parser import default_argument_parser
-from smarts.core import seed as random_seed
 from smarts.core.agent_interface import AgentInterface, AgentType
 from smarts.core.controllers import ControllerOutOfLaneException
 from smarts.core.scenario import Scenario
@@ -42,11 +41,9 @@ def _record_data(
         collected_data[car][t]["acceleration"] = acc_scalar
 
 
-def main(script: str, scenarios: Sequence[str], headless: bool, seed: int):
+def main(script: str, scenarios: Sequence[str], headless: bool):
     logger = logging.getLogger(script)
     logger.setLevel(logging.INFO)
-
-    random_seed(seed)
 
     agent_spec = AgentSpec(
         interface=AgentInterface.from_type(AgentType.Laner, max_episode_steps=None),
@@ -114,5 +111,4 @@ if __name__ == "__main__":
         script=parser.prog,
         scenarios=args.scenarios,
         headless=args.headless,
-        seed=args.seed,
     )

--- a/examples/observation_collection_for_imitation_learning.py
+++ b/examples/observation_collection_for_imitation_learning.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Sequence
 
 from envision.client import Client as Envision
 from examples.argument_parser import default_argument_parser
+from smarts.core import seed as random_seed
 from smarts.core.agent_interface import AgentInterface, AgentType
 from smarts.core.controllers import ControllerOutOfLaneException
 from smarts.core.scenario import Scenario
@@ -44,6 +45,8 @@ def _record_data(
 def main(script: str, scenarios: Sequence[str], headless: bool, seed: int):
     logger = logging.getLogger(script)
     logger.setLevel(logging.INFO)
+
+    random_seed(seed)
 
     agent_spec = AgentSpec(
         interface=AgentInterface.from_type(AgentType.Laner, max_episode_steps=None),

--- a/examples/single_agent.py
+++ b/examples/single_agent.py
@@ -2,7 +2,7 @@ import logging
 import pathlib
 
 import gym
-from typing import Sequence
+from typing import Optional, Sequence
 
 from examples.argument_parser import default_argument_parser
 from smarts.core.agent import Agent
@@ -39,7 +39,7 @@ def main(
     headless: bool,
     num_episodes: int,
     seed: int,
-    max_episode_steps: int = None,
+    max_episode_steps: Optional[int] = None,
 ):
     agent_spec = AgentSpec(
         interface=AgentInterface.from_type(

--- a/examples/single_agent.py
+++ b/examples/single_agent.py
@@ -2,6 +2,7 @@ import logging
 import pathlib
 
 import gym
+from typing import Sequence
 
 from examples.argument_parser import default_argument_parser
 from smarts.core.agent import Agent
@@ -33,7 +34,13 @@ class ChaseViaPointsAgent(Agent):
         )
 
 
-def main(scenarios, headless, num_episodes, max_episode_steps=None):
+def main(
+    scenarios: Sequence[str],
+    headless: bool,
+    num_episodes: int,
+    seed: int,
+    max_episode_steps: int = None,
+):
     agent_spec = AgentSpec(
         interface=AgentInterface.from_type(
             AgentType.LanerWithSpeed, max_episode_steps=max_episode_steps
@@ -47,6 +54,7 @@ def main(scenarios, headless, num_episodes, max_episode_steps=None):
         agent_specs={"SingleAgent": agent_spec},
         headless=headless,
         sumo_headless=True,
+        seed=seed,
     )
 
     # Convert `env.step()` and `env.reset()` from multi-agent interface to
@@ -82,4 +90,5 @@ if __name__ == "__main__":
         scenarios=args.scenarios,
         headless=args.headless,
         num_episodes=args.episodes,
+        seed=args.seed,
     )

--- a/examples/tests/test_examples.py
+++ b/examples/tests/test_examples.py
@@ -29,6 +29,7 @@ def test_examples(example):
         headless=True,
         num_episodes=1,
         max_episode_steps=100,
+        seed=42,
     )
 
 

--- a/examples/trajectory_tracking_agent.py
+++ b/examples/trajectory_tracking_agent.py
@@ -1,6 +1,7 @@
 import logging
 
 import gym
+from typing import Sequence
 
 from examples.argument_parser import default_argument_parser
 from smarts.core.agent import Agent
@@ -37,7 +38,13 @@ class TrackingAgent(Agent):
         return trajectory
 
 
-def main(scenarios, sim_name, headless, num_episodes, seed):
+def main(
+    scenarios: Sequence[str],
+    sim_name: str,
+    headless: bool,
+    num_episodes: int,
+    seed: int,
+):
     agent_spec = AgentSpec(
         interface=AgentInterface.from_type(AgentType.Tracker, max_episode_steps=None),
         agent_builder=TrackingAgent,


### PR DESCRIPTION
Cf Issue #1423, this hooks up the random seed that might be specified on the command line in various examples.  (It was often ignored before.)

This won't completely address #1423, but it at least allows for Patrick and Soheil to see the types of variation they can get by playing with the `seed`.