### PR TITLE
update sumo version in setup.py and changelog.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 # [Unreleased]
 
 ### Changed
+- Updated sumo to 1.13.0 to increase stability.
 - Updated license to 2022 version.
 - SMARTS reset now has a start time option which will skip simulation.
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "setuptools>=41.0.0,!=50.0",
         "cached-property>=1.5.2",
         "click==8.0.4",  # used in scl
-        "eclipse-sumo==1.10.0",  # sumo
+        "eclipse-sumo==1.13.0",  # sumo
         "gym==0.19.0",
         "numpy>=1.19.5",  # required for tf 2.4 below
         "pandas>=1.3.4",  # only used by zoo/evaluation


### PR DESCRIPTION
With the previous version of sumo `1.10.0`, when running the NGSIM simulation on `peachtree` map, it crashes every time at time step 23.80. Just tested the latest `1.13.0`. there's no crash anymore and it works just fine. 