### PR TITLE
[Bugfix] rgb wrapper support stdobs

### DIFF
--- a/smarts/env/wrappers/rgb_image.py
+++ b/smarts/env/wrappers/rgb_image.py
@@ -92,7 +92,10 @@ class RGBImage(gym.ObservationWrapper):
 
             images = []
             for agent_ob in agent_obs:
-                image = agent_ob.top_down_rgb.data
+                try:
+                    image = agent_ob.top_down_rgb.data
+                except AttributeError:
+                    image = agent_ob.rgb
                 images.append(image.astype(np.uint8))
 
             stacked_images = np.dstack(images)


### PR DESCRIPTION
This allows the rgb wrapper to work with `StdObs` from `FormatObs`.