### PR TITLE
NGSIM i80 map improvement

### DIFF
--- a/scenarios/NGSIM/i80/map.net.xml
+++ b/scenarios/NGSIM/i80/map.net.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- generated on 2022-06-01 11:07:20 by Eclipse SUMO netedit Version 1.13.0
+<!-- generated on 2022-07-01 00:42:17 by Eclipse SUMO netedit Version 1.13.0
 <configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/netconvertConfiguration.xsd">
 
     <input>
@@ -19,7 +19,6 @@
     </processing>
 
     <junctions>
-        <no-internal-links value="true"/>
         <no-turnarounds value="true"/>
         <junctions.corner-detail value="5"/>
         <junctions.limit-turn-speed value="5.5"/>
@@ -41,70 +40,82 @@
 
     <location netOffset="0.00,0.00" convBoundary="-5.32,-1.96,430.34,25.20" origBoundary="-10000000000.00,-10000000000.00,10000000000.00,10000000000.00" projParameter="!"/>
 
-    <edge id="E1" from="cluster_J2_J8" to="cluster_J3_J7" priority="-1" shape="136.60,6.68 242.57,6.79">
-        <lane id="E1_0" index="0" speed="13.89" length="123.27" width="6.00" shape="145.80,3.69 242.61,3.79"/>
+    <edge id=":cluster_J2_J8_0" function="internal">
+        <lane id=":cluster_J2_J8_0_0" index="0" speed="13.89" length="24.98" width="5.00" shape="127.37,0.64 131.28,1.23 135.83,2.31 141.46,3.36 148.61,3.83"/>
+        <lane id=":cluster_J2_J8_0_1" index="1" speed="13.89" length="24.98" width="3.66" shape="127.37,0.64 131.21,1.91 135.64,4.48 141.24,7.01 148.62,8.16"/>
+        <lane id=":cluster_J2_J8_0_2" index="2" speed="13.89" length="24.98" width="3.66" shape="127.37,0.64 131.11,2.48 135.37,6.31 140.94,10.10 148.63,11.82"/>
+        <lane id=":cluster_J2_J8_0_3" index="3" speed="13.89" length="24.98" width="3.66" shape="127.37,0.64 130.97,3.05 135.01,8.14 140.54,13.19 148.64,15.48"/>
+        <lane id=":cluster_J2_J8_0_4" index="4" speed="13.89" length="24.98" width="3.66" shape="127.37,0.64 130.82,3.62 134.59,9.97 140.07,16.27 148.65,19.14"/>
     </edge>
+    <edge id=":cluster_J2_J8_5" function="internal">
+        <lane id=":cluster_J2_J8_5_0" index="0" speed="13.89" length="21.28" width="5.00" shape="127.36,4.72 148.61,3.83"/>
+        <lane id=":cluster_J2_J8_5_1" index="1" speed="13.89" length="21.28" width="3.66" shape="127.36,8.38 148.62,8.16"/>
+        <lane id=":cluster_J2_J8_5_2" index="2" speed="13.89" length="21.28" width="3.66" shape="127.35,12.04 148.63,11.82"/>
+        <lane id=":cluster_J2_J8_5_3" index="3" speed="13.89" length="21.28" width="3.66" shape="127.35,15.70 148.64,15.48"/>
+        <lane id=":cluster_J2_J8_5_4" index="4" speed="13.89" length="21.28" width="3.66" shape="127.35,19.36 148.65,19.14"/>
+        <lane id=":cluster_J2_J8_5_5" index="5" speed="13.89" length="21.28" width="3.66" shape="127.34,23.02 148.66,22.80"/>
+    </edge>
+
     <edge id="E3" from="J5" to="cluster_J2_J8" priority="-1" shape="23.11,-1.96 128.68,2.95">
-        <lane id="E3_0" index="0" speed="13.89" length="117.82" width="4.50" shape="23.21,-4.21 127.37,0.64"/>
+        <lane id="E3_0" index="0" speed="13.89" length="104.27" width="4.50" shape="23.21,-4.21 127.37,0.64"/>
     </edge>
     <edge id="gneE01" from="gneJ00" to="cluster_J2_J8" priority="-1" shape="-5.32,24.70 127.34,24.85">
-        <lane id="gneE01_0" index="0" speed="13.89" length="142.40" width="3.66" shape="-5.30,4.57 127.36,4.72"/>
-        <lane id="gneE01_1" index="1" speed="13.89" length="142.40" width="3.66" shape="-5.30,8.23 127.36,8.38"/>
-        <lane id="gneE01_2" index="2" speed="13.89" length="142.40" width="3.66" shape="-5.31,11.89 127.35,12.04"/>
-        <lane id="gneE01_3" index="3" speed="13.89" length="142.40" width="3.66" shape="-5.31,15.55 127.35,15.70"/>
-        <lane id="gneE01_4" index="4" speed="13.89" length="142.40" width="3.66" shape="-5.31,19.21 127.35,19.36"/>
-        <lane id="gneE01_5" index="5" speed="13.89" length="142.40" width="3.66" shape="-5.32,22.87 127.34,23.02"/>
+        <lane id="gneE01_0" index="0" speed="13.89" length="132.66" width="3.66" shape="-5.30,4.57 127.36,4.72"/>
+        <lane id="gneE01_1" index="1" speed="13.89" length="132.66" width="3.66" shape="-5.30,8.23 127.36,8.38"/>
+        <lane id="gneE01_2" index="2" speed="13.89" length="132.66" width="3.66" shape="-5.31,11.89 127.35,12.04"/>
+        <lane id="gneE01_3" index="3" speed="13.89" length="132.66" width="3.66" shape="-5.31,15.55 127.35,15.70"/>
+        <lane id="gneE01_4" index="4" speed="13.89" length="132.66" width="3.66" shape="-5.31,19.21 127.35,19.36"/>
+        <lane id="gneE01_5" index="5" speed="13.89" length="132.66" width="3.66" shape="-5.32,22.87 127.34,23.02"/>
     </edge>
-    <edge id="gneE01.132" from="cluster_J2_J8" to="cluster_J3_J7" priority="-1" shape="136.55,24.61 244.08,24.99">
-        <lane id="gneE01.132_0" index="0" speed="13.89" length="123.10" width="3.66" shape="145.82,8.17 242.59,8.51"/>
-        <lane id="gneE01.132_1" index="1" speed="13.89" length="123.10" width="3.66" shape="145.84,11.83 242.58,12.17"/>
-        <lane id="gneE01.132_2" index="2" speed="13.89" length="123.10" width="3.66" shape="145.86,15.49 242.57,15.83"/>
-        <lane id="gneE01.132_3" index="3" speed="13.89" length="123.10" width="3.66" shape="145.88,19.15 242.55,19.49"/>
-        <lane id="gneE01.132_4" index="4" speed="13.89" length="123.10" width="3.66" shape="145.90,22.81 242.54,23.15"/>
-    </edge>
-    <edge id="gneE01.249" from="cluster_J3_J7" to="gneJ10" priority="-1" shape="244.08,24.99 430.34,25.20">
-        <lane id="gneE01.249_0" index="0" speed="13.89" length="194.16" width="5.00" shape="245.62,4.19 430.36,4.40"/>
-        <lane id="gneE01.249_1" index="1" speed="13.89" length="194.16" width="3.66" shape="245.61,8.52 430.36,8.73"/>
-        <lane id="gneE01.249_2" index="2" speed="13.89" length="194.16" width="3.66" shape="245.61,12.18 430.35,12.39"/>
-        <lane id="gneE01.249_3" index="3" speed="13.89" length="194.16" width="3.66" shape="245.60,15.84 430.35,16.05"/>
-        <lane id="gneE01.249_4" index="4" speed="13.89" length="194.16" width="3.66" shape="245.60,19.50 430.35,19.71"/>
-        <lane id="gneE01.249_5" index="5" speed="13.89" length="194.16" width="3.66" shape="245.60,23.16 430.34,23.37"/>
+    <edge id="gneE01.132" from="cluster_J2_J8" to="gneJ10" priority="-1" shape="136.55,24.61 430.34,25.20">
+        <lane id="gneE01.132_0" index="0" speed="13.89" length="281.73" width="5.00" shape="148.61,3.83 430.38,4.40"/>
+        <lane id="gneE01.132_1" index="1" speed="13.89" length="281.73" width="3.66" shape="148.62,8.16 430.37,8.73"/>
+        <lane id="gneE01.132_2" index="2" speed="13.89" length="281.73" width="3.66" shape="148.63,11.82 430.37,12.39"/>
+        <lane id="gneE01.132_3" index="3" speed="13.89" length="281.73" width="3.66" shape="148.64,15.48 430.36,16.05"/>
+        <lane id="gneE01.132_4" index="4" speed="13.89" length="281.73" width="3.66" shape="148.65,19.14 430.35,19.71"/>
+        <lane id="gneE01.132_5" index="5" speed="13.89" length="281.73" width="3.66" shape="148.66,22.80 430.34,23.37"/>
     </edge>
 
     <junction id="J4" type="dead_end" x="430.24" y="7.00" incLanes="" intLanes="" shape="430.24,7.00"/>
     <junction id="J5" type="dead_end" x="23.11" y="-1.96" incLanes="" intLanes="" shape="23.11,-1.96 23.32,-6.46"/>
-    <junction id="cluster_J2_J8" type="priority" x="131.02" y="15.83" incLanes="E3_0 gneE01_0 gneE01_1 gneE01_2 gneE01_3 gneE01_4 gneE01_5" intLanes="" shape="145.91,24.88 145.78,0.73 140.04,0.69 135.62,-0.23 131.12,-0.98 127.37,-1.62 127.34,24.85" customShape="1">
-        <request index="0" response="0000010" foes="0000010"/>
-        <request index="1" response="0000000" foes="0000001"/>
-        <request index="2" response="0000000" foes="0000000"/>
-        <request index="3" response="0000000" foes="0000000"/>
-        <request index="4" response="0000000" foes="0000000"/>
-        <request index="5" response="0000000" foes="0000000"/>
-        <request index="6" response="0000000" foes="0000000"/>
-    </junction>
-    <junction id="cluster_J3_J7" type="priority" x="243.33" y="15.85" incLanes="gneE01.132_0 gneE01.132_1 gneE01.132_2 gneE01.132_3 gneE01.132_4 E1_0" intLanes="" shape="245.59,24.99 245.62,1.69 244.49,1.46 243.75,1.02 243.28,0.86 242.62,0.79 242.54,24.98">
-        <request index="0" response="000000" foes="000000"/>
-        <request index="1" response="000000" foes="000000"/>
-        <request index="2" response="000000" foes="000000"/>
-        <request index="3" response="000000" foes="000000"/>
-        <request index="4" response="000000" foes="000000"/>
-        <request index="5" response="000000" foes="000000"/>
+    <junction id="cluster_J2_J8" type="priority" x="131.02" y="15.83" incLanes="E3_0 gneE01_0 gneE01_1 gneE01_2 gneE01_3 gneE01_4 gneE01_5" intLanes=":cluster_J2_J8_0_0 :cluster_J2_J8_0_1 :cluster_J2_J8_0_2 :cluster_J2_J8_0_3 :cluster_J2_J8_0_4 :cluster_J2_J8_5_0 :cluster_J2_J8_5_1 :cluster_J2_J8_5_2 :cluster_J2_J8_5_3 :cluster_J2_J8_5_4 :cluster_J2_J8_5_5" shape="148.66,24.50 148.60,1.57 141.82,0.81 136.54,-0.10 131.98,-0.84 127.37,-1.62 127.34,24.85" customShape="1">
+        <request index="0"  response="11111100000" foes="11111100000" cont="0"/>
+        <request index="1"  response="11111100000" foes="11111100000" cont="0"/>
+        <request index="2"  response="11111100000" foes="11111100000" cont="0"/>
+        <request index="3"  response="11111100000" foes="11111100000" cont="0"/>
+        <request index="4"  response="11111100000" foes="11111100000" cont="0"/>
+        <request index="5"  response="00000000000" foes="00000011111" cont="0"/>
+        <request index="6"  response="00000000000" foes="00000011111" cont="0"/>
+        <request index="7"  response="00000000000" foes="00000011111" cont="0"/>
+        <request index="8"  response="00000000000" foes="00000011111" cont="0"/>
+        <request index="9"  response="00000000000" foes="00000011111" cont="0"/>
+        <request index="10" response="00000000000" foes="00000011111" cont="0"/>
     </junction>
     <junction id="gneJ00" type="dead_end" x="-5.32" y="24.70" incLanes="" intLanes="" shape="-5.32,24.70 -5.30,2.74"/>
-    <junction id="gneJ10" type="dead_end" x="430.34" y="25.20" incLanes="gneE01.249_0 gneE01.249_1 gneE01.249_2 gneE01.249_3 gneE01.249_4 gneE01.249_5" intLanes="" shape="430.37,1.90 430.34,25.20"/>
+    <junction id="gneJ10" type="dead_end" x="430.34" y="25.20" incLanes="gneE01.132_0 gneE01.132_1 gneE01.132_2 gneE01.132_3 gneE01.132_4 gneE01.132_5" intLanes="" shape="430.39,1.90 430.34,25.20"/>
 
-    <connection from="E1" to="gneE01.249" fromLane="0" toLane="0" dir="s" state="M"/>
-    <connection from="E3" to="E1" fromLane="0" toLane="0" dir="s" state="m"/>
-    <connection from="gneE01" to="E1" fromLane="0" toLane="0" dir="s" state="M"/>
-    <connection from="gneE01" to="gneE01.132" fromLane="1" toLane="0" dir="s" state="M"/>
-    <connection from="gneE01" to="gneE01.132" fromLane="2" toLane="1" dir="s" state="M"/>
-    <connection from="gneE01" to="gneE01.132" fromLane="3" toLane="2" dir="s" state="M"/>
-    <connection from="gneE01" to="gneE01.132" fromLane="4" toLane="3" dir="s" state="M"/>
-    <connection from="gneE01" to="gneE01.132" fromLane="5" toLane="4" dir="s" state="M"/>
-    <connection from="gneE01.132" to="gneE01.249" fromLane="0" toLane="1" dir="s" state="M"/>
-    <connection from="gneE01.132" to="gneE01.249" fromLane="1" toLane="2" dir="s" state="M"/>
-    <connection from="gneE01.132" to="gneE01.249" fromLane="2" toLane="3" dir="s" state="M"/>
-    <connection from="gneE01.132" to="gneE01.249" fromLane="3" toLane="4" dir="s" state="M"/>
-    <connection from="gneE01.132" to="gneE01.249" fromLane="4" toLane="5" dir="s" state="M"/>
+    <connection from="E3" to="gneE01.132" fromLane="0" toLane="0" via=":cluster_J2_J8_0_0" dir="s" state="m"/>
+    <connection from="E3" to="gneE01.132" fromLane="0" toLane="1" via=":cluster_J2_J8_0_1" dir="s" state="m"/>
+    <connection from="E3" to="gneE01.132" fromLane="0" toLane="2" via=":cluster_J2_J8_0_2" dir="s" state="m"/>
+    <connection from="E3" to="gneE01.132" fromLane="0" toLane="3" via=":cluster_J2_J8_0_3" dir="s" state="m"/>
+    <connection from="E3" to="gneE01.132" fromLane="0" toLane="4" via=":cluster_J2_J8_0_4" dir="s" state="m"/>
+    <connection from="gneE01" to="gneE01.132" fromLane="0" toLane="0" via=":cluster_J2_J8_5_0" dir="s" state="M"/>
+    <connection from="gneE01" to="gneE01.132" fromLane="1" toLane="1" via=":cluster_J2_J8_5_1" dir="s" state="M"/>
+    <connection from="gneE01" to="gneE01.132" fromLane="2" toLane="2" via=":cluster_J2_J8_5_2" dir="s" state="M"/>
+    <connection from="gneE01" to="gneE01.132" fromLane="3" toLane="3" via=":cluster_J2_J8_5_3" dir="s" state="M"/>
+    <connection from="gneE01" to="gneE01.132" fromLane="4" toLane="4" via=":cluster_J2_J8_5_4" dir="s" state="M"/>
+    <connection from="gneE01" to="gneE01.132" fromLane="5" toLane="5" via=":cluster_J2_J8_5_5" dir="s" state="M"/>
+
+    <connection from=":cluster_J2_J8_0" to="gneE01.132" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":cluster_J2_J8_0" to="gneE01.132" fromLane="1" toLane="1" dir="s" state="M"/>
+    <connection from=":cluster_J2_J8_0" to="gneE01.132" fromLane="2" toLane="2" dir="s" state="M"/>
+    <connection from=":cluster_J2_J8_0" to="gneE01.132" fromLane="3" toLane="3" dir="s" state="M"/>
+    <connection from=":cluster_J2_J8_0" to="gneE01.132" fromLane="4" toLane="4" dir="s" state="M"/>
+    <connection from=":cluster_J2_J8_5" to="gneE01.132" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":cluster_J2_J8_5" to="gneE01.132" fromLane="1" toLane="1" dir="s" state="M"/>
+    <connection from=":cluster_J2_J8_5" to="gneE01.132" fromLane="2" toLane="2" dir="s" state="M"/>
+    <connection from=":cluster_J2_J8_5" to="gneE01.132" fromLane="3" toLane="3" dir="s" state="M"/>
+    <connection from=":cluster_J2_J8_5" to="gneE01.132" fromLane="4" toLane="4" dir="s" state="M"/>
+    <connection from=":cluster_J2_J8_5" to="gneE01.132" fromLane="5" toLane="5" dir="s" state="M"/>
 
 </net>


### PR DESCRIPTION
The previous map has two edges in the halfway (5-lane edges and a single-lane edge). See the screenshot below:
**Before:**
<img width="1340" alt="i80_before" src="https://user-images.githubusercontent.com/59240680/176827489-e6ff90de-e6de-4aa5-8217-88f762167bea.png">

Yuecheng suggested using one edge instead of two so that the bottom lane doesn't have a separate `lane_index` to the main 5-lane edge. Therefore, I combined the three edges (circled in the screenshot above) all together into one edge, see below:

**After:**
<img width="1153" alt="i80_after" src="https://user-images.githubusercontent.com/59240680/176827488-3a65cc99-daac-4285-b3d5-82d24f928353.png">
