### PR TITLE
deprecated history formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Removed `endless_traffic` option from `SumoTrafficSimulator` and instead added `repeat_route` to `Flow` type in Scenario Studio.
 
 ### Removed
+- Removed support for deprecated json-based and YAML formats for traffic histories.
 
 ### Fixed
 - Fixed bug where `yaw_rate` was always reported as 0.0 (Issue #1481).

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
         # The following are for /envision
         "tornado>=6.1",
         "websocket-client>=1.2.1",
-        # The following is used for imitation learning and envision
         "ijson>=3.1.4",
         # The following are for the /smarts/algorithms
         "matplotlib>=3.4.3",

--- a/smarts/sstudio/genhistories.py
+++ b/smarts/sstudio/genhistories.py
@@ -35,13 +35,9 @@ from typing import (
     Generator,
     Iterable,
     Optional,
-    Tuple,
-    Union,
 )
 
-import ijson
 import numpy as np
-import yaml
 
 from smarts.core.coordinates import BoundingBox, Point
 from smarts.core.utils.file import read_tfrecord_file
@@ -166,9 +162,9 @@ class _TrajectoryDataset:
         """Validate the form of the dataset specification."""
         errmsg = None
         if "input_path" not in dataset_spec:
-            errmsg = "'input_path' field is required in dataset yaml."
+            errmsg = "'input_path' field is required in dataset_spec."
         elif dataset_spec.get("flip_y"):
-            if not dataset_spec["source_type"].startswith("NGSIM"):
+            if dataset_spec["source_type"] != "NGSIM":
                 errmsg = "'flip_y' option only supported for NGSIM datasets."
             elif not dataset_spec.get("_map_bbox"):
                 errmsg = "'_map_bbox' is required if 'flip_y' option used; need to pass in a map_spec."
@@ -759,67 +755,6 @@ class NGSIM(_TrajectoryDataset):
         return row.get(col_name)
 
 
-class OldJSON(_TrajectoryDataset):
-    """This exists because SMARTS used to use JSON files for traffic histories.
-    We provide this to help people convert these previously-created .json
-    history files to the new .shf format."""
-
-    def __init__(self, dataset_spec: Dict[str, Any], output: str):
-        from warnings import warn
-
-        warn(
-            f"The {self.__class__.__name__} class has been deprecated.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        super().__init__(dataset_spec, output)
-
-    @property
-    def rows(self) -> Generator[Tuple, None, None]:
-        with open(self._dataset_spec["input_path"], "rb") as inf:
-            for t, states in ijson.kvitems(inf, "", use_float=True):
-                for state in states.values():
-                    yield (t, state)
-
-    def _lookup_agent_type(self, agent_type: Union[int, str]) -> int:
-        if isinstance(agent_type, int):
-            return agent_type
-        # Try to match the NGSIM types...
-        if agent_type == "motorcycle":
-            return 1
-        elif agent_type == "car":
-            return 2
-        elif agent_type == "truck":
-            return 3
-        elif agent_type == "pedestrian/bicycle":
-            return 4
-        self._log.warning(f"unknown agent_type:  {agent_type}.")
-        return 0
-
-    def column_val_in_row(self, row: Tuple, col_name: str) -> Any:
-        assert len(row) == 2
-        if col_name == "sim_time":
-            return float(row[0]) * 1000
-        state = row[1]
-        if col_name in state:
-            return state[col_name]
-        if col_name == "id":
-            return state["vehicle_id"]
-        if col_name == "type":
-            return self._lookup_agent_type(state["vehicle_type"])
-        if col_name == "length":
-            return state.get("vehicle_length", 0.0)
-        if col_name == "width":
-            return state.get("vehicle_width", 0.0)
-        if col_name.startswith("position_x"):
-            return state["position"][0]
-        if col_name.startswith("position_y"):
-            return state["position"][1]
-        if col_name == "heading_rad":
-            return state.get("heading", -math.pi / 2)
-        return None
-
-
 class Waymo(_TrajectoryDataset):
     """A tool for conversion of a Waymo dataset for use within SMARTS."""
 
@@ -1011,24 +946,6 @@ def import_dataset(
     dataset.create_output()
 
 
-def _migrate_deprecated_dataset(dataset_spec: Dict[str, Any]):
-    def remap(old_d: Dict[str, Any], old_key: str, new_d: Dict[str, Any], new_key: str):
-        if new_key not in new_d and old_key in old_d:
-            new_d[new_key] = old_d[old_key]
-
-    remap(dataset_spec, "source", dataset_spec, "source_type")
-    if "map_net" in dataset_spec:
-        map_spec = dataset_spec["map_net"]
-        remap(map_spec, "lane_width", dataset_spec, "map_lane_width")
-        if "max_y" in map_spec or "width" in map_spec or "height" in map_spec:
-            assert "_map_bbox" not in dataset_spec
-            max_x = map_spec.get("width")
-            max_y = map_spec.get("max_y", map_spec.get("height"))
-            dataset_spec["_map_bbox"] = BoundingBox(
-                min_pt=Point(0, 0), max_pt=Point(max_x, max_y)
-            )
-
-
 def _check_args(args) -> bool:
     if not args.force and os.path.exists(args.output):
         print("output file already exists\n")
@@ -1047,16 +964,9 @@ if __name__ == "__main__":
         action="store_true",
     )
     parser.add_argument(
-        "--old",
-        "--json",
-        help="Input is an old SMARTS traffic history in JSON format as opposed to a YAML dataset spec.",
-        action="store_true",
-    )
-    parser.add_argument(
         "dataset",
         type=str,
-        help="""Path to YAML file describing original trajectories dataset. See SMARTS Issue #732 for YAML file options.
-                Note: if --old is used, this path is expected to point to an old JSON traffic history to be converted.""",
+        help="""Path to YAML file describing trajectories dataset. YAML file should correspond with types.TrafficHistoryDataset fields.""",
     )
     parser.add_argument(
         "output", type=str, help="SMARTS traffic history file to create"
@@ -1070,17 +980,20 @@ if __name__ == "__main__":
     if args.force and os.path.exists(args.output):
         os.remove(args.output)
 
-    if args.old:
-        dataset_spec = {"source_type": "OldJSON", "input_path": args.dataset}
-    else:
-        with open(args.dataset, "r") as yf:
-            dataset_spec = yaml.safe_load(yf)["trajectory_dataset"]
+    import yaml
+
+    with open(args.dataset, "r") as yf:
+        dataset_spec = yaml.safe_load(yf)["trajectory_dataset"]
 
     if not dataset_spec.get("input_path"):
         print(f"skipping placeholder dataset spec at {args.dataset}.")
         sys.exit(0)
 
-    _migrate_deprecated_dataset(dataset_spec)
+    if dataset_spec.get("filter_off_map", False) or dataset_spec.get("flip_y", False):
+        print(
+            f"cannot use 'filter_off_map' or 'flip_y' as specified in {args.dataset} in command-line usage"
+        )
+        sys.exit(-1)
 
     if args.x_offset:
         dataset_spec["x_offset"] = args.x_offset
@@ -1089,12 +1002,10 @@ if __name__ == "__main__":
         dataset_spec["y_offset"] = args.y_offset
 
     source = dataset_spec.get("source_type", "NGSIM")
-    if source.startswith("NGSIM"):
+    if source == "NGSIM":
         dataset = NGSIM(dataset_spec, args.output)
     elif source == "Waymo":
         dataset = Waymo(dataset_spec, args.output)
-    elif source == "OldJSON":
-        dataset = OldJSON(dataset_spec, args.output)
     else:
         dataset = Interaction(dataset_spec, args.output)
 


### PR DESCRIPTION
This PR cleans up some old, deprecated stuff that we were carrying to support the old way(s) of doing traffic histories.

Note that I left in the ability to run `genhistories` as a script from the command line (even though that's not the way it is currently used by `gen_scenario()`) just in case it's desired to use that for debugging purposes.