### PR TITLE
cutin options

### DIFF
--- a/smarts/sstudio/types.py
+++ b/smarts/sstudio/types.py
@@ -148,6 +148,9 @@ class SmartsLaneChangingModel(LaneChangingModel):
         slow_down_after:
             Target speed during the hold_period will be scaled by this value.
             Must be non-negative.  default: 1.0.
+        multi_lane_cutin:
+            If True, this vehicle will consider changing across multiple lanes at once in order
+            to cutin upon an agent vehicle when there's an opportunity.  default: False.
     """
 
     def __init__(
@@ -157,6 +160,7 @@ class SmartsLaneChangingModel(LaneChangingModel):
         dogmatic: bool = True,
         hold_period: float = 3.0,
         slow_down_after: float = 1.0,
+        multi_lane_cutin: bool = False,
     ):
         super().__init__(
             cutin_prob=cutin_prob,
@@ -164,6 +168,7 @@ class SmartsLaneChangingModel(LaneChangingModel):
             dogmatic=dogmatic,
             hold_period=hold_period,
             slow_down_after=slow_down_after,
+            multi_lane_cutin=multi_lane_cutin,
         )
 
 

--- a/smarts/sstudio/types.py
+++ b/smarts/sstudio/types.py
@@ -141,12 +141,30 @@ class SmartsLaneChangingModel(LaneChangingModel):
             If True, will cutin when a suitable opportunity presents itself based on the above parameters,
             even if it means the risk of not not completing the assigned route; otherwise, will forego
             the chance.
+        hold_period:
+            The minimum amount of time (in seconds) to remain in the agent's lane after cutting into it
+            (including the time it takes within the lane to complete the maneuver). Must be non-negative.
+            default: 3.0.
+        slow_down_after:
+            Target speed during the hold_period will be scaled by this value.
+            Must be non-negative.  default: 1.0.
     """
 
     def __init__(
-        self, cutin_prob: float = 0.0, assertive: float = 1.0, dogmatic: bool = True
+        self,
+        cutin_prob: float = 0.0,
+        assertive: float = 1.0,
+        dogmatic: bool = True,
+        hold_period: float = 3.0,
+        slow_down_after: float = 1.0,
     ):
-        super().__init__(cutin_prob=cutin_prob, assertive=assertive, dogmatic=dogmatic)
+        super().__init__(
+            cutin_prob=cutin_prob,
+            assertive=assertive,
+            dogmatic=dogmatic,
+            hold_period=hold_period,
+            slow_down_after=slow_down_after,
+        )
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
This adds the `slow_down_after` and `hold_period` options to the SMARTS lane changing model.  

This is so we can simulate situations where the agent vehicle being cutin-upon definitely must react.

Edit:  upon further discussion with Patrick, I've also now added the `multi_lane_cutin` option.  And this led me to discover a bug in the handing of boolean parameters (cf. the previous `dogmatic` option) that I've now fixed as well.