### PR TITLE
Numpy array cache fix

### DIFF
--- a/smarts/core/coordinates.py
+++ b/smarts/core/coordinates.py
@@ -89,7 +89,7 @@ class Point(NamedTuple):
     @classmethod
     def from_np_array(cls, np_array: np.ndarray):
         """Factory for constructing a Point object from a numpy array."""
-        assert 2 <= len(np.array) <= 3
+        assert 2 <= len(np_array) <= 3
         z = np_array[2] if len(np.array) > 2 else 0.0
         return cls(np_array[0], np_array[1], z)
 

--- a/smarts/core/coordinates.py
+++ b/smarts/core/coordinates.py
@@ -90,7 +90,7 @@ class Point(NamedTuple):
     def from_np_array(cls, np_array: np.ndarray):
         """Factory for constructing a Point object from a numpy array."""
         assert 2 <= len(np.array) <= 3
-        z = np_array[2] if len(np_array) > 2 else 0.0
+        z = np_array[2] if len(np.array) > 2 else 0.0
         return cls(np_array[0], np_array[1], z)
 
     @property

--- a/smarts/core/coordinates.py
+++ b/smarts/core/coordinates.py
@@ -90,7 +90,7 @@ class Point(NamedTuple):
     def from_np_array(cls, np_array: np.ndarray):
         """Factory for constructing a Point object from a numpy array."""
         assert 2 <= len(np_array) <= 3
-        z = np_array[2] if len(np.array) > 2 else 0.0
+        z = np_array[2] if len(np_array) > 2 else 0.0
         return cls(np_array[0], np_array[1], z)
 
     @property

--- a/smarts/core/coordinates.py
+++ b/smarts/core/coordinates.py
@@ -95,7 +95,7 @@ class Point(NamedTuple):
 
     @property
     def as_np_array(self) -> np.ndarray:
-        """Convert this Point to a numpy array and cache the result."""
+        """Convert this Point to a read-only numpy array and cache the result."""
         # Since this happens frequently and numpy array construction
         # involves memory allocation, we include this convenience method
         # with a cache of the result.
@@ -110,6 +110,8 @@ class Point(NamedTuple):
         if cached is not None:
             return cached
         npt = np.array((self.x, self.y, self.z))
+        # the array shouln't be changed independently of this Point object now...
+        npt.setflags(write=False)
         _numpy_points[self] = npt
         return npt
 

--- a/smarts/core/smarts.py
+++ b/smarts/core/smarts.py
@@ -1273,8 +1273,8 @@ class SMARTS:
 
     def _check_ground_plane(self):
         rescale_plane = False
-        map_min = self._map_bb.min_pt.as_np_array[:2] if self._map_bb else None
-        map_max = self._map_bb.max_pt.as_np_array[:2] if self._map_bb else None
+        map_min = np.array(self._map_bb.min_pt)[:2] if self._map_bb else None
+        map_max = np.array(self._map_bb.max_pt)[:2] if self._map_bb else None
         for vehicle_id in self._vehicle_index.agent_vehicle_ids():
             vehicle = self._vehicle_index.vehicle_by_id(vehicle_id)
             map_spot = vehicle.pose.point.as_np_array[:2]


### PR DESCRIPTION
Fixes a bug where a numpy array corresponding to a `Point` was getting modified and thus corrupting the `Point` cache.