### PR TITLE
Fix traffic provider leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Fixed bug where `yaw_rate` was always reported as 0.0 (Issue #1481).
 - Modified `FrameStack` wrapper to support agents which start at a later time in the simulation.
 - Truncated all waypoint paths returned by `FormatObs` wrapper to be of the same length. Previously, variable waypoint-path lengths caused inhomogenous shape error in numpy array.
+- Fixed a bug where traffic providers would leak across instances due to the ~~(awful design decision of python)~~ reference types defaults in arguments sharing across instances.
 
 ## [0.6.1]
 ### Added

--- a/smarts/core/smarts.py
+++ b/smarts/core/smarts.py
@@ -104,7 +104,7 @@ class SMARTS:
         agent_interfaces: Dict[str, AgentInterface],
         # traffic_sim is deprecated:  use traffic_sims instead
         traffic_sim: Optional[TrafficProvider] = None,
-        traffic_sims: List[TrafficProvider] = [],
+        traffic_sims: Optional[List[TrafficProvider]] = None,
         envision: Optional[EnvisionClient] = None,
         visdom: Optional[VisdomClient] = None,
         fixed_timestep_sec: Optional[float] = 0.1,
@@ -139,7 +139,7 @@ class SMARTS:
         self._trajectory_interpolation_provider = TrajectoryInterpolationProvider(self)
         self._provider_recovery_flags: Dict[Provider, ProviderRecoveryFlags] = {}
 
-        self._traffic_sims = traffic_sims
+        self._traffic_sims = traffic_sims or []
         self._traffic_sims.append(self._traffic_history_provider)
         if traffic_sim:
             warnings.warn(


### PR DESCRIPTION
Traffic providers were getting stored in the default `list` reference in the simulator initializer.

Short: Python can be awful sometimes.

closes #1542 