### PR TITLE
Improve competition evaluation setup

### DIFF
--- a/competition/competition_bundle/Dockerfile
+++ b/competition/competition_bundle/Dockerfile
@@ -1,7 +1,7 @@
 # Steps to build and push minimal SMARTS docker image
 # ```bash
 # $ cd </path/to/SMARTS>
-# $ export VERSION=v0.6.1
+# $ export VERSION=<version> # e.g. VERSION=v0.6.1
 # $ docker build --no-cache -f ./utils/docker/Dockerfile.minimal -t huaweinoah/smarts:$VERSION-minimal .
 # $ docker login
 # $ docker push huaweinoah/smarts:$VERSION-minimal
@@ -19,6 +19,7 @@ RUN apt-get update --fix-missing && \
     apt-get update && \
     apt-get install -y \
         git \
+        git-lfs \
         libspatialindex-dev \
         python3.8 \
         python3.8-venv \

--- a/competition/competition_bundle/scoring_program/metadata
+++ b/competition/competition_bundle/scoring_program/metadata
@@ -1,2 +1,2 @@
-command: python3.8 $program/evaluate.py --input_dir=$input --output_dir=$output
+command: python3.8 $program/evaluate.py --input_dir=$input --output_dir=$output --auto_install_pip_deps
 description: The competition evaluation program

--- a/competition/evaluation/README.md
+++ b/competition/evaluation/README.md
@@ -25,11 +25,15 @@ This folder contains the python script that CodaLab uses to evaluate the submiss
 + There is a utility for setting up the base dependencies.
 + Be aware that you will need [git lfs](git-lfs.github.com) in order to get all dependencies.
 
+### Option 1
++ Install dependencies using the utility script.
+
     ```bash
     # Use --no-cache if you wish a full reinstall
     $ python -m auto_install
     ```
-+ The alternative is to install from source.
+### Option 2
++ The alternative is to install from source. This allows for updates of the source.
 
     ```bash
     $ cd <to/your/repo/storage>
@@ -37,7 +41,7 @@ This folder contains the python script that CodaLab uses to evaluate the submiss
     $ pip install -e <smarts_repo>
     # check that git lfs is installed:
     $ git lfs --version
-    $ git clone https://malban@bitbucket.org/malban/bubble_env.git
+    $ git clone https://malban:ATBByMTp2W2MnVGsxHBYwEbNsVca00608BD5@bitbucket.org/malban/bubble_env.git
     $ pip install -e ./bubble_env
     ```
 

--- a/competition/evaluation/README.md
+++ b/competition/evaluation/README.md
@@ -13,13 +13,33 @@ This folder contains the python script that CodaLab uses to evaluate the submiss
 + Factors included in `Humanness` aspect, include 
     + distance to obstacles
     + angular jerk
-    + linear jeark
+    + linear jerk
     + lane center offset
 + Factors included in the `Rules` aspect, include events such as 
     + exceeding speed limit
     + driving wrong way
 + Each score component must be minimized. The lower the value, the better it is.
 + Overall rank is obtained by sorting each score component in ascending order, with a priority order of Completion > Time > Humanness > Rules .
+
+## Setup
++ There is a utility for setting up the base dependencies.
++ Be aware that you will need [git lfs](git-lfs.github.com) in order to get all dependencies.
+
+    ```bash
+    # Use --no-cache if you wish a full reinstall
+    $ python -m auto_install
+    ```
++ The alternative is to install from source.
+
+    ```bash
+    $ cd <to/your/repo/storage>
+    $ git clone <smarts_repo> # likely already located at ../.. from this file
+    $ pip install -e <smarts_repo>
+    # check that git lfs is installed:
+    $ git lfs --version
+    $ git clone https://malban@bitbucket.org/malban/bubble_env.git
+    $ pip install -e ./bubble_env
+    ```
 
 ## Local evaluation
 + To evaluate the trained model locally, do the following:

--- a/competition/evaluation/auto_install.py
+++ b/competition/evaluation/auto_install.py
@@ -1,0 +1,63 @@
+import argparse
+import logging
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+logger = logging.getLogger(__file__)
+
+
+def install_evaluation_deps(requirements_dir: Path, reset_wheelhouse_cache: bool):
+    wheelhouse = Path(tempfile.gettempdir()) / "wheelhouse/driving_smarts_competition"
+    try:
+        subprocess.check_call(["git", "lfs", "--version"])
+    except:
+        logger.exception("`git lfs` is required to correctly install the dependencies.")
+        exit(1)
+    if not wheelhouse.exists() or reset_wheelhouse_cache:
+        subprocess.check_call(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "wheel",
+                f"--wheel-dir={str(wheelhouse)}",
+                "-r",
+                str(requirements_dir / "requirements.txt"),
+            ]
+        )
+
+    stdout, _ = subprocess.Popen(
+        ["ls", str(wheelhouse)], stdout=subprocess.PIPE
+    ).communicate()
+    files = stdout.decode(sys.getdefaultencoding())
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--force-reinstall",
+            "--no-index",
+            "--no-deps",
+            *(
+                str(wheelhouse / dep)
+                for dep in files.split("\n")
+                if dep.endswith(".whl")
+            ),
+        ]
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(prog="auto-install-deps")
+    parser.add_argument(
+        "--no-cache",
+        help="Resets the underlying wheelhouse cache. This is useful if there is a change in the dependencies.",
+        action="store_true",
+    )
+    args = parser.parse_args()
+    requirements_dir = (Path(__file__).parent).absolute()
+
+    install_evaluation_deps(requirements_dir, args.no_cache)

--- a/competition/evaluation/evaluate.py
+++ b/competition/evaluation/evaluate.py
@@ -221,14 +221,22 @@ if __name__ == "__main__":
     )
 
     # Install requirements.
-    req_file = os.path.join(submit_dir, "requirements.txt")
-    sys.path.insert(0, submit_dir)
-
     if args.auto_install_pip_deps:
         from auto_install import install_evaluation_deps
 
         install_evaluation_deps(Path(root_path), True)
 
+    try:
+        import smarts
+        import bubble_env_contrib
+    except:
+        raise ImportError(
+            "Missing evaluation dependencies. Please refer to the Setup section of README.md"
+            " as to how to install the dependencies or use the `--auto_install_pip_deps` flag."
+        )
+
+    req_file = os.path.join(submit_dir, "requirements.txt")
+    sys.path.insert(0, submit_dir)
     subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", req_file])
 
     import gym

--- a/competition/evaluation/evaluate.py
+++ b/competition/evaluation/evaluate.py
@@ -202,6 +202,11 @@ if __name__ == "__main__":
         help="Flag to set when running evaluate locally. Defaults to False.",
         action="store_true",
     )
+    parser.add_argument(
+        "--auto_install_pip_deps",
+        help="Automatically install dependencies through pip.",
+        action="store_true",
+    )
     args = parser.parse_args()
 
     # Get directories.
@@ -218,16 +223,12 @@ if __name__ == "__main__":
     # Install requirements.
     req_file = os.path.join(submit_dir, "requirements.txt")
     sys.path.insert(0, submit_dir)
-    subprocess.check_call(
-        [
-            sys.executable,
-            "-m",
-            "pip",
-            "install",
-            "smarts[camera-obs] @ git+https://github.com/huawei-noah/SMARTS.git@comp-1",
-            "bubble_env @ git+https://bitbucket.org/malban/bubble_env.git@master",
-        ]
-    )
+
+    if args.auto_install_pip_deps:
+        from auto_install import install_evaluation_deps
+
+        install_evaluation_deps(Path(root_path), True)
+
     subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", req_file])
 
     import gym

--- a/competition/evaluation/requirements.txt
+++ b/competition/evaluation/requirements.txt
@@ -1,0 +1,2 @@
+smarts[camera-obs] @ git+https://github.com/huawei-noah/SMARTS.git@comp-1
+bubble_env @ git+https://bitbucket.org/malban/bubble_env.git@master

--- a/competition/evaluation/requirements.txt
+++ b/competition/evaluation/requirements.txt
@@ -1,2 +1,2 @@
 smarts[camera-obs] @ git+https://github.com/huawei-noah/SMARTS.git@comp-1
-bubble_env @ git+https://bitbucket.org/malban/bubble_env.git@master
+bubble_env @ git+https://malban:ATBByMTp2W2MnVGsxHBYwEbNsVca00608BD5@bitbucket.org/malban/bubble_env.git@master


### PR DESCRIPTION
This addresses the hidden requirement to use `git lfs` for the `bubble_env` evaluation and a cache to manage the bandwidth cost of re-downloading the dataset each time.

Paired to this is the requirement to update codalab and the competition docker image.