### PR TITLE
Add alternative for grpc if timeout occurs

### DIFF
--- a/smarts/core/agent_buffer.py
+++ b/smarts/core/agent_buffer.py
@@ -32,8 +32,6 @@ class AgentBuffer(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def acquire_agent(
-        self, retries: int = 3, timeout: Optional[float] = None
-    ) -> BufferAgent:
+    def acquire_agent(self, timeout: Optional[float] = None) -> BufferAgent:
         """Get an agent from the buffer."""
         raise NotImplementedError

--- a/smarts/core/buffer_agent.py
+++ b/smarts/core/buffer_agent.py
@@ -25,6 +25,12 @@ from abc import abstractmethod
 from smarts.zoo.agent_spec import AgentSpec
 
 
+class RemoteAgentException(Exception):
+    """An exception describing issues relating to maintaining connection with a remote agent."""
+
+    pass
+
+
 class BufferAgent(metaclass=abc.ABCMeta):
     """An agent which is part of a buffer."""
 

--- a/smarts/core/heterogenous_agent_buffer.py
+++ b/smarts/core/heterogenous_agent_buffer.py
@@ -43,6 +43,7 @@ class HeterogenousAgentBuffer(AgentBuffer):
 
     @property
     def backup_buffer(self):
+        """The buffer fallback if the regular buffer fails."""
         if self._backup_buffer == None:
             from smarts.core.local_agent_buffer import LocalAgentBuffer
 

--- a/smarts/core/local_agent_buffer.py
+++ b/smarts/core/local_agent_buffer.py
@@ -36,8 +36,6 @@ class LocalAgentBuffer(AgentBuffer):
     def destroy(self):
         pass
 
-    def acquire_agent(
-        self, retries: int = 3, timeout: Optional[float] = None
-    ) -> BufferAgent:
+    def acquire_agent(self, timeout: Optional[float] = None) -> BufferAgent:
         localAgent = LocalAgent()
         return localAgent

--- a/smarts/core/remote_agent.py
+++ b/smarts/core/remote_agent.py
@@ -24,15 +24,9 @@ from typing import Tuple
 import cloudpickle
 import grpc
 
-from smarts.core.buffer_agent import BufferAgent
+from smarts.core.buffer_agent import BufferAgent, RemoteAgentException
 from smarts.zoo import manager_pb2, manager_pb2_grpc, worker_pb2, worker_pb2_grpc
 from smarts.zoo.agent_spec import AgentSpec
-
-
-class RemoteAgentException(Exception):
-    """An exception describing issues relating to maintaining connection with a remote agent."""
-
-    pass
 
 
 class RemoteAgent(BufferAgent):


### PR DESCRIPTION
This should provide an alternative to keep the simulation going if `grpc` starts to mess up.