### PR TITLE
Ensure ego observation road, lane, lane index fields are filled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Truncated all waypoint paths returned by `FormatObs` wrapper to be of the same length. Previously, variable waypoint-path lengths caused inhomogenous shape error in numpy array.
 - Fixed a bug where traffic providers would leak across instances due to the ~~(awful design decision of python)~~ reference types defaults in arguments sharing across instances.
 - Fixed minor bugs causing some Waymo maps not to load properly.
+- Fixed issue where the ego vehicle observation was returning `None` for the nearby `lane_id`, `lane_index`, and `road_id`. These now default to constants `off_lane`, `-1`, and `off_road` respectively. 
 
 ## [0.6.1]
 ### Added

--- a/smarts/core/sensors.py
+++ b/smarts/core/sensors.py
@@ -43,9 +43,9 @@ from .plan import Mission, Via
 
 logger = logging.getLogger(__name__)
 
-EGO_LANE_ID_CONSTANT = "off_lane"
-EGO_ROAD_ID_CONSTANT = "off_road"
-EGO_LANE_INDEX_CONSTANT = -1
+LANE_ID_CONSTANT = "off_lane"
+ROAD_ID_CONSTANT = "off_road"
+LANE_INDEX_CONSTANT = -1
 
 
 class VehicleObservation(NamedTuple):
@@ -252,9 +252,9 @@ def _make_vehicle_observation(road_map, neighborhood_vehicle):
         nv_lane_id = nv_lane.lane_id
         nv_lane_index = nv_lane.index
     else:
-        nv_road_id = None
-        nv_lane_id = None
-        nv_lane_index = None
+        nv_road_id = ROAD_ID_CONSTANT
+        nv_lane_id = LANE_ID_CONSTANT
+        nv_lane_index = LANE_INDEX_CONSTANT
 
     return VehicleObservation(
         id=neighborhood_vehicle.actor_id,
@@ -302,7 +302,7 @@ class Sensors:
                 veh_obs = _make_vehicle_observation(sim.road_map, nv)
                 nv_lane_pos = None
                 if (
-                    veh_obs.lane_id is not None
+                    veh_obs.lane_id is not LANE_ID_CONSTANT
                     and vehicle.subscribed_to_lane_position_sensor
                 ):
                     nv_lane_pos = vehicle.lane_position_sensor(
@@ -330,9 +330,9 @@ class Sensors:
             if vehicle.subscribed_to_lane_position_sensor:
                 ego_lane_pos = vehicle.lane_position_sensor(closest_lane, vehicle)
         else:
-            ego_lane_id = EGO_LANE_ID_CONSTANT
-            ego_lane_index = EGO_LANE_INDEX_CONSTANT
-            ego_road_id = EGO_ROAD_ID_CONSTANT
+            ego_lane_id = LANE_ID_CONSTANT
+            ego_lane_index = LANE_INDEX_CONSTANT
+            ego_road_id = ROAD_ID_CONSTANT
         ego_vehicle_state = vehicle.state
 
         acceleration_params = {

--- a/smarts/core/sensors.py
+++ b/smarts/core/sensors.py
@@ -43,6 +43,10 @@ from .plan import Mission, Via
 
 logger = logging.getLogger(__name__)
 
+EGO_LANE_ID_CONSTANT = "off_lane"
+EGO_ROAD_ID_CONSTANT = "off_road"
+EGO_LANE_INDEX_CONSTANT = -1
+
 
 class VehicleObservation(NamedTuple):
     """Perceived vehicle information."""
@@ -326,9 +330,9 @@ class Sensors:
             if vehicle.subscribed_to_lane_position_sensor:
                 ego_lane_pos = vehicle.lane_position_sensor(closest_lane, vehicle)
         else:
-            ego_lane_id = None
-            ego_lane_index = None
-            ego_road_id = None
+            ego_lane_id = EGO_LANE_ID_CONSTANT
+            ego_lane_index = EGO_LANE_INDEX_CONSTANT
+            ego_road_id = EGO_ROAD_ID_CONSTANT
         ego_vehicle_state = vehicle.state
 
         acceleration_params = {


### PR DESCRIPTION
This addresses an issue where there are values in the ego observation that are not optional but return `None`.