### PR TITLE
Avoid lane_index=None in neighbours.

### DIFF
--- a/smarts/core/sensors.py
+++ b/smarts/core/sensors.py
@@ -43,9 +43,9 @@ from .plan import Mission, Via
 
 logger = logging.getLogger(__name__)
 
-EGO_LANE_ID_CONSTANT = "off_lane"
-EGO_ROAD_ID_CONSTANT = "off_road"
-EGO_LANE_INDEX_CONSTANT = -1
+LANE_ID_CONSTANT = "off_lane"
+ROAD_ID_CONSTANT = "off_road"
+LANE_INDEX_CONSTANT = -1
 
 
 class VehicleObservation(NamedTuple):
@@ -252,9 +252,9 @@ def _make_vehicle_observation(road_map, neighborhood_vehicle):
         nv_lane_id = nv_lane.lane_id
         nv_lane_index = nv_lane.index
     else:
-        nv_road_id = None
-        nv_lane_id = None
-        nv_lane_index = None
+        nv_road_id = ROAD_ID_CONSTANT
+        nv_lane_id = LANE_ID_CONSTANT
+        nv_lane_index = LANE_INDEX_CONSTANT
 
     return VehicleObservation(
         id=neighborhood_vehicle.actor_id,
@@ -302,7 +302,7 @@ class Sensors:
                 veh_obs = _make_vehicle_observation(sim.road_map, nv)
                 nv_lane_pos = None
                 if (
-                    veh_obs.lane_id is not None
+                    veh_obs.lane_id >= 0
                     and vehicle.subscribed_to_lane_position_sensor
                 ):
                     nv_lane_pos = vehicle.lane_position_sensor(
@@ -330,9 +330,9 @@ class Sensors:
             if vehicle.subscribed_to_lane_position_sensor:
                 ego_lane_pos = vehicle.lane_position_sensor(closest_lane, vehicle)
         else:
-            ego_lane_id = EGO_LANE_ID_CONSTANT
-            ego_lane_index = EGO_LANE_INDEX_CONSTANT
-            ego_road_id = EGO_ROAD_ID_CONSTANT
+            ego_lane_id = LANE_ID_CONSTANT
+            ego_lane_index = LANE_INDEX_CONSTANT
+            ego_road_id = ROAD_ID_CONSTANT
         ego_vehicle_state = vehicle.state
 
         acceleration_params = {


### PR DESCRIPTION
+ An extension to #1574 
+ Avoid `lane_index=None` in `VehicleObservation.lane_index`