### PR TITLE
Set initial camera position when CameraSensor is created

### DIFF
--- a/smarts/core/sensors.py
+++ b/smarts/core/sensors.py
@@ -743,6 +743,7 @@ class CameraSensor(Sensor):
             height,
             resolution,
         )
+        self._follow_vehicle()  # ensure we have a correct initial camera position
 
     def teardown(self):
         self._camera.teardown()


### PR DESCRIPTION
Fixes #1619.

In the `traffic_histories_to_observations.py` example, the first RGB image was not rendered correctly because the observations are taken before the camera sensor calls `step()` and moves the camera to the correct position.