### PR TITLE
Fix `macos` test (naive)

### DIFF
--- a/.github/workflows/ci-auto-commit-mac.yml
+++ b/.github/workflows/ci-auto-commit-mac.yml
@@ -17,11 +17,15 @@ jobs:
         uses: actions/checkout@v2   
         with:
           ref: develop 
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
       - name: Setup Python
         run: |
           brew update
-          brew install python@3.7
-          brew unlink python@3.9
+          brew install python@3.8
+          brew unlink python@3.10
           brew link --force --overwrite python@3.7
       - name: Update requirements
         run: |

--- a/.github/workflows/ci-auto-commit-mac.yml
+++ b/.github/workflows/ci-auto-commit-mac.yml
@@ -21,16 +21,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.8"
-      - name: Setup Python
-        run: |
-          brew update
-          brew install python@3.8
-          brew unlink python@3.10
-          brew link --force --overwrite python@3.7
       - name: Update requirements
         run: |
           cd $GITHUB_WORKSPACE
-          python3.7 -m venv ${{env.venv_dir}}
+          python3.8 -m venv ${{env.venv_dir}}
           . ${{env.venv_dir}}/bin/activate
           pip install --upgrade pip wheel
           pip install .[camera-obs,rllib,test,torch,train]


### PR DESCRIPTION
- According to https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md#language-and-runtime the version of python on the `macos-11` runner is `python3.10`. 
- Actions allows for setup of python in a different way as indicated here: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python