### PR TITLE
Fix local traffic

### DIFF
--- a/smarts/core/local_traffic_provider.py
+++ b/smarts/core/local_traffic_provider.py
@@ -68,7 +68,6 @@ class LocalTrafficProvider(TrafficProvider):
 
     def __init__(self):
         self._logger = logging.getLogger(self.__class__.__name__)
-        self._logger.setLevel(logging.DEBUG)
         self._sim = None
         self._scenario = None
         self.road_map: RoadMap = None
@@ -457,7 +456,6 @@ class _TrafficActor:
 
     def __init__(self, flow: Dict[str, Any], owner: LocalTrafficProvider):
         self._logger = logging.getLogger(self.__class__.__name__)
-        self._logger.setLevel(logging.DEBUG)
         self._owner = weakref.ref(owner)
 
         self._state = None

--- a/smarts/core/local_traffic_provider.py
+++ b/smarts/core/local_traffic_provider.py
@@ -1130,7 +1130,7 @@ class _TrafficActor:
                 continue
             # if I can't safely reach the lane, don't consider it
             change_time = 0
-            if idx > 0:
+            if abs(idx - my_idx) > 1:
                 change_time, can_cross = self._crossing_time_into(idx)
                 if not can_cross:
                     continue

--- a/smarts/core/local_traffic_provider.py
+++ b/smarts/core/local_traffic_provider.py
@@ -298,7 +298,8 @@ class LocalTrafficProvider(TrafficProvider):
             self._relinquish_actor(actor.state)
         for actor_id in dones - removed:
             actor = self._my_actors.get(actor_id)
-            sim.provider_removing_actor(self, actor.state)
+            if actor:
+                sim.provider_removing_actor(self, actor.state)
             # The following is not really necessary due to the above calling teardown(),
             # but it doesn't hurt...
             if actor_id in self._my_actors:

--- a/smarts/core/local_traffic_provider.py
+++ b/smarts/core/local_traffic_provider.py
@@ -875,7 +875,7 @@ class _TrafficActor:
             len_to_end = self._route.distance_from(rt_oln)
             if len_to_end is None:
                 continue
-            lbc = owner.lane_bumpers_cache.get(ogl)
+            lbc = owner._lane_bumpers_cache.get(ogl)
             if lbc:
                 fi = 0
                 while fi < len(lbc):

--- a/smarts/scenarios/straight/3lane_cut_in/scenario.py
+++ b/smarts/scenarios/straight/3lane_cut_in/scenario.py
@@ -77,7 +77,7 @@ for name, routes in enumerate(route_comb):
                     end=("gneE3", end_lane, "max"),
                 ),
                 # Random flow rate, between x and y vehicles per minute.
-                rate=40* random.uniform(10, 20),
+                rate=60* random.uniform(6, 14),
                 # Random flow start time, between x and y seconds.
                 begin=random.uniform(0, 5),
                 # For an episode with maximum_episode_steps=3000 and step

--- a/smarts/scenarios/straight/3lane_cut_in/scenario.py
+++ b/smarts/scenarios/straight/3lane_cut_in/scenario.py
@@ -42,10 +42,7 @@ normal = TrafficActor(
     speed=Distribution(sigma=0.1, mean=1.5),
     min_gap=Distribution(sigma=0, mean=1),
     lane_changing_model=SmartsLaneChangingModel(
-        cutin_prob=1,
-        assertive=10,
-        dogmatic=True,
-        slow_down_after=0.5
+        cutin_prob=1, assertive=10, dogmatic=True, slow_down_after=0.5
     ),
 )
 
@@ -77,7 +74,7 @@ for name, routes in enumerate(route_comb):
                     end=("gneE3", end_lane, "max"),
                 ),
                 # Random flow rate, between x and y vehicles per minute.
-                rate=60* random.uniform(6, 14),
+                rate=60 * random.uniform(6, 14),
                 # Random flow start time, between x and y seconds.
                 begin=random.uniform(0, 5),
                 # For an episode with maximum_episode_steps=3000 and step

--- a/smarts/scenarios/straight/3lane_cut_in/scenario.py
+++ b/smarts/scenarios/straight/3lane_cut_in/scenario.py
@@ -38,13 +38,14 @@ from smarts.sstudio.types import (
 
 normal = TrafficActor(
     name="car",
-    # sigma=1,
-    speed=Distribution(sigma=0.3, mean=1),
-    # min_gap=Distribution(sigma=0, mean=1),
+    sigma=1,
+    speed=Distribution(sigma=0.1, mean=1.5),
+    min_gap=Distribution(sigma=0, mean=1),
     lane_changing_model=SmartsLaneChangingModel(
         cutin_prob=1,
-        assertive=5,
+        assertive=10,
         dogmatic=True,
+        slow_down_after=0.5
     ),
 )
 
@@ -76,7 +77,7 @@ for name, routes in enumerate(route_comb):
                     end=("gneE3", end_lane, "max"),
                 ),
                 # Random flow rate, between x and y vehicles per minute.
-                rate=30 * random.uniform(10, 20),
+                rate=40* random.uniform(10, 20),
                 # Random flow start time, between x and y seconds.
                 begin=random.uniform(0, 5),
                 # For an episode with maximum_episode_steps=3000 and step
@@ -92,11 +93,11 @@ for name, routes in enumerate(route_comb):
     )
 
 
-route = Route(begin=("gneE3", 0, 10), end=("gneE3", 0, "max"))
+route = Route(begin=("gneE3", 1, 10), end=("gneE3", 1, "max"))
 ego_missions = [
     Mission(
         route=route,
-        start_time=15,  # Delayed start, to ensure road has prior traffic.
+        start_time=20,  # Delayed start, to ensure road has prior traffic.
     )
 ]
 

--- a/smarts/scenarios/straight/3lane_cut_in/scenario.py
+++ b/smarts/scenarios/straight/3lane_cut_in/scenario.py
@@ -38,12 +38,12 @@ from smarts.sstudio.types import (
 
 normal = TrafficActor(
     name="car",
-    sigma=1,
-    speed=Distribution(sigma=0.3, mean=1.5),
-    min_gap=Distribution(sigma=0, mean=1),
+    # sigma=1,
+    speed=Distribution(sigma=0.3, mean=1),
+    # min_gap=Distribution(sigma=0, mean=1),
     lane_changing_model=SmartsLaneChangingModel(
         cutin_prob=1,
-        assertive=10,
+        assertive=5,
         dogmatic=True,
     ),
 )
@@ -57,7 +57,7 @@ route_opt = [
 
 # Traffic combinations = 3C2 + 3C3 = 3 + 1 = 4
 # Repeated traffic combinations = 4 * 100 = 400
-min_flows = 2
+min_flows = 3
 max_flows = 3
 route_comb = [
     com
@@ -76,7 +76,7 @@ for name, routes in enumerate(route_comb):
                     end=("gneE3", end_lane, "max"),
                 ),
                 # Random flow rate, between x and y vehicles per minute.
-                rate=60 * random.uniform(15, 25),
+                rate=30 * random.uniform(10, 20),
                 # Random flow start time, between x and y seconds.
                 begin=random.uniform(0, 5),
                 # For an episode with maximum_episode_steps=3000 and step


### PR DESCRIPTION
- This fixes two issues with the `local_traffic_provider`
  - Issue 1: Vehicles were stopping randomly. This was due to an optimization that was storing old caches individually in the internal traffic actors.
  - Issue 2: Newest actor was removed when an actor left the traffic provider. Similar to previous issue this had to do with using a local reference from a loop rather than recovering the agent from the id(which did no cause an error from a quirk of python scope rules.)
  - Minor issue: Vehicles that recently enter now hold lane for a short amount of time.


This should be merged into both `develop` and `comp-1` asap.