### PR TITLE
Waymo - bugfixes and improved error messages

### DIFF
--- a/smarts/core/waymo_map.py
+++ b/smarts/core/waymo_map.py
@@ -46,6 +46,7 @@ from waymo_open_dataset.protos.map_pb2 import (
 )
 
 from smarts.sstudio.types import MapSpec
+from smarts.waymo.waymo_utils import WaymoDatasetError
 
 from .coordinates import BoundingBox, Heading, Point, Pose, RefLinePoint
 from .lanepoints import LanePoints, LinkedLanePoint
@@ -89,12 +90,6 @@ class _GLBData:
         """Generate a geometry file."""
         with open(output_path, "wb") as f:
             f.write(self._bytes)
-
-
-class WaymoDatasetError(Exception):
-    """Represents an error related to the data in a Waymo dataset scenario."""
-
-    pass
 
 
 class WaymoMap(RoadMapWithCaches):

--- a/smarts/sstudio/genhistories.py
+++ b/smarts/sstudio/genhistories.py
@@ -39,7 +39,7 @@ from smarts.core.utils.math import (
     min_angles_difference_signed,
     vec_to_radians,
 )
-from smarts.core.waymo_map import WaymoDatasetError
+from smarts.waymo.waymo_utils import WaymoDatasetError
 from smarts.sstudio import types
 
 try:

--- a/smarts/sstudio/genhistories.py
+++ b/smarts/sstudio/genhistories.py
@@ -39,6 +39,7 @@ from smarts.core.utils.math import (
     min_angles_difference_signed,
     vec_to_radians,
 )
+from smarts.core.waymo_map import WaymoDatasetError
 from smarts.sstudio import types
 
 try:
@@ -864,9 +865,10 @@ class Waymo(_TrajectoryDataset):
                 time_expected = round(j * self._dt_sec, 3)
                 time_error = time_current - time_expected
 
-                assert (
-                    abs(time_error) < self._dt_sec
-                ), "Waymo data deviates by more than the size of 1 timestep. This likely indicates a gap in the dataset."
+                if round(abs(time_error), 1) >= self._dt_sec:
+                    raise WaymoDatasetError(
+                        f"[{scenario.scenario_id}] Waymo data deviates by more than the size of 1 timestep. This likely indicates a gap in the dataset."
+                    )
 
                 if not row["valid"] or time_error == 0:
                     continue

--- a/smarts/waymo/waymo_utils.py
+++ b/smarts/waymo/waymo_utils.py
@@ -24,9 +24,12 @@ import numpy as np
 from matplotlib import pyplot as plt
 from matplotlib.animation import FuncAnimation
 from matplotlib.lines import Line2D
+from smarts.core.utils.file import read_tfrecord_file
+
+# pytype: disable=import-error
 from waymo_open_dataset.protos import scenario_pb2
 
-from smarts.core.utils.file import read_tfrecord_file
+# pytype: enable=import-error
 
 
 class WaymoDatasetError(Exception):

--- a/smarts/waymo/waymo_utils.py
+++ b/smarts/waymo/waymo_utils.py
@@ -264,9 +264,9 @@ def _plot_trajectories(
 
 
 def get_tfrecord_info(tfrecord_file: str) -> Dict[str, Dict[str, Any]]:
+    """Extract info about each scenario in the TFRecord file."""
     from waymo_open_dataset.protos import scenario_pb2
 
-    """Extract info about each scenario in the TFRecord file."""
     scenarios = dict()
     records = read_tfrecord_file(tfrecord_file)
     for record in records:

--- a/smarts/waymo/waymo_utils.py
+++ b/smarts/waymo/waymo_utils.py
@@ -27,7 +27,13 @@ from matplotlib.lines import Line2D
 from waymo_open_dataset.protos import scenario_pb2
 
 from smarts.core.utils.file import read_tfrecord_file
-from smarts.core.waymo_map import WaymoMap
+
+
+class WaymoDatasetError(Exception):
+    """Represents an error related to the data in a Waymo dataset scenario."""
+
+    pass
+
 
 MAP_HANDLES = [
     Line2D([0], [0], linestyle=":", color="gray", label="Lane Polyline"),
@@ -293,6 +299,8 @@ def plot_scenario(
 ):
     """Plot the map features of a Waymo scenario,
     and optionally plot/animate the vehicle trajectories."""
+    from smarts.core.waymo_map import WaymoMap
+
     source = f"{tfrecord_file}#{scenario_id}"
     scenario = WaymoMap.parse_source_to_scenario(source)
 

--- a/smarts/waymo/waymo_utils.py
+++ b/smarts/waymo/waymo_utils.py
@@ -26,11 +26,6 @@ from matplotlib.animation import FuncAnimation
 from matplotlib.lines import Line2D
 from smarts.core.utils.file import read_tfrecord_file
 
-# pytype: disable=import-error
-from waymo_open_dataset.protos import scenario_pb2
-
-# pytype: enable=import-error
-
 
 class WaymoDatasetError(Exception):
     """Represents an error related to the data in a Waymo dataset scenario."""
@@ -187,7 +182,7 @@ def _plot_map_features(map_features: Dict):
         )
 
 
-def _get_map_features(scenario: scenario_pb2.Scenario) -> Dict[str, List]:
+def _get_map_features(scenario) -> Dict[str, List]:
     map_features = defaultdict(lambda: [])
     for i in range(len(scenario.map_features)):
         map_feature = scenario.map_features[i]
@@ -197,9 +192,7 @@ def _get_map_features(scenario: scenario_pb2.Scenario) -> Dict[str, List]:
     return map_features
 
 
-def _get_trajectories(
-    scenario: scenario_pb2.Scenario,
-) -> Dict[int, Dict[str, Any]]:
+def _get_trajectories(scenario) -> Dict[int, Dict[str, Any]]:
     num_steps = len(scenario.timestamps_seconds)
     trajectories = defaultdict(lambda: {"positions": [None] * num_steps})
     for i in range(len(scenario.tracks)):
@@ -271,6 +264,8 @@ def _plot_trajectories(
 
 
 def get_tfrecord_info(tfrecord_file: str) -> Dict[str, Dict[str, Any]]:
+    from waymo_open_dataset.protos import scenario_pb2
+
     """Extract info about each scenario in the TFRecord file."""
     scenarios = dict()
     records = read_tfrecord_file(tfrecord_file)


### PR DESCRIPTION
Addresses #1631

- Fix bug related to glb generation in Waymo maps (the `assert lane_to_left` error)
- Introduce custom `WaymoDatasetError` exception which will be raised when trying to load a Waymo scenario that SMARTS is not able to handle. Currently there are 2 possible reasons this could be raised: either the recorded timesteps deviate by more that 1 timestep (which is not supported by the traffic history provider), or the map contains lanes with single-point polylines (which is not supported by the Waymo map class). Any other exception raised related to Waymo should be considered a bug.

This is intended to make it more explicit when a Waymo scenario should be ignored by detecting these issues when building the scenario (rather than waiting for them to pop up during runtime). However, it now appears these cases are more common than we previously thought -- around 30% of Waymo scenarios have one of these issues.