### PR TITLE
Patch orphaned social agents

### DIFF
--- a/smarts/core/agents_provider.py
+++ b/smarts/core/agents_provider.py
@@ -125,11 +125,10 @@ class AgentsProvider(Provider):
         self._remove_actors_without_actions(agent_actions)
         agents_without_actors = agent_actions.keys() - self._my_agent_actors.keys()
         if agents_without_actors:
-            if self._log.level >= logging.ERROR:
-                self._log.error(
-                    "actions specified for an agent without an actor: %s. Cleaning up social agents.",
-                    agents_without_actors,
-                )
+            self._log.error(
+                "actions specified for an agent without an actor: %s. Cleaning up social agents.",
+                agents_without_actors,
+            )
             orphaned_social_agents = (
                 self._agent_manager.social_agent_ids & agents_without_actors
             )


### PR DESCRIPTION
- Bubble agents occasionally get orphaned.
- This change-set converts the assertion to an error log and automatically cleans up orphaned social agents.