### PR TITLE
Bugfix trip meter sensor [closes #1656]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Fixed a bug where `Vehicle.bounding_box` was mirrored over Y causing on shoulder events to fire inappropriately.
 - Fixed an issue where the ego and neighbour vehicle observation was returning `None` for the nearby `lane_id`, `lane_index`, and `road_id`. These now default to constants `off_lane`, `-1`, and `off_road` respectively.
 - Fixed a bug where bubble agents would stick around and to try to get observations even after being disassociated from a vehicle.
+- Fixed a bug with the `TripMeterSensor` that was not using a unit direction vector to calculate trip distance against current route.
 
 ## [0.6.1]
 ### Added

--- a/smarts/core/sensors.py
+++ b/smarts/core/sensors.py
@@ -973,6 +973,7 @@ class TripMeterSensor(Sensor):
         self._wps_for_distance: List[Waypoint] = []
         self._dist_travelled = 0.0
         self._last_dist_travelled = 0.0
+        self._last_actor_position = None
 
     def update_distance_wps_record(self, waypoint_paths):
         """Append a waypoint to the history if it is not already counted."""
@@ -992,9 +993,10 @@ class TripMeterSensor(Sensor):
         )
 
         if not self._wps_for_distance:
+            self._last_actor_position = self._vehicle.pose.position
             if should_count_wp:
                 self._wps_for_distance.append(new_wp)
-            return
+            return  # sensor does not have enough history
         most_recent_wp = self._wps_for_distance[-1]
 
         threshold_for_counting_wp = 0.5  # meters from last tracked waypoint
@@ -1003,19 +1005,31 @@ class TripMeterSensor(Sensor):
             and should_count_wp
         ):
             self._wps_for_distance.append(new_wp)
-        self._dist_travelled += TripMeterSensor._compute_additional_dist_travelled(
-            most_recent_wp, new_wp, self._vehicle.pose
+        additional_distance = TripMeterSensor._compute_additional_dist_travelled(
+            most_recent_wp,
+            new_wp,
+            self._vehicle.pose.position,
+            self._last_actor_position,
         )
+        self._dist_travelled += additional_distance
+        self._last_actor_position = self._vehicle.pose.position
 
     @staticmethod
     def _compute_additional_dist_travelled(
-        recent_wp: Waypoint, new_waypoint: Waypoint, vehicle_pose: Pose
+        recent_wp: Waypoint,
+        new_waypoint: Waypoint,
+        vehicle_position: np.ndarray,
+        last_vehicle_pos: np.ndarray,
     ):
+        # old waypoint minus current ahead waypoint
         wp_disp_vec = new_waypoint.pos - recent_wp.pos
-        pose_disp_vec = vehicle_pose.position[:2] - recent_wp.pos[:2]
-        direction = np.sign(np.dot(pose_disp_vec, wp_disp_vec))
-        distance = np.linalg.norm(wp_disp_vec)
-        return direction * distance
+        # make unit vector
+        wp_unit_vec = wp_disp_vec / np.linalg.norm(wp_disp_vec)
+        # vehicle position minus last vehicle position
+        position_disp_vec = vehicle_position[:2] - last_vehicle_pos[:2]
+        # distance of vehicle between last and current wp
+        distance = np.dot(position_disp_vec, wp_unit_vec)
+        return distance
 
     def __call__(self, increment=False):
         if increment:

--- a/smarts/core/sensors.py
+++ b/smarts/core/sensors.py
@@ -999,6 +999,7 @@ class TripMeterSensor(Sensor):
             return  # sensor does not have enough history
         most_recent_wp = self._wps_for_distance[-1]
 
+        # TODO: Instead of storing a waypoint every 0.5m just find the next one immediately
         threshold_for_counting_wp = 0.5  # meters from last tracked waypoint
         if (
             np.linalg.norm(new_wp.pos - most_recent_wp.pos) > threshold_for_counting_wp

--- a/smarts/core/sensors.py
+++ b/smarts/core/sensors.py
@@ -1025,7 +1025,7 @@ class TripMeterSensor(Sensor):
         # old waypoint minus current ahead waypoint
         wp_disp_vec = new_waypoint.pos - recent_wp.pos
         # make unit vector
-        wp_unit_vec = wp_disp_vec / np.linalg.norm(wp_disp_vec)
+        wp_unit_vec = wp_disp_vec / (np.linalg.norm(wp_disp_vec) or 1)
         # vehicle position minus last vehicle position
         position_disp_vec = vehicle_position[:2] - last_vehicle_pos[:2]
         # distance of vehicle between last and current wp


### PR DESCRIPTION
Wrong vectors were generated and dot product needed to be applied from the vehicle displacement vector onto the **unit** direction vector of the waypoints.
![image](https://user-images.githubusercontent.com/8764693/193957663-39350181-491b-4912-ae58-3f141643cd56.png)