### PR TITLE
Add wheel to pyproject.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=41.0.0"]
+requires = ["setuptools>=41.0.0","wheel"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Another simple update that installs wheel using the `pyproject.toml` build dependencies.