### PR TITLE
Fixed iss1587 smarts simulation crash

### DIFF
--- a/smarts/core/local_traffic_provider.py
+++ b/smarts/core/local_traffic_provider.py
@@ -1237,6 +1237,7 @@ class _TrafficActor:
     def _slow_for_curves(self):
         # XXX:  this may be too expensive.  if so, we'll need to precompute curvy spots for routes
         lookahead = math.ceil(1 + math.log(self._target_speed))
+        lookahead = max(1, lookahead)
         # we round the offset in an attempt to reduce the unique hits on the LRU caches...
         rounded_offset = round(self._offset)
         radius = self._lane.curvature_radius_at_offset(rounded_offset, lookahead)


### PR DESCRIPTION
This PR attempts to fix https://github.com/huawei-noah/SMARTS/issues/1587. Currently the `lookahead` in `smarts.core.road_map.curevature_radius_at_offset` only accept `lookahead>=1`, but `lookahead` is calculated by `lookahead = math.ceil(1 + math.log(self._target_speed))` in `smarts.core.local_traffic_provider._slow_for_curves`. The error will occur when the `self.target_speed` is very small which make the ` math.log(self._target_speed)<-1`. This will cause `lookahead` to be negative and thus raise the assertion error. I added code that set `lookahead=1` when it is negative due to small `self.target_speed` which ensure the `smarts.core.road_map.curevature_radius_at_offset`  doesn't raise assertion error.