### PR TITLE
Update ubuntu workers to 20.04.

### DIFF
--- a/.github/workflows/ci-auto-commit-linux.yml
+++ b/.github/workflows/ci-auto-commit-linux.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   auto-commit-linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     container: huaweinoah/smarts:v0.4.18-minimal
     steps:

--- a/.github/workflows/ci-base-tests-linux.yml
+++ b/.github/workflows/ci-base-tests-linux.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   base-tests-linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     container: huaweinoah/smarts:v0.4.18-minimal
     strategy:

--- a/.github/workflows/ci-format.yml
+++ b/.github/workflows/ci-format.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   test-header:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     container: huaweinoah/smarts:v0.4.18-minimal
     steps:
@@ -19,7 +19,7 @@ jobs:
           make header-test
 
   test-docstring:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     container: huaweinoah/smarts:v0.4.18-minimal
     steps:
@@ -39,7 +39,7 @@ jobs:
             ./smarts ./envision ./baselines
 
   test-types:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository) && (github.ref != 'refs/heads/master')
     container: huaweinoah/smarts:v0.4.18-minimal
     steps:

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   test-benchmark:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: huaweinoah/smarts:v0.4.18-minimal
     steps:
       - name: Checkout

--- a/.github/workflows/ci-smarts-run-ultra-tests.yml
+++ b/.github/workflows/ci-smarts-run-ultra-tests.yml
@@ -12,7 +12,7 @@ on:
 # Should be the same as ci-ultra-tests
 jobs:
   test-base:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: huaweinoah/smarts:v0.4.13-minimal
     steps:
       - name: Checkout
@@ -45,7 +45,7 @@ jobs:
           pytest -v ./tests/
   
   test-package-via-setup:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: huaweinoah/smarts:v0.4.13-minimal
     steps:
       - name: Checkout
@@ -75,7 +75,7 @@ jobs:
           pytest -v ./tests/test_ultra_package.py
   
   test-package-via-wheel:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: huaweinoah/smarts:v0.4.13-minimal
     steps:
       - name: Checkout

--- a/.github/workflows/ci-test-learning.yml
+++ b/.github/workflows/ci-test-learning.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   test_learning:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: huaweinoah/smarts:v0.4.18-minimal
     steps:
       - name: Checkout

--- a/.github/workflows/ci-test-long-determinism.yml
+++ b/.github/workflows/ci-test-long-determinism.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   test_long_determinism:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: huaweinoah/smarts:v0.4.18-minimal
     steps:
       - name: Checkout

--- a/.github/workflows/ci-test-memory-growth.yml
+++ b/.github/workflows/ci-test-memory-growth.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   test_memory:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: huaweinoah/smarts:v0.4.18-minimal
     steps:
       - name: Checkout

--- a/.github/workflows/ci-ultra-tests.yml
+++ b/.github/workflows/ci-ultra-tests.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   test-heavy-base-tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     container: huaweinoah/smarts:v0.4.13-minimal
     steps:
@@ -56,7 +56,7 @@ jobs:
           ./tests/test_evaluate.py
 
   test-light-base-tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     container: huaweinoah/smarts:v0.4.13-minimal
     steps:
@@ -97,7 +97,7 @@ jobs:
           ./tests/test_tune.py
 
   test-package-via-setup:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     container: huaweinoah/smarts:v0.4.13-minimal
     steps:
@@ -130,7 +130,7 @@ jobs:
           ./tests/test_ultra_package.py \
 
   test-package-via-wheel:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     container: huaweinoah/smarts:v0.4.13-minimal
     steps:
@@ -168,7 +168,7 @@ jobs:
           ./tests/test_ultra_package.py \
 
   test-package-via-pypi:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     container: huaweinoah/smarts:v0.4.13-minimal
     steps:


### PR DESCRIPTION
This will address a change in the minimum worker version which removes `ubuntu-18.04`: https://github.com/actions/runner-images/issues/6002