### PR TITLE
Use resource location for path

### DIFF
--- a/envision/server.py
+++ b/envision/server.py
@@ -490,7 +490,7 @@ class MainHandler(tornado.web.RequestHandler):
 def make_app(scenario_dirs: Sequence, max_capacity_mb: float, debug: bool):
     """Create the envision web server application through composition of services."""
 
-    dist_path = Path(os.path.dirname(web_dist.__file__)).parent
+    dist_path = Path(os.path.dirname(web_dist.__file__)).absolute()
     logging.debug("Creating app with resources at: `%s`", dist_path)
     return tornado.web.Application(
         [

--- a/smarts/sstudio/scenario_construction.py
+++ b/smarts/sstudio/scenario_construction.py
@@ -109,7 +109,7 @@ def _install_requirements(scenario_root, log: Optional[Callable[[Any], None]] = 
     if requirements_txt.exists():
         import zoo.policies
 
-        path = Path(os.path.dirname(zoo.policies.__file__)).parent
+        path = Path(os.path.dirname(zoo.policies.__file__)).absolute()
         # Serve policies through the static file server, then kill after
         # we've installed scenario requirements
         pip_index_proc = subprocess.Popen(


### PR DESCRIPTION
The previous fix somehow passed check even though it was not working. This fixes file resolution for the StaticFileHandler used by envision to load files.