### PR TITLE
Remove a duplicate traffic light subscription call

### DIFF
--- a/smarts/core/sumo_traffic_simulation.py
+++ b/smarts/core/sumo_traffic_simulation.py
@@ -743,7 +743,6 @@ class SumoTrafficSimulation(TrafficProvider):
         return signal_states
 
     def _compute_provider_state(self) -> ProviderState:
-        self._traffic_light_states()
         return ProviderState(
             actors=self._compute_traffic_vehicles() + self._traffic_light_states()
         )


### PR DESCRIPTION
Method call was 2 lines up from the same call.