### PR TITLE
Use build for map spec to avoid error prone syntax.

### DIFF
--- a/cli/studio.py
+++ b/cli/studio.py
@@ -90,7 +90,7 @@ def _is_scenario_folder_to_build(path: str) -> bool:
     from smarts.sstudio.types import MapSpec
 
     map_spec = MapSpec(path)
-    road_map, _ = map_spec.builder_fn(map_spec)
+    road_map, _ = map_spec.build()
     return road_map is not None
 
 

--- a/smarts/core/scenario.py
+++ b/smarts/core/scenario.py
@@ -128,7 +128,7 @@ class Scenario:
         # shared in a multi-user mode.
         if not map_spec:
             map_spec = Scenario.discover_map(self._root, 1.0, default_lane_width)
-        self._road_map, self._road_map_hash = map_spec.builder_fn(map_spec)
+        self._road_map, self._road_map_hash = map_spec.build()
         self._scenario_hash = path2hash(str(Path(self.root_filepath).resolve()))
 
         os.makedirs(self._log_dir, exist_ok=True)
@@ -450,13 +450,13 @@ class Scenario:
     @staticmethod
     def build_map(scenario_root: str) -> Tuple[Optional[RoadMap], Optional[str]]:
         """Builds a road map from the given scenario's resources."""
-        # XXX: using a map builder_fn supplied by users is a security risk
+        # XXX: using a map build supplied by users is a security risk
         # as SMARTS will be executing the code "as is".  We are currently
         # trusting our users to not try to sabotage their own simulations.
         # In the future, this may need to be revisited if SMARTS is ever
         # shared in a multi-user mode.
         map_spec = Scenario.discover_map(scenario_root)
-        return map_spec.builder_fn(map_spec)
+        return map_spec.build()
 
     @staticmethod
     def discover_map(

--- a/smarts/sstudio/generators.py
+++ b/smarts/sstudio/generators.py
@@ -364,7 +364,7 @@ class TrafficGenerator:
                 map_spec = types.MapSpec(
                     self._road_network_path, lanepoint_spacing=lp_spacing
                 )
-        road_map, _ = map_spec.builder_fn(map_spec)
+        road_map, _ = map_spec.build()
         return road_map
 
     def _fill_in_gaps(self, route: types.Route) -> types.Route:

--- a/smarts/sstudio/genscenario.py
+++ b/smarts/sstudio/genscenario.py
@@ -463,7 +463,7 @@ def gen_traffic_histories(
         if hdsr.filter_off_map or hdsr.flip_y:
             if map_spec:
                 if not road_map:
-                    road_map, _ = map_spec.builder_fn(map_spec)
+                    road_map, _ = map_spec.build()
                 assert road_map
                 map_bbox = road_map.bounding_box
             else:

--- a/smarts/sstudio/scenario_construction.py
+++ b/smarts/sstudio/scenario_construction.py
@@ -63,7 +63,7 @@ def build_scenario(
     shift_to_origin = not allow_offset_map and not bool(traffic_histories)
 
     map_spec = Scenario.discover_map(scenario_root_str, shift_to_origin=shift_to_origin)
-    road_map, _ = map_spec.builder_fn(map_spec)
+    road_map, _ = map_spec.build()
     if not road_map:
         log(
             "No reference to a RoadNetwork file was found in {}, or one could not be created. "

--- a/smarts/sstudio/tests/test_generate.py
+++ b/smarts/sstudio/tests/test_generate.py
@@ -113,7 +113,7 @@ def _gen_map_from_spec(scenario_root: str, map_spec: MapSpec):
         gen_map(scenario_root, map_spec, output_dir=temp_dir)
         found_map_spec = Scenario.discover_map(temp_dir)
         assert found_map_spec
-        road_map = found_map_spec.builder_fn(found_map_spec)
+        road_map = found_map_spec.build()
         assert road_map
 
 

--- a/smarts/sstudio/types.py
+++ b/smarts/sstudio/types.py
@@ -382,6 +382,12 @@ class MapSpec:
     If not specified, this currently defaults to a function that creates
     SUMO road networks (get_road_map()) in smarts.core.default_map_builder."""
 
+    def build(self) -> Tuple[Optional[RoadMap], Optional[str]]:
+        """This should return an object derived from the RoadMap base class
+        and a hash that uniquely identifies it (changes to the hash should signify
+        that the map is different enough that map-related caches should be reloaded)."""
+        return self.builder_fn(self)
+
 
 @dataclass(frozen=True)
 class Route:


### PR DESCRIPTION
This avoids the potential issue of passing in an improper value to the map spec builder function.