### PR TITLE
Expose underlying map source

### DIFF
--- a/smarts/core/sensors.py
+++ b/smarts/core/sensors.py
@@ -234,6 +234,7 @@ class Observation:
     top_down_rgb: Optional[TopDownRGB]
     road_waypoints: Optional[RoadWaypoints]
     via_data: Vias
+    map_source: str
     signals: Optional[List[SignalObservation]] = None
 
 
@@ -460,6 +461,7 @@ class Sensors:
                 lidar_point_cloud=lidar,
                 road_waypoints=road_waypoints,
                 via_data=via_data,
+                map_source=sim.road_map.source,
                 signals=signals,
             ),
             done,


### PR DESCRIPTION
@saulfield This might address the common issue where people want access to the underling map data.

A similar request was made [here](https://github.com/huawei-noah/SMARTS/issues/1722) as well as internally.

I am thinking we may wish to also expose the scenario directory as well. That way we can allow users to generate the RoadMap directly through `Scenario.discover_scenario_roots`.
