### PR TITLE
Suppress TraCI Error on simulationStep

### DIFF
--- a/smarts/core/sumo_traffic_simulation.py
+++ b/smarts/core/sumo_traffic_simulation.py
@@ -466,6 +466,9 @@ class SumoTrafficSimulation(TrafficProvider):
         # we tell SUMO to step through dt more seconds of the simulation
         self._cumulative_sim_seconds += dt
         try:
+            # Suppress errors here, to avoid a known (and likely benign)
+            # error related to removing vehicles.
+            # See: https://github.com/huawei-noah/SMARTS/issues/1155
             with suppress_output(stderr=False):
                 self._traci_conn.simulationStep(self._cumulative_sim_seconds)
         except self._traci_exceptions as e:

--- a/smarts/core/sumo_traffic_simulation.py
+++ b/smarts/core/sumo_traffic_simulation.py
@@ -466,7 +466,8 @@ class SumoTrafficSimulation(TrafficProvider):
         # we tell SUMO to step through dt more seconds of the simulation
         self._cumulative_sim_seconds += dt
         try:
-            self._traci_conn.simulationStep(self._cumulative_sim_seconds)
+            with suppress_output(stderr=False):
+                self._traci_conn.simulationStep(self._cumulative_sim_seconds)
         except self._traci_exceptions as e:
             self._handle_traci_disconnect(e)
             return ProviderState()


### PR DESCRIPTION
As mentioned in https://github.com/huawei-noah/SMARTS/pull/1751#issuecomment-1337023244 and https://github.com/huawei-noah/SMARTS/issues/1155, SUMO versions after 1.10.0 throw an error in the first call to `simulationStep()` after calling `vehicle.remove()`. After investigating this, I couldn't find a cause for the error, and it did not seem to impact the simulation, so I am suppressing the error message.

For future reference, this error can be reproduced reliably by running:

```sh
scl run examples/egoless.py scenarios/sumo/loop/ --headless --episodes=1
```