### PR TITLE
Updated use of shapely.geometry.Polygon and shapely.geometry.collection.GeometryCollection 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     rich>=11.2.0
     Rtree>=0.9.7
     sh>=1.14.2
-    shapely>=1.8.1
+    shapely>=2.0.0
     tableprint>=0.9.1
     trimesh==3.9.29  # Used for writing .glb files
     visdom>=0.1.8.9

--- a/smarts/core/sumo_road_network.py
+++ b/smarts/core/sumo_road_network.py
@@ -1209,7 +1209,7 @@ class SumoRoadNetwork(RoadMap):
                                 snapped_to.add(nl)
                                 thresh *= 0.75
                 if p != last_added:
-                    new_coords.append(p)
+                    new_coords.append((p.x, p.y))
                     last_added = p
             if new_coords:
                 lane_to_poly[lane_id] = (Polygon(new_coords), metadata)

--- a/smarts/core/sumo_road_network.py
+++ b/smarts/core/sumo_road_network.py
@@ -1265,7 +1265,7 @@ class SumoRoadNetwork(RoadMap):
                                 snapped_to.add(nl)
                                 thresh *= 0.75
                 if p != last_added:
-                    new_coords.append(p)
+                    new_coords.append((p.x, p.y))
                     last_added = p
             if new_coords:
                 lane_to_poly[lane_id] = (Polygon(new_coords), metadata)

--- a/smarts/core/tests/helpers/bubbles.py
+++ b/smarts/core/tests/helpers/bubbles.py
@@ -19,7 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-from collections import defaultdict, namedtuple
+from collections import namedtuple
 
 from shapely.geometry import LineString
 from shapely.ops import split
@@ -36,7 +36,7 @@ def bubble_geometry(bubble, road_map):
     airlock_geometry = bubble_geometry_.buffer(bubble.margin)
     split_x, split_y = airlock_geometry.centroid.coords[0]
     divider = LineString([(split_x, -999), (split_x, split_y + 999)])
-    airlock_entry_geometry, airlock_exit_geometry = split(airlock_geometry, divider)
+    airlock_entry_geometry, airlock_exit_geometry = (split(airlock_geometry, divider)).geoms
     return BubbleGeometry(
         bubble=bubble_geometry_,
         airlock_entry=airlock_entry_geometry,


### PR DESCRIPTION
1. Newly released `shapely==2.0.0` includes type check which fails when `Polygon` is instantiated using sequence of `Point` objects.
    ```python
    # File: shapely/geometry/polygon.py
    if not np.issubdtype(shell.dtype, np.number):
        # conversion of coords to 2D array failed, this might be due
        # to inconsistent coordinate dimensionality
        raise ValueError("Inconsistent coordinate dimensionality")
    ```
    + Hence, `Polygon` is instantiated using sequence of coordinate pairs instead of sequence of `Point` objects.

2. Newly released `shapely==2.0.0` deprecates iteration over multi-part geometries. 
    + Hence, `geoms` property is used to access the constituent parts of a multi-part `GeometryCollection` object.