### PR TITLE
Suppress the `DeprecationWarning` caused by the `trimesh` package

### DIFF
--- a/smarts/core/scenario.py
+++ b/smarts/core/scenario.py
@@ -66,6 +66,11 @@ from smarts.sstudio.types import Via as SSVia
 
 VehicleWindow = TrafficHistory.TrafficHistoryVehicleWindow
 
+# Suppress trimesh deprecation warning
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    import trimesh # only suppress the warnings caused by trimesh
 
 class Scenario:
     """The purpose of the Scenario is to provide an aggregate of all

--- a/smarts/core/scenario.py
+++ b/smarts/core/scenario.py
@@ -69,8 +69,13 @@ VehicleWindow = TrafficHistory.TrafficHistoryVehicleWindow
 # Suppress trimesh deprecation warning
 
 with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=DeprecationWarning)
-    import trimesh # only suppress the warnings caused by trimesh
+    warnings.filterwarnings(
+        "ignore",
+        message="Please use `coo_matrix` from the `scipy.sparse` namespace, the `scipy.sparse.coo` namespace is deprecated.",
+        category=DeprecationWarning,
+    )
+    import trimesh  # only suppress the warnings caused by trimesh
+
 
 class Scenario:
     """The purpose of the Scenario is to provide an aggregate of all
@@ -954,7 +959,6 @@ class Scenario:
     @lru_cache(1)
     def map_glb_meta_for_file(filepath):
         """The map metadata given a file."""
-        import trimesh
 
         scene = trimesh.load(filepath)
         return scene.metadata


### PR DESCRIPTION
Suppress the ```/root/SMARTS/.venv/lib/python3.8/site-packages/trimesh/curvature.py:12: DeprecationWarning: Please use `coo_matrix` from the `scipy.sparse` namespace, the `scipy.sparse.coo` namespace is deprecated.```  warning.