### PR TITLE
Fix `open-agent` setup error.

### DIFF
--- a/zoo/policies/open-agent/README.md
+++ b/zoo/policies/open-agent/README.md
@@ -8,10 +8,4 @@ Since we make use of Rust code-generation and compilation at run-time, you'll ne
 
 The easiest way to get up and running is to follow the instructions at https://rustup.rs/
 
-## Precompiled Binaries
-
-The open_agent-X.XXX.whl files contained here are precompiled agent policies, these policy wheels can be rebuilt using `./setup.py` located in this same folder.
-
-The purpose is for `./tests/test_open_agent.py` to have static policy binaries to test with.
-
-Build the docs and see `docs/readme.rst:4.3.2 RLlib Example`.
+After that you may need to call `pip install . # with -e if preferred` up to 2 times. The first time will get the base dependencies, the second time will rebuild the solver. The solver will be output to the `../python-bindings-open-agent-solver` directory.

--- a/zoo/policies/open-agent/open_agent/agent.py
+++ b/zoo/policies/open-agent/open_agent/agent.py
@@ -17,7 +17,12 @@ from smarts.core.controllers.trajectory_tracking_controller import (
 )
 from smarts.core.coordinates import Heading
 
-from .version import SOLVER_VERSION, VERSION
+with open(
+    Path(__file__).parent.absolute() / "metadata.json", mode="r", encoding="ascii"
+) as f:
+    meta = json.load(f)
+    VERSION = meta.get("VERSION")
+    SOLVER_VERSION = meta.get("SOLVER_VERSION")
 
 CONFIG_PATH = Path(__file__).parent / "config.json"
 

--- a/zoo/policies/open-agent/open_agent/metadata.json
+++ b/zoo/policies/open-agent/open_agent/metadata.json
@@ -1,0 +1,4 @@
+{
+    "VERSION": "0.1.195",
+    "SOLVER_VERSION": "0.0.9"
+}

--- a/zoo/policies/open-agent/open_agent/version.py
+++ b/zoo/policies/open-agent/open_agent/version.py
@@ -1,3 +1,0 @@
-VERSION = "0.1.195"
-
-SOLVER_VERSION = "0.0.9"

--- a/zoo/policies/open-agent/setup.py
+++ b/zoo/policies/open-agent/setup.py
@@ -1,7 +1,15 @@
+import json
 from pathlib import Path
 
-from open_agent.version import VERSION
 from setuptools import setup
+
+with open(
+    Path(__file__).parent.absolute() / "open_agent/metadata.json",
+    mode="rt",
+    encoding="ascii",
+) as f:
+    meta = json.load(f)
+    VERSION = meta.get("VERSION")
 
 try:
     import glob


### PR DESCRIPTION
This fixes the `open-agent` setup by moving the version strings to a meta file.