### PR TITLE
Envision map fix

### DIFF
--- a/envision/server.py
+++ b/envision/server.py
@@ -430,8 +430,8 @@ class MapFileHandler(FileHandler):
         for dir_ in scenario_dirs:
             path_map.update(
                 {
-                    f"{path2hash(str(glb.parent.resolve()))}.glb": glb
-                    for glb in Path(dir_).rglob("*.glb")
+                    f"{path2hash(str(glb.parent.parent.parent.resolve()))}.glb": glb
+                    for glb in Path(dir_).rglob("build/map/*.glb")
                 }
             )
 

--- a/envision/server.py
+++ b/envision/server.py
@@ -430,7 +430,7 @@ class MapFileHandler(FileHandler):
         for dir_ in scenario_dirs:
             path_map.update(
                 {
-                    f"{path2hash(str(glb.parent.parent.parent.resolve()))}.glb": glb
+                    f"{path2hash(str(glb.parents[2].resolve()))}.glb": glb
                     for glb in Path(dir_).rglob("build/map/*.glb")
                 }
             )


### PR DESCRIPTION
The envision server was using the incorrect path hash, since map glb files are now in a nested subfolder.