### PR TITLE
Add road lines to RGB image observations

### DIFF
--- a/smarts/core/glsl/dashed_line_shader.frag
+++ b/smarts/core/glsl/dashed_line_shader.frag
@@ -2,18 +2,18 @@
 
 out vec4 FragColor;
 
-flat in vec3 startPos;
-in vec3 vertPos;
+flat in vec3 StartPos;
+in vec3 VertPos;
 
 uniform vec4 p3d_Color;
-uniform vec2 resolution;
+uniform vec2 Resolution;
 
 void main()
 {
     uint pattern = 0x00FFu;
     float factor = 2.0;
 
-    vec2 dir = (vertPos.xy - startPos.xy) * resolution/2.0;
+    vec2 dir = (VertPos.xy - StartPos.xy) * Resolution / 2.0;
     float dist = length(dir);
 
     uint bit = uint(round(dist / factor)) & 15U;

--- a/smarts/core/glsl/dashed_line_shader.frag
+++ b/smarts/core/glsl/dashed_line_shader.frag
@@ -1,0 +1,23 @@
+#version 330 core
+
+out vec4 FragColor;
+
+flat in vec3 startPos;
+in vec3 vertPos;
+
+uniform vec4 p3d_Color;
+uniform vec2 resolution;
+
+void main()
+{
+    uint pattern = 0x00FFu;
+    float factor = 2.0;
+
+    vec2 dir = (vertPos.xy - startPos.xy) * resolution/2.0;
+    float dist = length(dir);
+
+    uint bit = uint(round(dist / factor)) & 15U;
+    if ((pattern & (1U<<bit)) == 0U)
+        discard; 
+    FragColor = p3d_Color;
+}

--- a/smarts/core/glsl/dashed_line_shader.vert
+++ b/smarts/core/glsl/dashed_line_shader.vert
@@ -1,0 +1,16 @@
+#version 330 core
+
+uniform mat4 p3d_ModelViewProjectionMatrix;
+
+in vec4 p3d_Vertex;
+
+flat out vec3 startPos;
+out vec3 vertPos;
+
+void main()
+{
+    vec4 pos = p3d_ModelViewProjectionMatrix * p3d_Vertex;
+    gl_Position = pos;
+    vertPos = pos.xyz / pos.w;
+    startPos = vertPos;
+}

--- a/smarts/core/glsl/dashed_line_shader.vert
+++ b/smarts/core/glsl/dashed_line_shader.vert
@@ -4,13 +4,13 @@ uniform mat4 p3d_ModelViewProjectionMatrix;
 
 in vec4 p3d_Vertex;
 
-flat out vec3 startPos;
-out vec3 vertPos;
+flat out vec3 StartPos;
+out vec3 VertPos;
 
 void main()
 {
     vec4 pos = p3d_ModelViewProjectionMatrix * p3d_Vertex;
     gl_Position = pos;
-    vertPos = pos.xyz / pos.w;
-    startPos = vertPos;
+    VertPos = pos.xyz / pos.w;
+    StartPos = VertPos;
 }

--- a/smarts/core/road_map.py
+++ b/smarts/core/road_map.py
@@ -80,7 +80,7 @@ class RoadMap:
         """Check if the MapSpec Object source points to the same RoadMap instance as the current"""
         raise NotImplementedError
 
-    def to_glb(self, at_path: str):
+    def to_glb(self, glb_dir: str):
         """Build a glb file for camera rendering and envision"""
         raise NotImplementedError()
 

--- a/smarts/core/sumo_road_network.py
+++ b/smarts/core/sumo_road_network.py
@@ -18,7 +18,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 import logging
+import math
 import os
+from pathlib import Path
 import random
 from functools import lru_cache
 from subprocess import check_output
@@ -279,10 +281,17 @@ class SumoRoadNetwork(RoadMap):
         # map units per meter
         return self._default_lane_width / SumoRoadNetwork.DEFAULT_LANE_WIDTH
 
-    def to_glb(self, at_path):
+    def to_glb(self, glb_dir):
+        lane_dividers, edge_dividers = self._compute_traffic_dividers()
         polys = self._compute_road_polygons()
-        glb = self._make_glb_from_polys(polys)
-        glb.write_glb(at_path)
+        map_glb = self._make_glb_from_polys(polys, lane_dividers, edge_dividers)
+        map_glb.write_glb(Path(glb_dir) / "map.glb")
+
+        road_lines_glb = self._make_road_line_glb(edge_dividers)
+        road_lines_glb.write_glb(Path(glb_dir) / "road_lines.glb")
+
+        lane_lines_glb = self._make_road_line_glb(lane_dividers)
+        lane_lines_glb.write_glb(Path(glb_dir) / "lane_lines.glb")
 
     class Surface(RoadMap.Surface):
         """Describes a Sumo surface."""
@@ -1270,7 +1279,18 @@ class SumoRoadNetwork(RoadMap):
             if new_coords:
                 lane_to_poly[lane_id] = (Polygon(new_coords), metadata)
 
-    def _make_glb_from_polys(self, polygons):
+    def _make_road_line_glb(self, lines: List[List[Tuple[float, float]]]):
+        scene = trimesh.Scene()
+        for line_pts in lines:
+            vertices = [(*pt, 0.1) for pt in line_pts]
+            point_cloud = trimesh.PointCloud(vertices=vertices)
+            point_cloud.apply_transform(
+                trimesh.transformations.rotation_matrix(math.pi / 2, [-1, 0, 0])
+            )
+            scene.add_geometry(point_cloud)
+        return _GLBData(gltf.export_glb(scene))
+
+    def _make_glb_from_polys(self, polygons, lane_dividers, edge_dividers):
         scene = trimesh.Scene()
         meshes = generate_meshes_from_polygons(polygons)
         # Attach additional information for rendering as metadata in the map glb
@@ -1281,7 +1301,6 @@ class SumoRoadNetwork(RoadMap):
         metadata["bounding_box"] = self._graph.getBoundary()
 
         # lane markings information
-        lane_dividers, edge_dividers = self._compute_traffic_dividers()
         metadata["lane_dividers"] = lane_dividers
         metadata["edge_dividers"] = edge_dividers
 

--- a/smarts/core/tests/helpers/scenario.py
+++ b/smarts/core/tests/helpers/scenario.py
@@ -35,8 +35,6 @@ def temp_scenario(name: str, map: str):
 
         test_maps_dir = Path(__file__).parent.parent
         shutil.copyfile(test_maps_dir / map, scenario / "map.net.xml")
-        generate_glb_from_sumo_file(
-            str(scenario / "map.net.xml"), str(scenario / "map.glb")
-        )
+        generate_glb_from_sumo_file(str(scenario / "map.net.xml"), scenario)
 
         yield scenario

--- a/smarts/core/tests/helpers/scenario.py
+++ b/smarts/core/tests/helpers/scenario.py
@@ -35,6 +35,6 @@ def temp_scenario(name: str, map: str):
 
         test_maps_dir = Path(__file__).parent.parent
         shutil.copyfile(test_maps_dir / map, scenario / "map.net.xml")
-        generate_glb_from_sumo_file(str(scenario / "map.net.xml"), scenario)
+        generate_glb_from_sumo_file(str(scenario / "map.net.xml"), str(scenario))
 
         yield scenario

--- a/smarts/core/waymo_map.py
+++ b/smarts/core/waymo_map.py
@@ -21,6 +21,7 @@
 import heapq
 import logging
 import math
+from pathlib import Path
 import random
 import time
 from collections import defaultdict, deque
@@ -989,10 +990,10 @@ class WaymoMap(RoadMapWithCaches):
     def scale_factor(self) -> float:
         return 1.0  # TODO
 
-    def to_glb(self, at_path):
+    def to_glb(self, glb_dir):
         """Build a glb file for camera rendering and envision."""
         glb = self._make_glb_from_polys()
-        glb.write_glb(at_path)
+        glb.write_glb(Path(glb_dir) / "map.glb")
 
     def _make_glb_from_polys(self):
         scene = trimesh.Scene()

--- a/smarts/sstudio/genscenario.py
+++ b/smarts/sstudio/genscenario.py
@@ -213,7 +213,7 @@ def gen_scenario(
 
             map_dir = os.path.join(build_dir, "map")
             os.makedirs(map_dir, exist_ok=True)
-            road_map.to_glb(os.path.join(map_dir, "map.glb"))
+            road_map.to_glb(map_dir)
             _update_artifacts(db_conn, artifact_paths, map_hash)
 
     # Traffic

--- a/smarts/sstudio/od2mesh.py
+++ b/smarts/sstudio/od2mesh.py
@@ -23,11 +23,11 @@ from smarts.core.opendrive_road_network import OpenDriveRoadNetwork
 from smarts.sstudio.types import MapSpec
 
 
-def generate_glb_from_opendrive_file(od_xodr_file: str, out_glb_file: str):
+def generate_glb_from_opendrive_file(od_xodr_file: str, out_glb_dir: str):
     """Creates a geometry file from an OpenDRIVE map file."""
     map_spec = MapSpec(od_xodr_file)
     road_network = OpenDriveRoadNetwork.from_spec(map_spec)
-    road_network.to_glb(out_glb_file)
+    road_network.to_glb(out_glb_dir)
 
 
 if __name__ == "__main__":

--- a/smarts/sstudio/sumo2mesh.py
+++ b/smarts/sstudio/sumo2mesh.py
@@ -23,11 +23,11 @@ from smarts.core.sumo_road_network import SumoRoadNetwork
 from smarts.sstudio.types import MapSpec
 
 
-def generate_glb_from_sumo_file(sumo_net_file: str, out_glb_file: str):
+def generate_glb_from_sumo_file(sumo_net_file: str, out_glb_dir: str):
     """Creates a geometry file from a sumo map file."""
     map_spec = MapSpec(sumo_net_file)
     road_network = SumoRoadNetwork.from_spec(map_spec)
-    road_network.to_glb(out_glb_file)
+    road_network.to_glb(out_glb_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #1791.

This PR adds road lines to RGB image observations for maps that have `lane_dividers` and `edge_dividers`. Only SUMO and Opendrive are supported at the moment, since we don't currently calculate `edge_dividers` for Waymo maps.

The edge dividers are rendered as solid yellow lines and the lane dividers as dashed white lines. Here is an example from the `4lane` scenario:

![image](https://user-images.githubusercontent.com/17256344/212775865-4c673bd9-4f34-435b-965a-67d4621f8592.png)

Since modern OpenGL does not include dashed lines in the API, a custom shader was needed. Additionally, the lines needed to be generated as their own `.glb` files since Panda3D does not allow accessing them through the `extras` metadata in the map glb file. This required some refactoring in the glb generation code for the map classes.