### PR TITLE
Fix sanity test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ sanity-test: build-sanity-scenarios
 		./smarts/core/tests/test_dynamics_backend.py::test_set_pose \
 		./smarts/core/tests/test_sensors.py::test_waypoints_sensor \
 		./smarts/core/tests/test_smarts.py::test_smarts_doesnt_leak_tasks_after_reset \
-		./examples/tests/test_examples.py::test_examples[multi_agent] \
+		./examples/tests/test_examples.py::test_examples[laner] \
 		./smarts/env/tests/test_social_agent.py::test_social_agents
 
 .PHONY: test-learning


### PR DESCRIPTION
The sanity test was broken after removing the `multi_agent` example. I have updated the test to use the `laner` example instead.