### PR TITLE
Envision map fix

### DIFF
--- a/envision/server.py
+++ b/envision/server.py
@@ -431,7 +431,7 @@ class MapFileHandler(FileHandler):
             path_map.update(
                 {
                     f"{path2hash(str(glb.parents[2].resolve()))}.glb": glb
-                    for glb in Path(dir_).rglob("build/map/*.glb")
+                    for glb in Path(dir_).rglob("build/map/map.glb")
                 }
             )
 


### PR DESCRIPTION
Scenarios with road lines (which are now exported as separate glbs) were having their road line glbs served instead of the map glb in envision.