### PR TITLE
Fix waypoint observations for offline dataset generation

### DIFF
--- a/scenarios/sumo/intersections/2lane/scenario.py
+++ b/scenarios/sumo/intersections/2lane/scenario.py
@@ -81,8 +81,9 @@ gen_scenario(
     scenario=Scenario(
         traffic=traffic,
         map_spec=MapSpec(
-            source=Path(__file__).parent,
+            source=Path(__file__).parent.absolute(),
             shift_to_origin=True,
+            lanepoint_spacing=1.0,
         ),
     ),
     output_dir=Path(__file__).parent,

--- a/scenarios/sumo/intersections/4lane/scenario.py
+++ b/scenarios/sumo/intersections/4lane/scenario.py
@@ -89,8 +89,9 @@ scenario = Scenario(
     },
     ego_missions=ego_missions,
     map_spec=MapSpec(
-        source=Path(__file__).parent,
+        source=Path(__file__).parent.absolute(),
         shift_to_origin=True,
+        lanepoint_spacing=1.0,
     ),
 )
 

--- a/smarts/core/agent_manager.py
+++ b/smarts/core/agent_manager.py
@@ -660,11 +660,11 @@ class AgentManager:
             # If this is a history vehicle, assign a mission based on its final position.
             # This is necessary so that the observations have waypoints that lead to the goal.
             mission = None
-            if sv_id in sim.traffic_history_provider._history_vehicle_ids:
+            if sv_id in sim.traffic_history_provider.history_vehicle_ids:
                 v_id = sv_id.split("-")[-1]
                 start_time = sim.scenario.traffic_history.vehicle_initial_time(v_id)
                 start, _ = sim.scenario.get_vehicle_start_at_time(v_id, start_time)
-                veh_goal = sim.scenario._get_vehicle_goal(v_id)
+                veh_goal = sim.scenario.get_vehicle_goal(v_id)
                 mission = Mission(
                     start=start,
                     goal=PositionalGoal(veh_goal, radius=5),

--- a/smarts/core/plan.py
+++ b/smarts/core/plan.py
@@ -134,9 +134,7 @@ class TraverseGoal(Goal):
     the vehicle must be going the correct direction in its lane
     just prior to doing so."""
 
-    def __init__(self, road_map: RoadMap):
-        super().__init__()
-        self._road_map = road_map
+    road_map: RoadMap
 
     def is_specific(self) -> bool:
         return False
@@ -147,7 +145,7 @@ class TraverseGoal(Goal):
 
     def _drove_off_map(self, veh_pos: Point, veh_heading: float) -> bool:
         # try to determine if the vehicle "exited" the map by driving beyond the end of a dead-end lane.
-        nearest_lanes = self._road_map.nearest_lanes(veh_pos)
+        nearest_lanes = self.road_map.nearest_lanes(veh_pos)
         if not nearest_lanes:
             return False  # we can't tell anything here
         nl, dist = nearest_lanes[0]

--- a/smarts/core/scenario.py
+++ b/smarts/core/scenario.py
@@ -490,7 +490,7 @@ class Scenario:
         Returns:
             A new map spec.
         """
-        path = os.path.join(scenario_root, "build", "map_spec.pkl")
+        path = os.path.join(scenario_root, "build", "map", "map_spec.pkl")
         if not os.path.exists(path):
             # Use our default map builder if none specified by scenario...
             return MapSpec(
@@ -706,9 +706,10 @@ class Scenario:
     @staticmethod
     def discover_traffic_histories(scenario_root: str):
         """Finds all existing traffic history files in the specific scenario."""
+        build_dir = Path(scenario_root) / "build"
         return [
             entry
-            for entry in os.scandir(scenario_root)
+            for entry in os.scandir(str(build_dir))
             if entry.is_file() and entry.path.endswith(".shf")
         ]
 

--- a/smarts/core/scenario.py
+++ b/smarts/core/scenario.py
@@ -577,6 +577,7 @@ class Scenario:
         )
 
     def get_vehicle_goal(self, vehicle_id: str) -> Point:
+        """Get the final position for a history vehicle."""
         final_exit_time = self._traffic_history.vehicle_final_exit_time(vehicle_id)
         final_pose = self._traffic_history.vehicle_pose_at_time(
             vehicle_id, final_exit_time

--- a/smarts/core/scenario.py
+++ b/smarts/core/scenario.py
@@ -576,7 +576,7 @@ class Scenario:
             speed,
         )
 
-    def _get_vehicle_goal(self, vehicle_id: str) -> Point:
+    def get_vehicle_goal(self, vehicle_id: str) -> Point:
         final_exit_time = self._traffic_history.vehicle_final_exit_time(vehicle_id)
         final_pose = self._traffic_history.vehicle_pose_at_time(
             vehicle_id, final_exit_time
@@ -625,7 +625,7 @@ class Scenario:
              vehicle leaves the map.
         """
         start, speed = self.get_vehicle_start_at_time(veh_id, trigger_time)
-        veh_goal = self._get_vehicle_goal(veh_id)
+        veh_goal = self.get_vehicle_goal(veh_id)
         entry_tactic = default_entry_tactic(speed)
         # create a positional mission and a traverse mission
         positional_mission = Mission(

--- a/smarts/core/traffic_history.py
+++ b/smarts/core/traffic_history.py
@@ -131,6 +131,12 @@ class TrafficHistory:
         return ego_id
 
     @lru_cache(maxsize=32)
+    def vehicle_initial_time(self, vehicle_id: str) -> float:
+        """Returns the final time the specified vehicle is seen in the history data."""
+        query = "SELECT MIN(sim_time) FROM Trajectory WHERE vehicle_id = ?"
+        return self._query_val(float, query, params=(vehicle_id,))
+
+    @lru_cache(maxsize=32)
     def vehicle_final_exit_time(self, vehicle_id: str) -> float:
         """Returns the final time the specified vehicle is seen in the history data."""
         query = "SELECT MAX(sim_time) FROM Trajectory WHERE vehicle_id = ?"

--- a/smarts/core/traffic_history.py
+++ b/smarts/core/traffic_history.py
@@ -132,7 +132,7 @@ class TrafficHistory:
 
     @lru_cache(maxsize=32)
     def vehicle_initial_time(self, vehicle_id: str) -> float:
-        """Returns the final time the specified vehicle is seen in the history data."""
+        """Returns the initial time the specified vehicle is seen in the history data."""
         query = "SELECT MIN(sim_time) FROM Trajectory WHERE vehicle_id = ?"
         return self._query_val(float, query, params=(vehicle_id,))
 

--- a/smarts/core/traffic_history_provider.py
+++ b/smarts/core/traffic_history_provider.py
@@ -215,6 +215,7 @@ class TrafficHistoryProvider(TrafficProvider):
 
     @cached_property
     def history_vehicle_ids(self) -> Set[str]:
+        """Actor IDs for all history vehicles."""
         if not self._histories:
             return set()
         return {

--- a/smarts/core/traffic_history_provider.py
+++ b/smarts/core/traffic_history_provider.py
@@ -87,9 +87,9 @@ class TrafficHistoryProvider(TrafficProvider):
 
     def setup(self, scenario) -> ProviderState:
         """Initialize this provider with the given scenario."""
-        if "_history_vehicle_ids" in self.__dict__:
+        if "history_vehicle_ids" in self.__dict__:
             # clear the cached_property
-            del self.__dict__["_history_vehicle_ids"]
+            del self.__dict__["history_vehicle_ids"]
         self._scenario = scenario
         self._histories = scenario.traffic_history
         if self._histories:
@@ -214,7 +214,7 @@ class TrafficHistoryProvider(TrafficProvider):
         return ProviderState(actors=vehicles + signals)
 
     @cached_property
-    def _history_vehicle_ids(self) -> Set[str]:
+    def history_vehicle_ids(self) -> Set[str]:
         if not self._histories:
             return set()
         return {
@@ -223,7 +223,7 @@ class TrafficHistoryProvider(TrafficProvider):
 
     @property
     def _my_vehicles(self) -> Set[str]:
-        return self._history_vehicle_ids - self._replaced_actor_ids
+        return self.history_vehicle_ids - self._replaced_actor_ids
 
     def manages_actor(self, actor_id: str) -> bool:
         return actor_id in self._my_vehicles

--- a/smarts/dataset/traffic_histories_to_observations.py
+++ b/smarts/dataset/traffic_histories_to_observations.py
@@ -289,12 +289,12 @@ class ObservationRecorder:
                 for t in data.keys():
                     ego_state = data[t].ego_vehicle_state
                     new_ego_state = ego_state._replace(mission=new_mission)
-                    data[t] = replace(data[t], ego_vehicle_state=new_ego_state)
+                    data[t] = data[t]._replace(ego_vehicle_state=new_ego_state)
 
                 # Create terminal state for last timestep, when the vehicle reaches the goal
                 events = data[last_t].events
                 new_events = events._replace(reached_goal=True)
-                data[last_t] = replace(data[last_t], events=new_events)
+                data[last_t] = data[last_t]._replace(events=new_events)
 
                 outfile = os.path.join(
                     self._output_dir,
@@ -356,7 +356,7 @@ class ObservationRecorder:
                 color = np.array(Colors.Red.value[0:3], ndmin=3) * 255
                 rgb[shape[0][0] : shape[0][1], shape[1][0] : shape[1][1], :] = color
                 top_down_rgb_edited = top_down_rgb._replace(data=rgb)
-                obs[id_] = replace(obs[id_], top_down_rgb=top_down_rgb_edited)
+                obs[id_] = obs[id_]._replace(top_down_rgb=top_down_rgb_edited)
 
                 if self._output_dir:
                     img = Image.fromarray(rgb, "RGB")

--- a/smarts/sstudio/genscenario.py
+++ b/smarts/sstudio/genscenario.py
@@ -177,7 +177,10 @@ def gen_scenario(
             _update_artifacts(db_conn, artifact_paths, obj_hash)
         map_spec = scenario.map_spec
     else:
-        map_spec = types.MapSpec(source=scenario_dir)
+        if scenario.map_spec is not None:
+            map_spec = scenario.map_spec
+        else:
+            map_spec = types.MapSpec(source=scenario_dir)
 
     if map_spec.shift_to_origin and scenario.traffic_histories:
         logger.warning(


### PR DESCRIPTION
Closes #1706, #1735.

## Context

When generating offline dataset observations with the `traffic_histories_to_observations.py` script, history vehicles do not have routes associated with their missions. This results in the waypoints sensor returning waypoints for the nearest lanes, somewhat erratically (see below -- vehicle positions are in red, waypoints for each position are plotted as lines):

<img src="https://user-images.githubusercontent.com/17256344/214686064-137aa305-ba1b-474a-a00c-f0361e91c129.png" width="500">

The desired behaviour is for the waypoints to consistently lead to the final position in the recorded trajectory:

<img src="https://user-images.githubusercontent.com/17256344/214685978-dd8149b5-40e8-477f-9b1d-d53c8fccd3c3.png" width="500">

## Solution
- When adding sensors to history vehicles, create a mission with a route leading to the final position in the trajectory
- Various changes to get the `traffic_histories_to_observations` script working again