### PR TITLE
Metrics use env obs

### DIFF
--- a/smarts/env/gymnasium/wrappers/metric/completion.py
+++ b/smarts/env/gymnasium/wrappers/metric/completion.py
@@ -133,16 +133,19 @@ def _dist_remainder():
     step: int = 0
 
     def func(
-        road_map: RoadMap, obs: Dict[str, Any], initial_compl: Completion
+        road_map: RoadMap, obs: Observation, initial_compl: Completion
     ) -> Completion:
         nonlocal mean, step
 
-        if obs["events"]["reached_goal"]:
+        if obs.events.reached_goal:
             dist = 0
         else:
-            cur_pos = Point(*obs["ego_vehicle_state"]["position"])
-            goal_pos = Point(*obs["ego_vehicle_state"]["mission"]["goal_position"])
-            dist = get_dist(road_map=road_map, point_a=cur_pos, point_b=goal_pos)
+            cur_pos = Point(*obs.ego_vehicle_state.position)
+            goal_pos = Point(*getattr(obs.ego_vehicle_state.mission.goal, "position", None))
+            if goal_pos is not None:
+                dist = get_dist(road_map=road_map, point_a=cur_pos, point_b=goal_pos)
+            else:
+                dist = 0
 
         # Cap remainder distance
         c_dist = min(dist, initial_compl.dist_tot)

--- a/smarts/env/gymnasium/wrappers/metric/completion.py
+++ b/smarts/env/gymnasium/wrappers/metric/completion.py
@@ -141,13 +141,12 @@ def _dist_remainder():
             dist = 0
         else:
             cur_pos = Point(*obs.ego_vehicle_state.position)
-            goal_pos = Point(
-                *getattr(obs.ego_vehicle_state.mission.goal, "position", None)
-            )
-            if goal_pos is not None:
-                dist = get_dist(road_map=road_map, point_a=cur_pos, point_b=goal_pos)
-            else:
-                dist = 0
+            goal_position = getattr(obs.ego_vehicle_state.mission.goal, "position")
+            assert (
+                goal_position is not None
+            ), f"Ego using `{obs.ego_vehicle_state.id}` cannot use cost func without a positional goal."
+            goal_point = Point(*goal_position)
+            dist = get_dist(road_map=road_map, point_a=cur_pos, point_b=goal_point)
 
         # Cap remainder distance
         c_dist = min(dist, initial_compl.dist_tot)

--- a/smarts/env/gymnasium/wrappers/metric/completion.py
+++ b/smarts/env/gymnasium/wrappers/metric/completion.py
@@ -144,7 +144,7 @@ def _dist_remainder():
             goal_position = getattr(obs.ego_vehicle_state.mission.goal, "position")
             assert (
                 goal_position is not None
-            ), f"Ego using `{obs.ego_vehicle_state.id}` cannot use cost func without a positional goal."
+            ), f"Ego `{obs.ego_vehicle_state.id}` cannot use cost func without a positional goal."
             goal_point = Point(*goal_position)
             dist = get_dist(road_map=road_map, point_a=cur_pos, point_b=goal_point)
 

--- a/smarts/env/gymnasium/wrappers/metric/completion.py
+++ b/smarts/env/gymnasium/wrappers/metric/completion.py
@@ -141,7 +141,9 @@ def _dist_remainder():
             dist = 0
         else:
             cur_pos = Point(*obs.ego_vehicle_state.position)
-            goal_pos = Point(*getattr(obs.ego_vehicle_state.mission.goal, "position", None))
+            goal_pos = Point(
+                *getattr(obs.ego_vehicle_state.mission.goal, "position", None)
+            )
             if goal_pos is not None:
                 dist = get_dist(road_map=road_map, point_a=cur_pos, point_b=goal_pos)
             else:

--- a/smarts/env/gymnasium/wrappers/metric/costs.py
+++ b/smarts/env/gymnasium/wrappers/metric/costs.py
@@ -43,80 +43,76 @@ class Costs:
     wrong_way: float = 0
 
 
-def _collisions(road_map: RoadMap, obs: Dict[str, Any]) -> Costs:
-    return Costs(collisions=int(obs["events"]["collisions"]))
+def _collisions(road_map: RoadMap, obs: Observation) -> Costs:
+    return Costs(collisions=len(obs.events.collisions))
 
 
-def _dist_to_obstacles() -> Callable[[RoadMap, Dict[str, Any]], Costs]:
+def _dist_to_obstacles() -> Callable[[RoadMap, Observation], Costs]:
     mean = 0
     step = 0
     rel_angle_th = np.pi * 40 / 180
     rel_heading_th = np.pi * 179 / 180
     w_dist = 0.05
 
-    def func(road_map: RoadMap, obs: Dict[str, Any]) -> Costs:
+    def func(road_map: RoadMap, obs: Observation) -> Costs:
         nonlocal mean, step, rel_angle_th, rel_heading_th, w_dist
 
         # Ego's position and heading with respect to the map's coordinate system.
         # Note: All angles returned by smarts is with respect to the map's coordinate system.
         #       On the map, angle is zero at positive y axis, and increases anti-clockwise.
-        ego = obs["ego_vehicle_state"]
-        ego_heading = (ego["heading"] + np.pi) % (2 * np.pi) - np.pi
-        ego_pos = ego["position"]
+        ego = obs.ego_vehicle_state
+        ego_heading = (ego.heading + np.pi) % (2 * np.pi) - np.pi
+        ego_pos = ego.position
 
         # Set obstacle distance threshold using 3-second rule
-        obstacle_dist_th = ego["speed"] * 3
+        obstacle_dist_th = ego.speed * 3
         if obstacle_dist_th == 0:
             return Costs(dist_to_obstacles=0)
 
         # Get neighbors.
-        nghbs = obs["neighborhood_vehicle_states"]
+        nghbs = obs.neighborhood_vehicle_states
 
         # Filter neighbors by distance.
-        nghbs_indicies = [
-            (nghb_idx, np.linalg.norm(nghb_pos - ego_pos))
-            for nghb_idx, nghb_pos in enumerate(nghbs["position"])
+        nghbs_state = [
+            (nghb, np.linalg.norm(nghb.position - ego_pos)) for nghb in nghbs
         ]
-        nghbs_indicies = [
-            nghb_idx for nghb_idx in nghbs_indicies if nghb_idx[1] <= obstacle_dist_th
+        nghbs_state = [
+            nghb_state
+            for nghb_state in nghbs_state
+            if nghb_state[1] <= obstacle_dist_th
         ]
-        if len(nghbs_indicies) == 0:
+        if len(nghbs_state) == 0:
             return Costs(dist_to_obstacles=0)
 
         # Filter neighbors within ego's visual field.
         obstacles = []
-        for nghb_idx in nghbs_indicies:
+        for nghb_state in nghbs_state:
             # Neighbors's angle with respect to the ego's position.
             # Note: In np.angle(), angle is zero at positive x axis, and increases anti-clockwise.
             #       Hence, map_angle = np.angle() - π/2
-            rel_pos = np.array(nghbs["position"][nghb_idx[0]]) - ego_pos
+            rel_pos = np.array(nghb_state[0].position) - ego_pos
             obstacle_angle = np.angle(rel_pos[0] + 1j * rel_pos[1]) - np.pi / 2
             obstacle_angle = (obstacle_angle + np.pi) % (2 * np.pi) - np.pi
             # Relative angle is the angle rotation required by ego agent to face the obstacle.
             rel_angle = obstacle_angle - ego_heading
             rel_angle = (rel_angle + np.pi) % (2 * np.pi) - np.pi
             if abs(rel_angle) <= rel_angle_th:
-                obstacles.append(nghb_idx)
-        nghbs_indicies = obstacles
-        if len(nghbs_indicies) == 0:
+                obstacles.append(nghb_state)
+        nghbs_state = obstacles
+        if len(nghbs_state) == 0:
             return Costs(dist_to_obstacles=0)
 
         # Filter neighbors by their relative heading to that of ego's heading.
-        nghbs_indicies = [
-            nghbs_idx
-            for nghbs_idx in nghbs_indicies
-            if abs(
-                Heading(nghbs["heading"][nghbs_idx[0]]).relative_to(
-                    Heading(ego["heading"])
-                )
-            )
-            <= rel_heading_th
+        nghbs_state = [
+            nghb_state
+            for nghb_state in nghbs_state
+            if abs(nghb_state[0].heading.relative_to(ego.heading)) <= rel_heading_th
         ]
-        if len(nghbs_indicies) == 0:
+        if len(nghbs_state) == 0:
             return Costs(dist_to_obstacles=0)
 
         # J_D : Distance to obstacles cost
-        di = np.array([nghb_dist for _, nghb_dist in nghbs_indicies])
+        di = np.array([nghb_state[1] for nghb_state in nghbs_state])
         j_d = np.amax(np.exp(-w_dist * di))
 
         mean, step = running_mean(prev_mean=mean, prev_step=step, new_val=j_d)
@@ -125,22 +121,22 @@ def _dist_to_obstacles() -> Callable[[RoadMap, Dict[str, Any]], Costs]:
     return func
 
 
-def _jerk_angular() -> Callable[[RoadMap, Dict[str, Any]], Costs]:
+def _jerk_angular() -> Callable[[RoadMap, Observation], Costs]:
     mean = 0
     step = 0
 
     # TODO: The output of this cost function should be normalised and bounded to [0,1].
-    def func(road_map: RoadMap, obs: Dict[str, Any]) -> Costs:
+    def func(road_map: RoadMap, obs: Observation) -> Costs:
         nonlocal mean, step
 
-        j_a = np.linalg.norm(obs["ego_vehicle_state"]["angular_jerk"])
+        j_a = np.linalg.norm(obs.ego_vehicle_state.angular_jerk)
         mean, step = running_mean(prev_mean=mean, prev_step=step, new_val=j_a)
         return Costs(jerk_angular=mean)
 
     return func
 
 
-def _jerk_linear() -> Callable[[RoadMap, Dict[str, Any]], Costs]:
+def _jerk_linear() -> Callable[[RoadMap, Observation], Costs]:
     mean = 0
     step = 0
     jerk_linear_max = np.linalg.norm(np.array([0.9, 0.9, 0]))  # Units: m/s^3
@@ -153,10 +149,10 @@ def _jerk_linear() -> Callable[[RoadMap, Dict[str, Any]], Costs]:
     Neural Information Processing Systems, NeurIPS 2019, Vancouver, Canada.
     """
 
-    def func(road_map: RoadMap, obs: Dict[str, Any]) -> Costs:
+    def func(road_map: RoadMap, obs: Observation) -> Costs:
         nonlocal mean, step, jerk_linear_max
 
-        jerk_linear = np.linalg.norm(obs["ego_vehicle_state"]["linear_jerk"])
+        jerk_linear = np.linalg.norm(obs.ego_vehicle_state.linear_jerk)
         j_l = min(jerk_linear / jerk_linear_max, 1)
         mean, step = running_mean(prev_mean=mean, prev_step=step, new_val=j_l)
         return Costs(jerk_linear=mean)
@@ -164,21 +160,21 @@ def _jerk_linear() -> Callable[[RoadMap, Dict[str, Any]], Costs]:
     return func
 
 
-def _lane_center_offset() -> Callable[[RoadMap, Dict[str, Any]], Costs]:
+def _lane_center_offset() -> Callable[[RoadMap, Observation], Costs]:
     mean = 0
     step = 0
 
-    def func(road_map: RoadMap, obs: Dict[str, Any]) -> Costs:
+    def func(road_map: RoadMap, obs: Observation) -> Costs:
         nonlocal mean, step
 
-        if obs["events"]["off_road"]:
+        if obs.events.off_road:
             # When vehicle is off road, the lane_center_offset cost
             # (i.e., j_lc) is set as zero.
             j_lc = 0
         else:
             # Vehicle's offset along the lane
-            ego_pos = obs["ego_vehicle_state"]["position"]
-            ego_lane = road_map.lane_by_id(obs["ego_vehicle_state"]["lane_id"].rstrip())
+            ego_pos = obs.ego_vehicle_state.position
+            ego_lane = road_map.lane_by_id(obs.ego_vehicle_state.lane_id)
             reflinepoint = ego_lane.to_lane_coord(world_point=Point(*ego_pos))
 
             # Half width of lane
@@ -198,25 +194,25 @@ def _lane_center_offset() -> Callable[[RoadMap, Dict[str, Any]], Costs]:
     return func
 
 
-def _off_road(road_map: RoadMap, obs: Dict[str, Any]) -> Costs:
-    return Costs(off_road=obs["events"]["off_road"])
+def _off_road(road_map: RoadMap, obs: Observation) -> Costs:
+    return Costs(off_road=obs.events.off_road)
 
 
-def _speed_limit() -> Callable[[RoadMap, Dict[str, Any]], Costs]:
+def _speed_limit() -> Callable[[RoadMap, Observation], Costs]:
     mean = 0
     step = 0
 
-    def func(road_map: RoadMap, obs: Dict[str, Any]) -> Costs:
+    def func(road_map: RoadMap, obs: Observation) -> Costs:
         nonlocal mean, step
 
-        if obs["events"]["off_road"]:
+        if obs.events.off_road:
             # When vehicle is off road, the speed_limit cost (i.e., j_v) is
             # set as zero.
             j_v = 0
         else:
             # Nearest lane's speed limit.
-            ego_speed = obs["ego_vehicle_state"]["speed"]
-            ego_lane = road_map.lane_by_id(obs["ego_vehicle_state"]["lane_id"].rstrip())
+            ego_speed = obs.ego_vehicle_state.speed
+            ego_lane = road_map.lane_by_id(obs.ego_vehicle_state.lane_id)
             speed_limit = ego_lane.speed_limit
             assert speed_limit > 0, (
                 "Expected lane speed limit to be a positive "
@@ -234,14 +230,14 @@ def _speed_limit() -> Callable[[RoadMap, Dict[str, Any]], Costs]:
     return func
 
 
-def _wrong_way() -> Callable[[RoadMap, Dict[str, Any]], Costs]:
+def _wrong_way() -> Callable[[RoadMap, Observation], Costs]:
     mean = 0
     step = 0
 
-    def func(road_map: RoadMap, obs: Dict[str, Any]) -> Costs:
+    def func(road_map: RoadMap, obs: Observation) -> Costs:
         nonlocal mean, step
         j_wrong_way = 0
-        if obs["events"]["wrong_way"]:
+        if obs.events.wrong_way:
             j_wrong_way = 1
 
         mean, step = running_mean(prev_mean=mean, prev_step=step, new_val=j_wrong_way)

--- a/smarts/env/gymnasium/wrappers/metrics.py
+++ b/smarts/env/gymnasium/wrappers/metrics.py
@@ -28,6 +28,7 @@ import numpy as np
 
 from smarts.core.agent_interface import AgentInterface
 from smarts.core.coordinates import Point
+from smarts.core.observations import Observation
 from smarts.core.plan import PositionalGoal
 from smarts.core.road_map import RoadMap
 from smarts.core.scenario import Scenario
@@ -38,7 +39,6 @@ from smarts.env.gymnasium.wrappers.metric.completion import (
 )
 from smarts.env.gymnasium.wrappers.metric.costs import CostFuncs, Costs
 from smarts.env.gymnasium.wrappers.metric.counts import Counts
-from smarts.core.observations import Observation
 
 
 @dataclass

--- a/smarts/env/gymnasium/wrappers/metrics.py
+++ b/smarts/env/gymnasium/wrappers/metrics.py
@@ -243,7 +243,7 @@ class MetricsBase(gym.Wrapper):
 
         return records
 
-    def score(self) -> Dict[str, float]:
+    def score(self) -> Score:
         """
         Computes four sub-component scores, namely, "Completion", "Time",
         "Humanness", "Rules", and one total combined score named "Overall"

--- a/smarts/env/gymnasium/wrappers/metrics.py
+++ b/smarts/env/gymnasium/wrappers/metrics.py
@@ -38,6 +38,7 @@ from smarts.env.gymnasium.wrappers.metric.completion import (
 )
 from smarts.env.gymnasium.wrappers.metric.costs import CostFuncs, Costs
 from smarts.env.gymnasium.wrappers.metric.counts import Counts
+from smarts.core.observations import Observation
 
 
 @dataclass
@@ -110,14 +111,15 @@ class MetricsBase(gym.Wrapper):
 
         obs = {agent_id: o for agent_id, o in obs.items() if o["active"]}
         # fmt: off
-        for agent_name, agent_obs in obs.items():
+        for agent_name in obs:
+            base_obs: Observation = info[agent_name]["env_obs"]
             self._steps[agent_name] += 1
 
             # Compute all cost functions.
             costs = Costs()
             for field in fields(self._records[self._scen_name][agent_name].cost_funcs):
                 cost_func = getattr(self._records[self._scen_name][agent_name].cost_funcs, field.name)
-                new_costs = cost_func(road_map=self._road_map, obs=agent_obs)
+                new_costs = cost_func(road_map=self._road_map, obs=base_obs)
                 costs = _add_dataclass(new_costs, costs)
 
             # Update stored costs.
@@ -126,15 +128,15 @@ class MetricsBase(gym.Wrapper):
             if dones[agent_name]:
                 self._done_agents.add(agent_name)
                 if not (
-                    agent_obs["events"]["reached_goal"]
-                    or agent_obs["events"]["collisions"]
-                    or agent_obs["events"]["off_road"]
-                    or agent_obs["events"]["reached_max_episode_steps"]
+                    base_obs.events.reached_goal
+                    or len(base_obs.events.collisions)
+                    or base_obs.events.off_road
+                    or base_obs.events.reached_max_episode_steps
                 ):
                     raise MetricsError(
                         "Expected reached_goal, collisions, off_road, or " 
                         "max_episode_steps to be true on agent done, but got "
-                        f"events: {agent_obs.events}."
+                        f"events: {base_obs.events}."
                     )
 
                 # Update stored counts.
@@ -145,7 +147,7 @@ class MetricsBase(gym.Wrapper):
                         self._steps[agent_name],
                         self.env.agent_interfaces[agent_name].max_episode_steps
                     ),
-                    goals=agent_obs["events"]["reached_goal"],
+                    goals=base_obs.events.reached_goal,
                     max_steps=self.env.agent_interfaces[agent_name].max_episode_steps
                 )
                 self._records[self._scen_name][agent_name].record.counts = _add_dataclass(
@@ -162,7 +164,7 @@ class MetricsBase(gym.Wrapper):
                     )
                     new_completion = completion_func(
                         road_map=self._road_map,
-                        obs=agent_obs,
+                        obs=base_obs,
                         initial_compl=completion,
                     )
                     completion = _add_dataclass(new_completion, completion)

--- a/smarts/sstudio/scenario_construction.py
+++ b/smarts/sstudio/scenario_construction.py
@@ -44,7 +44,7 @@ def build_scenario(
         if seed is not None:
             with tempfile.NamedTemporaryFile("w", suffix=".py", dir=scenario_root) as c:
                 with open(scenario_py, "r") as o:
-                    c.write(f"import smarts.core; smarts.core.seed({seed});\n")
+                    c.write(f"from smarts.core import seed as smarts_seed; smarts_seed({seed});\n")
                     c.write(o.read())
 
                 c.flush()

--- a/smarts/sstudio/scenario_construction.py
+++ b/smarts/sstudio/scenario_construction.py
@@ -44,7 +44,9 @@ def build_scenario(
         if seed is not None:
             with tempfile.NamedTemporaryFile("w", suffix=".py", dir=scenario_root) as c:
                 with open(scenario_py, "r") as o:
-                    c.write(f"from smarts.core import seed as smarts_seed; smarts_seed({seed});\n")
+                    c.write(
+                        f"from smarts.core import seed as smarts_seed; smarts_seed({seed});\n"
+                    )
                     c.write(o.read())
 
                 c.flush()


### PR DESCRIPTION
This allows the metrics wrapper to be used over top of other wrappers instead of directly on `hiway-v1` by using `info["env_obs"]`.

This can also be placed over top of a `hiway-v0` using the `gymnasium.wrappers.compatibility.EnvCompatibility` wrapper and then converted back to a `gym` environment using our `smarts.env.gymnasium.wrappers.api_reversion.Api021Reversion` wrapper.