### PR TITLE
Engine configuration utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 
 ## [Unreleased]
 ### Added
+- Engine configuration utility that uses the following locations to allow configuration of the SMARTS engine. The engine consumes the configuration files from the following locations in the following priority: `./engine.ini`, `~/.smarts/engine.ini`, `$GLOBAL_USER/smarts/engine.ini`, and `${PYTHON_ENV}/lib/${PYTHON_VERSION}/site-packages/smarts/engine.ini`.
 - Added map source uri as `map_source` inside of `hiway-v1` reset info to indicate what the current map is on reset.
 ### Changed
 - Made changes in the docs to reflect `master` branch as the main development branch.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include smarts/core/glsl/*.vert smarts/core/glsl/*.frag
 include smarts/core/models/*.glb smarts/core/models/*.urdf
 include smarts/core/models/controller_parameters.yaml
 include envision/web/dist/*
+include smarts/*.ini
 recursive-include smarts/benchmark *.yaml *.yml
 recursive-include smarts/ros/src *.launch *.msg *.srv package.xml CMakeLists.txt *.py
 recursive-include smarts/scenarios *.xml *.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,7 @@ extensions = [
     "sphinx.ext.coverage",  # to generate documentation coverage reports
     "sphinx.ext.extlinks",  # shorten external links
     "sphinx.ext.napoleon",  # support Numpy and Google doc style
+    "sphinx.ext.todo", # support for todo items
     "sphinx.ext.viewcode",  # link to sourcecode from docs
     "sphinx_rtd_theme",  # Read The Docs theme
     "sphinx_click",  # extract documentation from a `click` application
@@ -89,6 +90,8 @@ autodoc_mock_imports = [
     "tools",
     "waymo_open_dataset",
 ]
+
+todo_include_todos = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/ecosystem/sumo.rst
+++ b/docs/ecosystem/sumo.rst
@@ -5,7 +5,7 @@ SUMO
 
 Learn SUMO through its user `documentation <https://sumo.dlr.de/docs/index.html>`_ . 
 
-SMARTS currently directly installs SUMO version >=1.12.0 via `pip`. 
+SMARTS currently directly installs SUMO version >=1.15.0 via `pip`. 
 
 .. code-block:: bash
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,6 +46,7 @@ If you use SMARTS in your research, please cite the `paper <https://arxiv.org/ab
    sim/simulator.rst
    sim/scenario_studio.rst
    sim/bubbles.rst
+   sim/configuration.rst
 
 .. toctree::
    :hidden:
@@ -69,7 +70,6 @@ If you use SMARTS in your research, please cite the `paper <https://arxiv.org/ab
    :caption: API
 
    api/modules.rst
-   sim/configuration.rst
 
 .. toctree::
    :hidden:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,6 +69,7 @@ If you use SMARTS in your research, please cite the `paper <https://arxiv.org/ab
    :caption: API
 
    api/modules.rst
+   sim/configuration.rst
 
 .. toctree::
    :hidden:
@@ -88,3 +89,4 @@ If you use SMARTS in your research, please cite the `paper <https://arxiv.org/ab
    resources/diagnostic.rst
    resources/faq.rst
    resources/contributing.rst
+   resources/todo.rst

--- a/docs/resources/contributing.rst
+++ b/docs/resources/contributing.rst
@@ -100,6 +100,10 @@ Execute the following to build the docs locally.
     $ python3.8 -m http.server 8000 --bind 127.0.0.1 -d docs/_build/html
     # Open http://127.0.0.1:8000 in your browser
 
+If documentation is incomplete please mark the area with a ``.. todo::`` as described in `sphinx.ext.todo <https://www.sphinx-doc.org/en/master/usage/extensions/todo.html>`_.
+
+Feel free to further contribute to the documentation and look at :ref:`todo` for sections that may yet need to be filled.
+
 Communication
 -------------
 

--- a/docs/resources/todo.rst
+++ b/docs/resources/todo.rst
@@ -1,0 +1,8 @@
+.. _todo:
+
+TODO List
+=========
+
+A list of current documentation TODO.
+
+.. todolist_::

--- a/docs/sim/configuration.rst
+++ b/docs/sim/configuration.rst
@@ -5,7 +5,7 @@ Configuration
 
 You can change the behavior of the underlying SMARTS engine.
 
-Configuration of the engine can come from several sources. These locations take precidence as noted:
+Configuration of the engine can come from several sources. These locations take precedence as noted:
 
 1. Individual ``SMARTS_`` prefixed environment variables (e.g. ``SMARTS_SENSOR_WORKER_COUNT``)
 2. Local directory engine configuration (./smarts_engine.ini )

--- a/docs/sim/configuration.rst
+++ b/docs/sim/configuration.rst
@@ -1,0 +1,27 @@
+.. _configuration:
+
+Configuration
+=============
+
+You can change the behavior of the underlying SMARTS engine.
+
+Configuration of the engine can come from several sources. These locations take precidence as noted:
+
+1. Individual ``SMARTS_`` prefixed environment variables (e.g. ``SMARTS_SENSOR_WORKER_COUNT``)
+2. Local directory engine configuration (./smarts_engine.ini )
+3. Local user engine configuration, ``~/.smarts/engine.ini``, if local directory configuration is not found.
+4. Global engine configuration, ``/etc/smarts/engine.ini``, if local configuration is not found.
+5. Package default configuration, ``$PYTHON_PATH/smarts/engine.ini``, if global configuration is not found.
+
+Note that configuration files resolve all settings at the first found configuration file (they do not layer.)
+
+Options
+-------
+
+All settings demostrated as environment variables are formatted to ``UPPERCASE`` and prefixed with ``SMARTS_`` (e.g. ``[core] logging`` can be configured with ``SMARTS_CORE_LOGGING``)
+
+These settings are as follows:
+
+.. todo::
+
+    List engine settings

--- a/docs/sim/configuration.rst
+++ b/docs/sim/configuration.rst
@@ -18,7 +18,7 @@ Note that configuration files resolve all settings at the first found configurat
 Options
 -------
 
-All settings demostrated as environment variables are formatted to ``UPPERCASE`` and prefixed with ``SMARTS_`` (e.g. ``[core] logging`` can be configured with ``SMARTS_CORE_LOGGING``)
+All settings demonstrated as environment variables are formatted to ``UPPERCASE`` and prefixed with ``SMARTS_`` (e.g. ``[core] logging`` can be configured with ``SMARTS_CORE_LOGGING``)
 
 These settings are as follows:
 

--- a/smarts/benchmark/entrypoints/benchmark_runner_v0.py
+++ b/smarts/benchmark/entrypoints/benchmark_runner_v0.py
@@ -28,7 +28,6 @@ import psutil
 import ray
 
 from smarts.benchmark.driving_smarts import load_config
-from smarts.benchmark.driving_smarts.v0 import DEFAULT_CONFIG
 from smarts.core.utils.logging import suppress_output
 from smarts.env.gymnasium.wrappers.metrics import Metrics, Score
 from smarts.zoo import registry as agent_registry

--- a/smarts/core/__init__.py
+++ b/smarts/core/__init__.py
@@ -56,7 +56,23 @@ def gen_id():
 
 
 @lru_cache(maxsize=1)
-def config(default=Path(".") / "smarts_engine.ini") -> Config:
+def config(default=str("./smarts_engine.ini")) -> Config:
+    """Get the SMARTS environment config for the smarts engine.
+
+    .. note::
+
+        This searches the following locations and loads the first one it finds:
+        ./smarts_engine.ini
+        ~/.smarts/engine.ini
+        /etc/smarts/engine.ini
+        $PYTHON_PATH/smarts/engine.ini
+
+    Args:
+        default (str, optional): The default configurable location. Defaults to "./smarts_engine.ini".
+
+    Returns:
+        Config: A configuration utility that allows resolving environment and `engine.ini` configuration.
+    """
     from smarts.core.utils.file import smarts_global_user_dir, smarts_local_user_dir
 
     def get_file(config_file):
@@ -70,7 +86,7 @@ def config(default=Path(".") / "smarts_engine.ini") -> Config:
 
     conf = partial(Config, environment_prefix="SMARTS")
 
-    file = get_file(default)
+    file = get_file(Path(default))
     if file:
         return conf(file)
 

--- a/smarts/core/__init__.py
+++ b/smarts/core/__init__.py
@@ -30,7 +30,6 @@ from pathlib import Path
 
 import numpy as np
 
-import smarts
 from smarts.core.configuration import Config
 
 _current_seed = None
@@ -56,7 +55,7 @@ def gen_id():
 
 
 @lru_cache(maxsize=1)
-def config(default=str("./smarts_engine.ini")) -> Config:
+def config(default: str = "./smarts_engine.ini") -> Config:
     """Get the SMARTS environment config for the smarts engine.
 
     .. note::
@@ -75,7 +74,7 @@ def config(default=str("./smarts_engine.ini")) -> Config:
     """
     from smarts.core.utils.file import smarts_global_user_dir, smarts_local_user_dir
 
-    def get_file(config_file):
+    def get_file(config_file: Path):
         try:
             if not config_file.is_file():
                 return ""
@@ -86,7 +85,7 @@ def config(default=str("./smarts_engine.ini")) -> Config:
 
     conf = partial(Config, environment_prefix="SMARTS")
 
-    file = get_file(Path(default))
+    file = get_file(Path(default).absolute())
     if file:
         return conf(file)
 
@@ -104,4 +103,5 @@ def config(default=str("./smarts_engine.ini")) -> Config:
     if file:
         return conf(file)
 
-    return conf(get_file(Path(smarts.__file__).parent.absolute() / "engine.ini"))
+    default_path = Path(__file__).parents[1].resolve() / "engine.ini"
+    return conf(get_file(default_path))

--- a/smarts/core/configuration.py
+++ b/smarts/core/configuration.py
@@ -1,3 +1,24 @@
+# MIT License
+# 
+# Copyright (C) 2023. Huawei Technologies Co., Ltd. All rights reserved.
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 import configparser
 import functools
 import os

--- a/smarts/core/configuration.py
+++ b/smarts/core/configuration.py
@@ -1,0 +1,75 @@
+import configparser
+import functools
+import os
+from pathlib import Path
+from typing import Any, Callable, Optional, Union
+
+_UNSET = object()
+
+
+class Config:
+    """A configuration utility that handles configuration from file and environment variable.
+
+    Args:
+        config_file (Union[str, Path]): The path to the configuration file.
+        environment_prefix (str, optional): The prefix given to the environment variables. Defaults to "".
+
+    Raises:
+
+    """
+
+    def __init__(
+        self, config_file: Union[str, Path], environment_prefix: str = ""
+    ) -> None:
+        config_file = str(config_file)
+        if not Path(config_file).is_file():
+            raise FileNotFoundError(f"Configuration file not found at {config_file}")
+
+        self._config = configparser.ConfigParser(
+            interpolation=configparser.ExtendedInterpolation
+        )
+        self._config.read(config_file)
+        self._environment_prefix = environment_prefix.upper()
+        self._format_string = self._environment_prefix + "_{}_{}"
+
+    @property
+    def environment_prefix(self):
+        """The prefix that environment variables configuration is provided with."""
+        return self._environment_prefix
+
+    @functools.lru_cache(maxsize=100)
+    def get_setting(
+        self,
+        section: str,
+        option: str,
+        default: Any = _UNSET,
+        cast: Callable[[str], Any] = str,
+    ) -> Optional[Any]:
+        """Finds the given configuration checking the following in order: environment variable,
+        configuration file, and default.
+
+        Args:
+            section (str): The grouping that the configuration option is under.
+            option (str): The specific configuration option.
+            default (Any, optional): The default if the requested configuration option is not found. Defaults to _UNSET.
+            cast (Callable, optional): A function that takes a string and returns the desired type. Defaults to str.
+
+
+        Returns:
+            Optional[str]: The value of the configuration.
+
+        Raises:
+            KeyError: If the configuration option is not found in the configuration file and no default is provided.
+            configparser.NoSectionError: If the section in the configuration file is not found and no default is provided.
+        """
+        env_variable = self._format_string.format(section.upper(), option.upper())
+        setting = os.getenv(env_variable)
+        if setting is not None:
+            return cast(setting)
+        try:
+            value = self._config[section][option]
+        except (configparser.NoSectionError, KeyError):
+            if default is _UNSET:
+                raise
+            return default
+        return cast(value)

--- a/smarts/core/configuration.py
+++ b/smarts/core/configuration.py
@@ -1,17 +1,17 @@
 # MIT License
-# 
+#
 # Copyright (C) 2023. Huawei Technologies Co., Ltd. All rights reserved.
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
@@ -42,14 +42,15 @@ class Config:
     def __init__(
         self, config_file: Union[str, Path], environment_prefix: str = ""
     ) -> None:
-        config_file = str(config_file)
-        if not Path(config_file).is_file():
+        if isinstance(config_file, str):
+            config_file = Path(config_file)
+        if not config_file.is_file():
             raise FileNotFoundError(f"Configuration file not found at {config_file}")
 
         self._config = configparser.ConfigParser(
-            interpolation=configparser.ExtendedInterpolation
+            interpolation=configparser.ExtendedInterpolation()
         )
-        self._config.read(config_file)
+        self._config.read(str(config_file.absolute()))
         self._environment_prefix = environment_prefix.upper()
         self._format_string = self._environment_prefix + "_{}_{}"
 

--- a/smarts/core/configuration.py
+++ b/smarts/core/configuration.py
@@ -95,3 +95,15 @@ class Config:
                 raise
             return default
         return cast(value)
+
+    def __call__(
+        self,
+        section: str,
+        option: str,
+        default: Any = _UNSET,
+        cast: Callable[[str], Any] = str,
+    ) -> Optional[Any]:
+        return self.get_setting(section, option, default, cast)
+
+    def __repr__(self) -> str:
+        return f"Config(config_file={ {k: dict(v.items()) for k, v in self._config.items(raw=True)} }, environment_prefix={self._environment_prefix})"

--- a/smarts/core/configuration.py
+++ b/smarts/core/configuration.py
@@ -36,7 +36,7 @@ class Config:
         environment_prefix (str, optional): The prefix given to the environment variables. Defaults to "".
 
     Raises:
-
+        FileNotFoundError: If the configuration file cannot be found at the given file location.
     """
 
     def __init__(

--- a/smarts/core/smarts.py
+++ b/smarts/core/smarts.py
@@ -1282,19 +1282,10 @@ class SMARTS(ProviderManager):
     @fixed_timestep_sec.setter
     def fixed_timestep_sec(self, fixed_timestep_sec: float):
         if not fixed_timestep_sec:
-            # This is the fastest we could possibly run given constraints from pybullet
-            self._rounder = rounder_for_dt(
-                round(
-                    1
-                    / config()(
-                        "physics",
-                        "max_pybullet_freq",
-                        default=MAX_PYBULLET_FREQ,
-                        cast=int,
-                    ),
-                    6,
-                )
+            max_pybullet_freq = config()(
+                "physics", "max_pybullet_freq", default=MAX_PYBULLET_FREQ, cast=int
             )
+            self._rounder = rounder_for_dt(round(1 / max_pybullet_freq, 6))
         else:
             self._rounder = rounder_for_dt(fixed_timestep_sec)
         self._fixed_timestep_sec = fixed_timestep_sec

--- a/smarts/core/smarts.py
+++ b/smarts/core/smarts.py
@@ -32,7 +32,7 @@ from smarts import VERSION
 from smarts.core.plan import Plan
 from smarts.core.utils.logging import timeit
 
-from . import models, config
+from . import config, models
 from .actor import ActorRole, ActorState
 from .agent_interface import AgentInterface
 from .agent_manager import AgentManager
@@ -70,6 +70,8 @@ logging.basicConfig(
     datefmt="%Y-%m-%d,%H:%M:%S",
     level=logging.ERROR,
 )
+
+MAX_PYBULLET_FREQ = 240
 
 
 class SMARTSNotSetupError(Exception):
@@ -726,7 +728,9 @@ class SMARTS(ProviderManager):
         client.configureDebugVisualizer(
             pybullet.COV_ENABLE_GUI, 0  # pylint: disable=no-member
         )
-        MAX_PYBULLET_FREQ = config()("physics", "max_pybullet_freq", cast=int)
+        max_pybullet_freq = config()(
+            "physics", "max_pybullet_freq", default=MAX_PYBULLET_FREQ, cast=int
+        )
         # PyBullet defaults the timestep to 240Hz. Several parameters are tuned with
         # this value in mind. For example the number of solver iterations and the error
         # reduction parameters (erp) for contact, friction and non-contact joints.
@@ -739,11 +743,11 @@ class SMARTS(ProviderManager):
         self._pybullet_period = (
             self._fixed_timestep_sec
             if self._fixed_timestep_sec
-            else 1 / MAX_PYBULLET_FREQ
+            else 1 / max_pybullet_freq
         )
         client.setPhysicsEngineParameter(
             fixedTimeStep=self._pybullet_period,
-            numSubSteps=int(self._pybullet_period * MAX_PYBULLET_FREQ),
+            numSubSteps=int(self._pybullet_period * max_pybullet_freq),
             numSolverIterations=10,
             solverResidualThreshold=0.001,
             # warmStartingFactor=0.99
@@ -1280,7 +1284,16 @@ class SMARTS(ProviderManager):
         if not fixed_timestep_sec:
             # This is the fastest we could possibly run given constraints from pybullet
             self._rounder = rounder_for_dt(
-                round(1 / config().get_setting("physics", "max_pybullet_freq", cast=int), 6)
+                round(
+                    1
+                    / config()(
+                        "physics",
+                        "max_pybullet_freq",
+                        default=MAX_PYBULLET_FREQ,
+                        cast=int,
+                    ),
+                    6,
+                )
             )
         else:
             self._rounder = rounder_for_dt(fixed_timestep_sec)

--- a/smarts/core/tests/test_configuration.py
+++ b/smarts/core/tests/test_configuration.py
@@ -1,0 +1,69 @@
+# MIT License
+#
+# Copyright (C) 2023. Huawei Technologies Co., Ltd. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+import configparser
+import functools
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from smarts.core.configuration import Config
+
+
+@pytest.fixture
+def config_path() -> str:
+    config = configparser.ConfigParser()
+    config["section_1"] = {"string_option": "value", "option_2": "value_2"}
+    config["section_2"] = {"bool_option": "True", "float_option": "3.14"}
+    with tempfile.TemporaryDirectory() as tmpdir:
+        file = Path(tmpdir) / "config.ini"
+        with file.open("w") as file_pointer:
+            config.write(fp=file_pointer)
+        yield str(file)
+
+
+def test_get_setting_with_file(config_path):
+    config = Config(config_path)
+    assert config.get_setting("section_1", "string_option") == "value"
+    partition_string = functools.partial(
+        lambda source, sep: str.partition(source, sep), sep="_"
+    )
+    assert config.get_setting("section_1", "option_2", cast=partition_string) == (
+        "value",
+        "_",
+        "2",
+    )
+    assert config.get_setting("section_2", "bool_option", cast=bool) is True
+    assert config.get_setting("section_2", "float_option", cast=float) == 3.14
+    with pytest.raises(KeyError):
+        config.get_setting("nonexistent", "option")
+
+
+def test_get_setting_with_environment_variables(config_path):
+    config = Config(config_path, "smarts")
+    assert config.get_setting("nonexistent", "option", default=None) is None
+
+    os.environ["SMARTS_NONEXISTENT_OPTION"] = "now_exists"
+    config = Config(config_path, "smarts")
+    assert config.get_setting("nonexistent", "option", default=None) == "now_exists"
+    del os.environ["SMARTS_NONEXISTENT_OPTION"]

--- a/smarts/core/tests/test_configuration.py
+++ b/smarts/core/tests/test_configuration.py
@@ -67,3 +67,17 @@ def test_get_setting_with_environment_variables(config_path):
     config = Config(config_path, "smarts")
     assert config.get_setting("nonexistent", "option", default=None) == "now_exists"
     del os.environ["SMARTS_NONEXISTENT_OPTION"]
+
+
+def test_get_missing_section_and_missing_option():
+    from smarts.core import config as core_conf
+
+    core_conf.cache_clear()
+
+    config: Config = core_conf()
+
+    with pytest.raises(KeyError):
+        config.get_setting("core", "not_a_setting")
+    
+    with pytest.raises(KeyError):
+        config.get_setting("not_a_section", "bar")

--- a/smarts/core/tests/test_configuration.py
+++ b/smarts/core/tests/test_configuration.py
@@ -31,7 +31,7 @@ from smarts.core.configuration import Config
 
 
 @pytest.fixture
-def config_path() -> str:
+def config_path():
     config = configparser.ConfigParser()
     config["section_1"] = {"string_option": "value", "option_2": "value_2"}
     config["section_2"] = {"bool_option": "True", "float_option": "3.14"}

--- a/smarts/core/tests/test_configuration.py
+++ b/smarts/core/tests/test_configuration.py
@@ -78,6 +78,6 @@ def test_get_missing_section_and_missing_option():
 
     with pytest.raises(KeyError):
         config.get_setting("core", "not_a_setting")
-    
+
     with pytest.raises(KeyError):
         config.get_setting("not_a_section", "bar")

--- a/smarts/core/utils/file.py
+++ b/smarts/core/utils/file.py
@@ -142,17 +142,31 @@ def pickle_hash_int(obj) -> int:
     return c_int64(val).value
 
 
-def smarts_log_dir() -> str:
-    """Retrieves the smarts logging directory."""
+def smarts_local_user_dir() -> str:
+    """Retrieves the smarts logging directory.
+
+    Returns:
+        str: The smarts local user directory path.
+    """
     ## Following should work for linux and macos
     smarts_dir = os.path.join(os.path.expanduser("~"), ".smarts")
     os.makedirs(smarts_dir, exist_ok=True)
     return smarts_dir
 
 
+def smarts_global_user_dir() -> str:
+    """Retrieves the smarts global user directory.
+
+    Returns:
+        str: The smarts global user directory path.
+    """
+    smarts_dir = os.path.join("/etc", "smarts")
+    return smarts_dir
+
+
 def make_dir_in_smarts_log_dir(dir):
     """Return a new directory location in the smarts logging directory."""
-    return os.path.join(smarts_log_dir(), dir)
+    return os.path.join(smarts_local_user_dir(), dir)
 
 
 @contextmanager

--- a/smarts/engine.ini
+++ b/smarts/engine.ini
@@ -1,0 +1,8 @@
+[benchmark]
+[core]
+[controllers]
+[physics]
+max_pybullet_freq = 240
+[providers]
+[rendering]
+[resources]

--- a/smarts/env/utils/record.py
+++ b/smarts/env/utils/record.py
@@ -24,13 +24,13 @@ import gym
 import numpy as np
 
 from smarts.core.sensors import Observation
-from smarts.core.utils.file import smarts_log_dir
+from smarts.core.utils.file import smarts_local_user_dir
 from smarts.env.wrappers.utils.rendering import vis_sim_obs
 
 Action = Any
 Operation = Any
 
-default_log_dir = smarts_log_dir()
+default_log_dir = smarts_local_user_dir()
 
 
 class AgentCameraRGBRender:

--- a/smarts/env/wrappers/format_action.py
+++ b/smarts/env/wrappers/format_action.py
@@ -31,8 +31,8 @@ class FormatAction(gym.ActionWrapper):
 
     Note:
 
-        (a) Only ``ActionSpaceType.Continuous``, ``ActionSpaceType.Lane``, 
-            ``ActionSpaceType.ActuatorDynamic``, and `ActionSpaceType.TargetPose`` 
+        (a) Only ``ActionSpaceType.Continuous``, ``ActionSpaceType.Lane``,
+            ``ActionSpaceType.ActuatorDynamic``, and `ActionSpaceType.TargetPose``
             are supported by this wrapper now.
 
         (b) All agents should have the same action space.
@@ -98,7 +98,9 @@ def _lane() -> Tuple[Callable[[Dict[str, int]], Dict[str, str]], gym.Space]:
     return wrapper, space
 
 
-def _actuator_dynamic() -> Tuple[Callable[[Dict[str, np.ndarray]], Dict[str, np.ndarray]], gym.Space]:
+def _actuator_dynamic() -> Tuple[
+    Callable[[Dict[str, np.ndarray]], Dict[str, np.ndarray]], gym.Space
+]:
     space = gym.spaces.Box(
         low=np.array([0.0, 0.0, -1.0]), high=np.array([1.0, 1.0, 1.0]), dtype=np.float32
     )


### PR DESCRIPTION
This adds an engine configuration utility to SMARTS.

- [X] Add configuration utility.
- [x] Add tests.
- [x] Confirm that configuration can be shared between processes.
- [x] Add issue to convert engine constants to use config. https://github.com/huawei-noah/SMARTS/issues/1854
- [x] Update changelog.