### PR TITLE
Add the map source to the hiway-v1 reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 
 ## [Unreleased]
 ### Added
+- Added map source as `map_source` inside of `hiway-v1` reset info.
 ### Changed
 ### Deprecated
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 
 ## [Unreleased]
 ### Added
-- Added map source as `map_source` inside of `hiway-v1` reset info.
+- Added map source uri as `map_source` inside of `hiway-v1` reset info to indicate what the current map is on reset.
 ### Changed
 ### Deprecated
 ### Fixed

--- a/smarts/env/gymnasium/hiway_env_v1.py
+++ b/smarts/env/gymnasium/hiway_env_v1.py
@@ -350,7 +350,7 @@ class HiWayEnvV1(gym.Env):
 
         self._dones_registered = 0
         observations = self._smarts.reset(scenario)
-        info = {}
+        info = {"map_source": self._smarts.scenario.road_map.source}
 
         if self._env_renderer is not None:
             self._env_renderer.reset(observations)


### PR DESCRIPTION
This provides the map source on reset of the `hiway-v1` environment.

Closes #1747