### PR TITLE
Run benchmark directly using agent locator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Added map source uri as `map_source` inside of `hiway-v1` reset info to indicate what the current map is on reset.
 ### Changed
 - Made changes in the docs to reflect `master` branch as the main development branch.
+- Enabled supplying agent locator directly to benchmark runner and removed need for an intermediary config file.
 ### Deprecated
 ### Fixed
 - Fixed an exit error that occurs when envision attempts to close down.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Added map source uri as `map_source` inside of `hiway-v1` reset info to indicate what the current map is on reset.
 ### Changed
 - Made changes in the docs to reflect `master` branch as the main development branch.
-- Enabled supplying agent locator directly to benchmark runner and removed need for an intermediary config file.
+- Enabled supplying agent locator directly to benchmark runner and removed the need for an intermediary config file. Updated benchmark docs to reflect this.
+- Individualised the agent instances in the `benchmark_runner_v0.py`.
+- Made driving_smarts_competition_v0 env configurable through supply of `AgentInterface`.
+- Observation of driving_smarts_competition_v0 env was fixed to be of type `ObservationOptions.unformatted`.
 ### Deprecated
 ### Fixed
 - Fixed an exit error that occurs when envision attempts to close down.

--- a/baselines/driving_smarts/v0/agent_config.yaml
+++ b/baselines/driving_smarts/v0/agent_config.yaml
@@ -1,8 +1,0 @@
-agent:
-  interface:
-    action_space: "RelativeTargetPose" # we can only allow `RelativeTargetPose` and `TargetPose`
-    img_meters: 50 # Observation image area size in meters.
-    img_pixels: 112 # Observation image size in pixels.
-  locator: "smarts.zoo:random-relative-target-pose-agent-v0"
-  kwargs:
-    speed: 20 # Provided to the agent

--- a/cli/benchmark.py
+++ b/cli/benchmark.py
@@ -36,7 +36,7 @@ def benchmark_cli():
     "run",
 )
 @click.argument("benchmark_id", nargs=1, metavar="<benchmark_id>")
-@click.argument("agent_config", nargs=1, metavar="<agent_config>")
+@click.argument("agent_locator", nargs=1, metavar="<agent_locator>")
 @click.option(
     "--debug-log",
     is_flag=True,
@@ -57,7 +57,7 @@ def benchmark_cli():
 )
 def run(
     benchmark_id: str,
-    agent_config: str,
+    agent_locator: str,
     debug_log: bool,
     benchmark_listing: Optional[str],
     auto_install: bool,
@@ -68,22 +68,20 @@ def run(
 
     \b
     <benchmark_id> is formatted like BENCHMARK_NAME==BENCHMARK_VERSION.
-    <agent_config> is the path to an agent configuration file.
+    <agent_locator> is the locator string for the registered agent.
 
-    An example use: `scl benchmark run --auto-install driving_smarts==0.0 ./baselines/driving_smarts/v0/agent_config.yaml`
+    An example use: `scl benchmark run --auto-install driving_smarts==0.0 random-relative-target-pose-agent-v0`
     """
     from smarts.benchmark import BENCHMARK_LISTING_FILE, run_benchmark
 
     benchmark_id, _, benchmark_version = benchmark_id.partition("==")
 
     run_benchmark(
-        benchmark_id,
-        float(benchmark_version) if benchmark_version else None,
-        Path(agent_config),
-        Path(benchmark_listing)
-        if benchmark_listing is not None
-        else BENCHMARK_LISTING_FILE,
-        debug_log,
+        benchmark_name=benchmark_id,
+        benchmark_version=float(benchmark_version) if benchmark_version else None,
+        agent_locator=agent_locator,
+        benchmark_listing=Path(benchmark_listing) if benchmark_listing is not None else BENCHMARK_LISTING_FILE,
+        debug_log=debug_log,
         auto_install=auto_install,
     )
 

--- a/cli/benchmark.py
+++ b/cli/benchmark.py
@@ -80,7 +80,9 @@ def run(
         benchmark_name=benchmark_id,
         benchmark_version=float(benchmark_version) if benchmark_version else None,
         agent_locator=agent_locator,
-        benchmark_listing=Path(benchmark_listing) if benchmark_listing is not None else BENCHMARK_LISTING_FILE,
+        benchmark_listing=Path(benchmark_listing)
+        if benchmark_listing is not None
+        else BENCHMARK_LISTING_FILE,
         debug_log=debug_log,
         auto_install=auto_install,
     )

--- a/docs/benchmarks/benchmark.rst
+++ b/docs/benchmarks/benchmark.rst
@@ -9,8 +9,8 @@ Run a benchmark
 | Run a particular benchmark by executing 
 | ``scl benchmark run <benchmark_name>==<benchmark_version> <agent_locator> --auto-install`` 
 
-The ``--auto-install`` flag is optional and is only
-needed once at the start to install the benchmark's dependencies.
+The ``--auto-install`` flag is optional and is only needed for the
+first time the benchmark is run to install the benchmark's dependencies.
 
 If ``scl benchmark run <benchmark_name> <agent_locator>`` is run without the
 benchmark version, then the benchmark's latest version is run by default.

--- a/docs/benchmarks/benchmark.rst
+++ b/docs/benchmarks/benchmark.rst
@@ -1,139 +1,23 @@
 .. _benchmark:
 
-Driving SMARTS 2022
-===================
+Instructions
+============
 
-The Driving SMARTS 2022 is a benchmark derived from the
-NeurIPS 2022 Driving SMARTS Competition.
+Run a benchmark
+---------------
 
-This benchmark is intended to address the following requirements:
+| Run a particular benchmark by executing 
+| ``scl benchmark run <benchmark_name>==<benchmark_version> <agent_locator> --auto-install`` 
 
--  The benchmark should use an up to date version of gym to simplify the
-   interface. (we used gymnasium)
--  The competition gym environment should strictly follow the
-   requirements of the gym interface to allow for obvious actions and
-   observations.
--  The observations out of this environment should be just data.
--  The benchmark runner should be configurable for future benchmark
-   versions.
--  Added benchmarks should be versioned.
--  Added benchmarks should be discover-able.
+The ``--auto-install`` flag is optional and is only
+needed once at the start to install the benchmark's dependencies.
 
-See: https://smarts-project.github.io/archive/2022_nips_driving_smarts/
-for historical context.
-
-Benchmark discovery
--------------------
-
-The ``scl benchmark list`` command is used to check what benchmarks are
-available.
+If ``scl benchmark run <benchmark_name> <agent_locator>`` is run without the
+benchmark version, then the benchmark's latest version is run by default.
 
 .. code:: bash
 
-   $ scl benchmark list 
-   BENCHMARK_NAME               BENCHMARK_ID             VERSIONS
-   - Driving SMARTS:            driving_smarts           0.0 0.1
-
-If creating your own version it is also possible to use
-``--benchmark-listing`` to target a different benchmark listing file.
-
-Agent configuration
--------------------
-
-Agent Configuration for Driving SMARTS 0.0
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The current version of the agent configuration is as follows:
-
-.. code:: yaml
-
-   # baselines/driving_smarts/v0/agent_config.yaml
-   agent:
-     interface: # This is a section specific to the benchmark `driving_smarts==0.0`
-       # we currently allow `RelativeTargetPose` and `TargetPose` 
-       action_space: "RelativeTargetPose" 
-       img_meters: 50 # Observation image area size in meters.
-       img_pixels: 112 # Observation image size in pixels.
-     locator: "smarts.zoo:random-relative-target-pose-agent-v0" # This is an example agent
-     kwargs: # A collection of keyword arguments provided to the agent entrypoint
-       speed: 20
-
-Of particular note is the ``locator`` which is has to resolve to the
-registration of an agent. This can be registered as seen below.
-
-.. code:: python
-
-   # smarts/zoo/__init__.py
-   import math
-   import random
-   from typing import Any, Dict
-
-   from smarts.core.agent import Agent
-   from smarts.core.agent_interface import ActionSpaceType, AgentInterface
-   from smarts.zoo.agent_spec import AgentSpec
-   from smarts.zoo.registry import register
-
-
-   class RandomRelativeTargetPoseAgent(Agent):
-       """A simple agent that can move a random distance."""
-
-       def __init__(self, speed=28, timestep=0.1) -> None:
-           super().__init__()
-           self._speed_per_step = speed / timestep
-
-       def act(self, obs: Dict[str, Any], **configs):
-           return [
-               (random.random() - 0.5) * self._speed_per_step,
-               (random.random() - 0.5) * self._speed_per_step,
-               random.random() * 2 * math.pi - math.pi,
-           ]
-
-   # Note `speed` from configuration file maps here.
-   def entry_point(speed=10, **kwargs):
-       """An example entrypoint for a simple agent.
-       This can have any number of arguments similar to the gym environment standard.
-       """
-       return AgentSpec(
-           AgentInterface(
-               action=ActionSpaceType.RelativeTargetPose,
-           ),
-           agent_builder=RandomRelativeTargetPoseAgent,
-           agent_params=dict(speed=speed),
-       )
-
-
-   # Where the name of the agent is registered.
-   # note this is in `smarts/zoo/__init__.py` which is the `smarts.zoo` module.
-   # this would be referenced like `"smarts.zoo:random-relative-target-pose-agent-v0"`
-   register("random-relative-target-pose-agent-v0", entry_point)
-
-The syntax of the referencing the locator is like ``"``
-``module.importable.in.python`` ``:`` ``registered_name_of_agent``
-``-v`` ``X`` ``"``.
-
--  Module: ``module.importable.in.python`` The module section must be
-   importable from within python. An easy test to see if the module is
-   importable is to try importing the module within interactive python
-   or a script (e.g. ``import module.importable.in.python``)
--  Separator: ``:`` This separates the module and name sections of the
-   locator.
--  Registered name: ``registered_name_of_agent`` The name of the agent
-   as registered using ``smarts.zoo.register``.
--  Version separator: ``-v`` This separates the name and version
-   sections of the locator.
--  Version: ``X`` The version of the agent (this is required to register
-   an agent.) ``X`` can be any integer.
-
-Running the benchmark
----------------------
-
-The easiest way to run the benchmark is through ``scl benchmark run``.
-This takes a benchmark name, benchmark version, and agent configuration
-file.
-
-.. code:: bash
-
-   $ scl benchmark run driving_smarts "./baselines/driving_smarts/v0/agent_config.yaml" --auto-install # --auto-install only needs to be used to get dependencies.
+   $ scl benchmark run driving_smarts smarts.zoo:random-relative-target-pose-agent-v0 --auto-install 
    Starting `Driving SMARTS V1` benchmark.
    This is a cleaned up version of the Driving SMARTS benchmark.
 
@@ -156,48 +40,45 @@ file.
    - time: 0.2
    - overall: 0.504
 
-A particular version of a benchmark can be targeted using a modified
-syntax ``benchmark_name==version``:
+See available benchmarks
+------------------------
+
+The ``scl benchmark list`` command can be used to see the list of available benchmarks.
 
 .. code:: bash
 
-   $ scl benchmark run driving_smarts==0.0 "./baselines/driving_smarts/v0/agent_config.yaml"
+   $ scl benchmark list 
+   BENCHMARK_NAME               BENCHMARK_ID             VERSIONS
+   - Driving SMARTS:            driving_smarts           0.0 0.1
 
-Advanced Configuration
-----------------------
+Custom benchmark listing
+------------------------
 
-``--benchmark-listing``
-~~~~~~~~~~~~~~~~~~~~~~~
-
-``scl benchmark run``
-^^^^^^^^^^^^^^^^^^^^^
-
-The benchmark listing file is used by ``scl benchmark run`` to determine
-what benchmarks are currently available. This can be passed using
-``--benchmark-listing`` to provide a different list of benchmarks.
+The ``scl benchmark run`` uses a 
+`default benchmark listing <https://github.com/huawei-noah/SMARTS/blob/master/smarts/benchmark/benchmark_listing.yaml>`_ 
+file to determine the currently available benchmarks. Alternatively, a custom
+benchmark listing file may be supplied as follows.   
 
 .. code:: bash
 
-   $ scl benchmark run --benchmark-listing benchmark_listing.yaml driving_smarts "./baselines/driving_smarts/v0/agent_config.yaml"
+   $ scl benchmark run --benchmark-listing benchmark_listing.yaml <benchmark_name> <agent_locator>
 
-WARNING! Since with ``scl benchmark run`` this listing directs to a code
-``entrypoint`` do not use this with a listing file from an unknown
-source.
+.. warning::
 
-``scl benchmark list``
-^^^^^^^^^^^^^^^^^^^^^^
+    Since a listing directs ``scl benchmark run`` to execute an 
+    ``entrypoint`` code, do not use this with a listing file from an unknown
+    source.
 
-This option also appears on ``scl benchmark list`` to examine a listing
-file.
+The list of benchmarks from the custom benchmark listing file can be examined as usual.
 
 .. code:: bash
 
    $ scl benchmark list --benchmark-listing benchmark_listing.yaml
 
-Listing File
-^^^^^^^^^^^^
+Benchmark listing file
+----------------------
 
-The listing file is organised as below.
+The benchmark listing file is organised as below.
 
 .. code:: yaml
 
@@ -216,17 +97,18 @@ The listing file is organised as below.
            params: # additional values to pass into the entrypoint as named keyword arguments.
              benchmark_config: ${{smarts.benchmark.driving_smarts.v0}}/config.yaml
 
-Resolving module directories
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. note:: 
+    
+    Resolving module directories.
 
-The benchmark configuration directory can be dynamically found through
-python using an evaluation syntax ``${{}}``. This is experimental and
-open to change but the following resolves the python module location in
-loaded configuration files:
+    The benchmark configuration directory can be dynamically found through
+    python using an evaluation syntax ``${{}}``. This is experimental and
+    open to change but the following resolves the python module location in
+    loaded configuration files:
 
-.. code:: yaml
+    .. code:: yaml
 
-   somewhere_path: ${{module.to.resolve}}/file.txt # resolves to <path>/module/to/resolve/file.txt
+        somewhere_path: ${{module.to.resolve}}/file.txt # resolves to <path>/module/to/resolve/file.txt
 
-This avoids loading the module into python but resolves to the first
-path that matches the module.
+    This avoids loading the module into python but resolves to the first
+    path that matches the module.

--- a/docs/benchmarks/driving_smarts_2022.rst
+++ b/docs/benchmarks/driving_smarts_2022.rst
@@ -1,0 +1,39 @@
+.. _driving_smarts_2022:
+
+Driving SMARTS 2022
+===================
+
+The Driving SMARTS 2022 is a benchmark derived from the
+NeurIPS 2022 Driving SMARTS Competition.
+
+This benchmark is intended to address the following requirements:
+
+-  The benchmark should use an up to date version of gym to simplify the
+   interface. (we used gymnasium)
+-  The competition gym environment should strictly follow the
+   requirements of the gym interface to allow for obvious actions and
+   observations.
+-  The observations out of this environment should be just data.
+-  The benchmark runner should be configurable for future benchmark
+   versions.
+-  Added benchmarks should be versioned.
+-  Added benchmarks should be discover-able.
+
+See `NeurIPS 2022 Driving SMARTS <https://smarts-project.github.io/archive/2022_nips_driving_smarts/>`_ page for historical context.
+
+This benchmark allows ego agents to use any one of the following action spaces.
+
++ :attr:`~smarts.core.controllers.ActionSpaceType.TargetPose`
++ :attr:`~smarts.core.controllers.ActionSpaceType.RelativeTargetPose`
+
+Compatible zoo agents
+---------------------
+
+A list of SMARTS zoo agents which are compatible with this benchmark is
+provided here. A compatible zoo agent can be run as follows.
+
+.. code-block:: bash
+
+    $ cd <path>/SMARTS
+    $ scl zoo install <path/to/agent policy>
+    $ scl benchmark run driving_smarts==0.0 <agent_locator> --auto_install

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,7 @@ If you use SMARTS in your research, please cite the `paper <https://arxiv.org/ab
    :caption: Benchmarks
 
    benchmarks/benchmark.rst
+   benchmarks/driving_smarts_2022.rst
 
 .. toctree::
    :hidden:

--- a/docs/sim/agent.rst
+++ b/docs/sim/agent.rst
@@ -72,20 +72,20 @@ A registered agent can, at a later time, be built (i.e., instantiated) using its
     # Builds the agent, by instantiatng the agent's policy.
     follow_waypoints_agent = make_agent("smarts.zoo:follow-waypoints-v0")
 
-The syntax of an agent locator is: 
-``"`` ``module.importable.in.python`` ``:`` ``registered_name_of_agent`` ``-v`` ``X`` ``"``
+| The syntax of an agent locator is:
+| ``"`` ``module.importable.in.python`` ``:`` ``registered_name_of_agent`` ``-v`` ``X`` ``"``
 
--  ``module.importable.in.python``: Denotes the module containing the agent
-  registry. In SMARTS, agent registry is at ``smarts.zoo``. The module must be 
-  importable from within python. An easy test to see if the module is 
-  importable, is to try importing the module within interactive python or a 
-  script (e.g., ``import module.importable.in.python``)
-- ``:``: A separator, which separates the module and name sections of the
-   locator.
--  ``registered_name_of_agent``: The registered name of the agent.
--  ``-v``: A version separator, which separates the name and version
+-  ``module.importable.in.python`` : Denotes the module containing the agent
+   registry. In SMARTS, agent registry is at ``smarts.zoo``. The module must be 
+   importable from within python. An easy test to see if the module is  
+   importable, is to try importing the module within interactive python or a 
+   script (e.g., ``import module.importable.in.python``)
+- ``:`` : A separator, which separates the module and name sections of the
+  locator.
+-  ``registered_name_of_agent`` : The registered name of the agent.
+-  ``-v`` : A version separator, which separates the name and version
    sections of the locator.
--  ``X``: The version of the agent. This is required to register
+-  ``X`` : The version of the agent. This is required to register
    an agent. The version can be any integer.
 
 

--- a/docs/sim/agent.rst
+++ b/docs/sim/agent.rst
@@ -75,9 +75,10 @@ A registered agent can, at a later time, be built (i.e., instantiated) using its
 | The syntax of an agent locator is:
 | ``"`` ``module.importable.in.python`` ``:`` ``registered_name_of_agent`` ``-v`` ``X`` ``"``
 
--  ``module.importable.in.python`` : Denotes the module containing the agent
-   registry. In SMARTS, agent registry is at ``smarts.zoo``. The module must be 
-   importable from within python. An easy test to see if the module is  
+-  ``module.importable.in.python`` : Denotes the module in which the agent was 
+   registered. For example, if the agent was registered in 
+   ``smarts/zoo/__init__.py``, the module would be ``smarts.zoo``. The module
+   must be importable from within python. An easy test to see if the module is
    importable, is to try importing the module within interactive python or a 
    script (e.g., ``import module.importable.in.python``)
 - ``:`` : A separator, which separates the module and name sections of the

--- a/docs/sim/agent.rst
+++ b/docs/sim/agent.rst
@@ -48,24 +48,46 @@ Next, a minimal example of how to create and register an agent is illustrated.
         ),
         # Agent's policy.
         agent_builder=FollowWaypoints,
+        agent_params=None, # Optional parameters passed to agent_builder during building. 
     )
 
-    # Builds the agent, by instantiatng the agent's policy.
-    agent = agent_spec.build_agent()
+    def entry_point(**kwargs):
+       """An entrypoint for the agent, which takes any number of optional keyword
+       arguments, and returns an :class:`~smarts.zoo.agent_spec.AgentSpec`.
+       """
+       return agent_spec
 
-    # Registers the agent.
+    # Register the agent.
     register(
         locator="follow-waypoints-v0",
-        entry_point=lambda **kwargs: agent_spec,
+        entry_point=entry_point,
     )
 
-A registered agent can be invoked later.
+A registered agent can, at a later time, be built (i.e., instantiated) using its agent locator string.
 
 .. code-block:: python
 
-    from smarts.zoo.registry import make as zoo_make
+    from smarts.zoo.registry import make_agent
 
-    agent_spec = zoo_make("follow-waypoints-v0")
+    # Builds the agent, by instantiatng the agent's policy.
+    follow_waypoints_agent = make_agent("smarts.zoo:follow-waypoints-v0")
+
+The syntax of an agent locator is: 
+``"`` ``module.importable.in.python`` ``:`` ``registered_name_of_agent`` ``-v`` ``X`` ``"``
+
+-  ``module.importable.in.python``: Denotes the module containing the agent
+  registry. In SMARTS, agent registry is at ``smarts.zoo``. The module must be 
+  importable from within python. An easy test to see if the module is 
+  importable, is to try importing the module within interactive python or a 
+  script (e.g., ``import module.importable.in.python``)
+- ``:``: A separator, which separates the module and name sections of the
+   locator.
+-  ``registered_name_of_agent``: The registered name of the agent.
+-  ``-v``: A version separator, which separates the name and version
+   sections of the locator.
+-  ``X``: The version of the agent. This is required to register
+   an agent. The version can be any integer.
+
 
 Sections below elaborate on the agent's `interface` and `policy` design.
 

--- a/docs/sim/agent.rst
+++ b/docs/sim/agent.rst
@@ -87,7 +87,7 @@ A registered agent can, at a later time, be built (i.e., instantiated) using its
 -  ``-v`` : A version separator, which separates the name and version
    sections of the locator.
 -  ``X`` : The version of the agent. This is required to register
-   an agent. The version can be any integer.
+   an agent. The version can be any positive integer.
 
 
 Sections below elaborate on the agent's `interface` and `policy` design.

--- a/smarts/benchmark/__init__.py
+++ b/smarts/benchmark/__init__.py
@@ -70,7 +70,7 @@ def _get_entrypoint(path, name):
 def run_benchmark(
     benchmark_name: str,
     benchmark_version: Optional[float],
-    agent_config: Path,
+    agent_locator: str,
     benchmark_listing: Path,
     debug_log: bool = False,
     auto_install: bool = False,
@@ -81,7 +81,7 @@ def run_benchmark(
     Args:
         benchmark_name(str): The name of the benchmark to run.
         benchmark_version(float|None): The version of the benchmark.
-        agent_config(Path): An agent configuration file.
+        agent_locator(str): Locator string for the registered agent.
         benchmark_listing(Path): A configuration file that lists benchmark metadata and must list
             the target benchmark.
         debug_log: Debug to stdout.
@@ -108,7 +108,7 @@ def run_benchmark(
     entrypoint = _get_entrypoint(module, name)
     entrypoint(
         **benchmark_spec.get("params", {}),
-        agent_config=str(agent_config),
+        agent_locator=agent_locator,
         debug_log=debug_log,
     )
 

--- a/smarts/benchmark/entrypoints/benchmark_runner_v0.py
+++ b/smarts/benchmark/entrypoints/benchmark_runner_v0.py
@@ -48,7 +48,7 @@ def _eval_worker_local(name, env_config, episodes, agent_locator, error_tolerant
     env = gym.make(
         env_config["env"],
         scenario=env_config["scenario"],
-        agent_interface=agent_registry.make(locator=agent_locator).interface
+        agent_interface=agent_registry.make(locator=agent_locator).interface,
         **env_config["kwargs"],
     )
     env = Metrics(env)

--- a/smarts/core/smarts.py
+++ b/smarts/core/smarts.py
@@ -860,7 +860,7 @@ class SMARTS(ProviderManager):
             except (AttributeError, KeyboardInterrupt):
                 return
             raise exception
-            
+
     def _teardown_vehicles(self, vehicle_ids):
         self._vehicle_index.teardown_vehicles_by_vehicle_ids(vehicle_ids)
         self._clear_collisions(vehicle_ids)

--- a/smarts/env/gymnasium/driving_smarts_competition_env.py
+++ b/smarts/env/gymnasium/driving_smarts_competition_env.py
@@ -39,8 +39,8 @@ from smarts.core.agent_interface import (
 )
 from smarts.core.controllers import ActionSpaceType
 from smarts.env.gymnasium.hiway_env_v1 import HiWayEnvV1, SumoOptions
-from smarts.sstudio.scenario_construction import build_scenario
 from smarts.env.utils.observation_conversion import ObservationOptions
+from smarts.sstudio.scenario_construction import build_scenario
 
 logger = logging.getLogger(__file__)
 logger.setLevel(logging.WARNING)
@@ -67,11 +67,11 @@ def driving_smarts_competition_v0_env(
         An unformatted :class:`~smarts.core.observations.Observation` is returned as observation.
 
     Action space for each agent:
-        Action space for each agent is configured through its `AgentInterface`. 
+        Action space for each agent is configured through its `AgentInterface`.
         The action space could be either of the following.
-        
+
         (i) :attr:`~smarts.core.controllers.ActionSpaceType.RelativeTargetPose`
-        
+
            +------------------------------------+-------------+-------+
            | Action                             | Values      | Units |
            +====================================+=============+=======+
@@ -110,7 +110,7 @@ def driving_smarts_competition_v0_env(
         agent_interface (AgentInterface): Agent interface specification.
         headless (bool, optional): If True, disables visualization in
             Envision. Defaults to False.
-        seed (int, optional): Random number generator seed. Defaults to 42.    
+        seed (int, optional): Random number generator seed. Defaults to 42.
         visdom (bool, optional): If True, enables visualization of observed
             RGB images in Visdom. Defaults to False.
         sumo_headless (bool, optional): If True, disables visualization in
@@ -127,8 +127,7 @@ def driving_smarts_competition_v0_env(
 
     resolved_agent_interface = resolve_agent_interface(agent_interface)
     agent_interfaces = {
-        f"Agent_{i}": resolved_agent_interface
-        for i in range(env_specs["num_agent"])
+        f"Agent_{i}": resolved_agent_interface for i in range(env_specs["num_agent"])
     }
     env_action_space = resolve_env_action_space(agent_interfaces)
 
@@ -303,10 +302,10 @@ def resolve_env_action_space(agent_interfaces: Dict[str, AgentInterface]):
     )
 
 
-def resolve_agent_interface(agent_interface:AgentInterface):
+def resolve_agent_interface(agent_interface: AgentInterface):
     """Resolve the agent interface for a given environment. Some interface
     values can be configured by the user, but others are pre-determined and
-    fixed. 
+    fixed.
     """
 
     done_criteria = DoneCriteria(
@@ -397,9 +396,7 @@ class _LimitTargetPose(gym.Wrapper):
         filtered_obs: Dict[str, Dict[str, Any]] = {}
         for agent_name, agent_obs in obs.items():
             filtered_obs[agent_name] = {
-                "position": copy.deepcopy(
-                    agent_obs.ego_vehicle_state.position[:2]
-                )
+                "position": copy.deepcopy(agent_obs.ego_vehicle_state.position[:2])
             }
         return filtered_obs
 

--- a/smarts/env/gymnasium/driving_smarts_competition_env.py
+++ b/smarts/env/gymnasium/driving_smarts_competition_env.py
@@ -32,17 +32,15 @@ import numpy as np
 from envision.client import Client as Envision
 from envision.client import EnvisionDataFormatterArgs
 from smarts.core.agent_interface import (
-    OGM,
-    RGB,
     AgentInterface,
     DoneCriteria,
-    DrivableAreaGridMap,
     RoadWaypoints,
     Waypoints,
 )
 from smarts.core.controllers import ActionSpaceType
 from smarts.env.gymnasium.hiway_env_v1 import HiWayEnvV1, SumoOptions
 from smarts.sstudio.scenario_construction import build_scenario
+from smarts.env.utils.observation_conversion import ObservationOptions
 
 logger = logging.getLogger(__file__)
 logger.setLevel(logging.WARNING)
@@ -56,9 +54,7 @@ MAXIMUM_SPEED_MPS = 28  # 28m/s = 100.8 km/h. This is a safe maximum speed.
 
 def driving_smarts_competition_v0_env(
     scenario: str,
-    img_meters: int = 64,
-    img_pixels: int = 256,
-    action_space="RelativeTargetPose",
+    agent_interface: AgentInterface,
     headless: bool = True,
     seed: int = 42,
     visdom: bool = False,
@@ -68,110 +64,70 @@ def driving_smarts_competition_v0_env(
     """An environment with a mission to be completed by a single or multiple ego agents.
 
     Observation space for each agent:
-
-        A ``smarts.core.sensors.Observation`` is returned as observation.
+        An unformatted :class:`~smarts.core.observations.Observation` is returned as observation.
 
     Action space for each agent:
-    .. note::
+        Action space for each agent is configured through its `AgentInterface`. 
+        The action space could be either of the following.
+        
+        (i) :attr:`~smarts.core.controllers.ActionSpaceType.RelativeTargetPose`
+        
+           +------------------------------------+-------------+-------+
+           | Action                             | Values      | Units |
+           +====================================+=============+=======+
+           | Δx-coordinate                      | [-2.8, 2.8] | m     |
+           +------------------------------------+-------------+-------+
+           | Δy-coordinate                      | [-2.8, 2.8] | m     |
+           +------------------------------------+-------------+-------+
+           | Heading with respect to map's axes | [-π, π]     | rad   |
+           +------------------------------------+-------------+-------+
 
-        A ``smarts.core.controllers.ActionSpaceType.RelativeTargetPose``, which is a
-        sequence of [Δx, Δy, heading] or a
-        ``smarts.core.controllers.ActionSpaceType.TargetPose``, which is a
-            sequence of [x-coordinate, y-coordinate, heading, 0.1].
+        (ii) :attr:`~smarts.core.controllers.ActionSpaceType.TargetPose`
 
-        Type(RelativeTargetPose):
-
-        .. code-block:: python
-
-            gym.spaces.Box(
-                    low=np.array([-28, -28, -π]),
-                    high=np.array([28, 28, π]),
-                    dtype=np.float32
-                    )
-
-        .. list-table:: Table
-            :widths: 25 25
-            :header-rows: 1
-
-            * - Action
-              - Value range
-            * - Ego's next x-coordinate on the map
-              - [-2.8m/s,2.8m/s]
-            * - Ego's next y-coordinate on the map
-              - [-2.8m/s,2.8m/s]
-            * - Ego's next heading with respect to the map's axes
-              - [-π,π]
-
-        Type(TargetPose):
-
-        .. code-block:: python
-
-            gym.spaces.Box(
-                    low=np.array([-1e10, -1e10, -π, 0.1]),
-                    high=np.array([1e10, 1e10, π], 0.1),
-                    dtype=np.float32
-                    )
-
-        .. list-table:: Table
-            :widths: 25 25
-            :header-rows: 1
-
-            * - Action
-              - Value range
-            * - Ego's next x-coordinate on the map
-              - [-1e10m,1e10m]
-            * - Ego's next y-coordinate on the map
-              - [-1e10m,1e10m]
-            * - Ego's next heading with respect to the map's axes
-              - [-π,π]
-            * - The time delta snapped to 0.1 seconds.
-              - [0.1,0.1]
+            +------------------------------------+---------------+-------+
+            | Action                             | Values        | Units |
+            +====================================+===============+=======+
+            | Next x-coordinate                  | [-1e10, 1e10] | m     |
+            +------------------------------------+---------------+-------+
+            |  Next y-coordinate                 | [-1e10, 1e10] | m     |
+            +------------------------------------+---------------+-------+
+            | Heading with respect to map's axes | [-π, π]       | rad   |
+            +------------------------------------+---------------+-------+
+            | ΔTime                              |  0.1          | s     |
+            +------------------------------------+---------------+-------+
 
     Reward:
-
         Reward is distance travelled (in meters) in each step, including the termination step.
 
     Episode termination:
-
-    .. note::
-
         Episode is terminated if any of the following occurs.
 
-            1. Steps per episode exceed 800.
+        1. Steps per episode exceed 800.
+        2. Agent collides, drives off road, drives off route, or drives on wrong way.
 
-            2. Agent collides, drives off road, drives off route, or drives on wrong way.
+    Args:
+        scenario (str): Scenario name or path to scenario folder.
+        agent_interface (AgentInterface): Agent interface specification.
+        headless (bool, optional): If True, disables visualization in
+            Envision. Defaults to False.
+        seed (int, optional): Random number generator seed. Defaults to 42.    
+        visdom (bool, optional): If True, enables visualization of observed
+            RGB images in Visdom. Defaults to False.
+        sumo_headless (bool, optional): If True, disables visualization in
+            SUMO GUI. Defaults to True.
+        envision_record_data_replay_path (Optional[str], optional):
+            Envision's data replay output directory. Defaults to None.
 
-    Solved requirement:
-
-    .. note::
-
-        If agent successfully completes the mission then ``info["score"]`` will
-        equal 1, else it is 0. Considered solved when ``info["score"] == 1`` is
-        achieved over 500 consecutive episodes.
-
-    :param scenario: Scenario name or path to scenario folder.
-    :type scenario: str
-    :param img_meters: Ground square size covered by image observations. Defaults to 64 x 64 meter (height x width) square.
-    :type img_meters: int
-    :param img_pixels: Pixels representing the square image observations. Defaults to 256 x 256 pixels (height x width) square.
-    :type img_pixels: int
-    :param action_space: Action space used. Defaults to ``Continuous``.
-    :param headless: If True, disables visualization in Envision. Defaults to False.
-    :type headless: bool, optional
-    :param visdom: If True, enables visualization of observed RGB images in Visdom. Defaults to False.
-    :type visdom: bool, optional
-    :param sumo_headless: If True, disables visualization in SUMO GUI. Defaults to True.
-    :type sumo_headless: bool, optional
-    :param envision_record_data_replay_path: Envision's data replay output directory. Defaults to None.
-    :type envision_record_data_replay_path: Optional[str], optional
-    :return: An environment described by the input argument ``scenario``.
+    Returns:
+        An environment described by the input argument `scenario`.
     """
 
     env_specs = _get_env_specs(scenario)
     build_scenario(scenario=env_specs["scenario"])
 
+    resolved_agent_interface = resolve_agent_interface(agent_interface)
     agent_interfaces = {
-        f"Agent_{i}": resolve_agent_interface(img_meters, img_pixels, action_space)
+        f"Agent_{i}": resolved_agent_interface
         for i in range(env_specs["num_agent"])
     }
     env_action_space = resolve_env_action_space(agent_interfaces)
@@ -194,12 +150,14 @@ def driving_smarts_competition_v0_env(
         sim_name="Driving_SMARTS_v0",
         headless=headless,
         visdom=visdom,
+        fixed_timestep_sec=0.1,
         seed=seed,
         sumo_options=SumoOptions(headless=sumo_headless),
         visualization_client_builder=visualization_client_builder,
+        observation_options=ObservationOptions.unformatted,
     )
     env.action_space = env_action_space
-    if ActionSpaceType[action_space] == ActionSpaceType.TargetPose:
+    if resolved_agent_interface.action == ActionSpaceType.TargetPose:
         env = _LimitTargetPose(env)
     return env
 
@@ -345,13 +303,11 @@ def resolve_env_action_space(agent_interfaces: Dict[str, AgentInterface]):
     )
 
 
-def resolve_agent_interface(
-    img_meters: int = 64,
-    img_pixels: int = 256,
-    action_space="RelativeTargetPose",
-    **kwargs,
-):
-    """Resolve an agent interface for the environments in this module."""
+def resolve_agent_interface(agent_interface:AgentInterface):
+    """Resolve the agent interface for a given environment. Some interface
+    values can be configured by the user, but others are pre-determined and
+    fixed. 
+    """
 
     done_criteria = DoneCriteria(
         collision=True,
@@ -367,26 +323,14 @@ def resolve_agent_interface(
     waypoints_lookahead = 50
     return AgentInterface(
         accelerometer=True,
-        action=ActionSpaceType[action_space],
+        action=agent_interface.action,
         done_criteria=done_criteria,
-        drivable_area_grid_map=DrivableAreaGridMap(
-            width=img_pixels,
-            height=img_pixels,
-            resolution=img_meters / img_pixels,
-        ),
+        drivable_area_grid_map=agent_interface.drivable_area_grid_map,
         lidar_point_cloud=True,
         max_episode_steps=max_episode_steps,
         neighborhood_vehicle_states=True,
-        occupancy_grid_map=OGM(
-            width=img_pixels,
-            height=img_pixels,
-            resolution=img_meters / img_pixels,
-        ),
-        top_down_rgb=RGB(
-            width=img_pixels,
-            height=img_pixels,
-            resolution=img_meters / img_pixels,
-        ),
+        occupancy_grid_map=agent_interface.occupancy_grid_map,
+        top_down_rgb=agent_interface.top_down_rgb,
         road_waypoints=RoadWaypoints(horizon=road_waypoint_horizon),
         waypoint_paths=Waypoints(lookahead=waypoints_lookahead),
     )
@@ -454,7 +398,7 @@ class _LimitTargetPose(gym.Wrapper):
         for agent_name, agent_obs in obs.items():
             filtered_obs[agent_name] = {
                 "position": copy.deepcopy(
-                    agent_obs["ego_vehicle_state"]["position"][:2]
+                    agent_obs.ego_vehicle_state.position[:2]
                 )
             }
         return filtered_obs


### PR DESCRIPTION
Runs the benchmark directly using an agent locator string, instead of going through a config file such as  `SMARTS/baselines/driving_smarts/v0/agent_config.yaml`.

Addresses https://github.com/huawei-noah/SMARTS/pull/1838#discussion_r1100329033 .