### PR TITLE
Add NeurIPS 2022 Discrete Soft Actor Critic agent to agent zoo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Added NGSIM documentation.
 - Added a zoo agent, named Interaction-aware Motion Prediction, from NeurIPS2022 submission. This zoo agent runs in benchmark `driving_smarts==0.0`.
 - Added Agent Zoo documentation in ReadTheDocs.
+- Added a zoo agent, named Discrete Soft Actor Critic, from NeurIPS 2022 submission. This zoo agent runs in benchmark `driving_smarts==0.0`.
 ### Changed
 - Made changes in the docs to reflect `master` branch as the main development branch.
 - Enabled supplying agent locator directly to benchmark runner and removed the need for an intermediary config file. Updated benchmark docs to reflect this.

--- a/docs/benchmarks/agent_zoo.rst
+++ b/docs/benchmarks/agent_zoo.rst
@@ -53,7 +53,7 @@ Available zoo agents
      - driving_smarts==0.0
      - :attr:`~smarts.core.controllers.ActionSpaceType.TargetPose`
      - `code <https://github.com/smarts-project/smarts-project.rl/tree/master/interaction_aware_motion_prediction>`__
-     - Contributed as part of `NeurIPS 2022 Driving SMARTS <https://smarts-project.github.io/archive/2022_nips_driving_smarts/>`_ competition.
+     - Contributed as part of `NeurIPS 2022 Driving SMARTS <https://smarts-project.github.io/archive/2022_nips_driving_smarts/>`__ competition.
    * - | zoo.policies:control-and-supervised-learning-agent-v0
        | zoo/policies/control_and_supervised_learning
      - driving_smarts==0.0
@@ -65,4 +65,4 @@ Available zoo agents
      - driving_smarts==0.0
      - :attr:`~smarts.core.controllers.ActionSpaceType.TargetPose`
      - `code <https://github.com/smarts-project/smarts-project.rl/tree/master/discrete_soft_actor_critic>`__
-     - Contributed as part of `NeurIPS 2022 Driving SMARTS <https://smarts-project.github.io/archive/2022_nips_driving_smarts/>`_ competition.
+     - Contributed as part of `NeurIPS 2022 Driving SMARTS <https://smarts-project.github.io/archive/2022_nips_driving_smarts/>`__ competition.

--- a/docs/benchmarks/agent_zoo.rst
+++ b/docs/benchmarks/agent_zoo.rst
@@ -54,3 +54,9 @@ Available zoo agents
      - :attr:`~smarts.core.controllers.ActionSpaceType.TargetPose`
      - `code <https://github.com/smarts-project/smarts-project.rl/tree/master/interaction_aware_motion_prediction>`__
      - Contributed as part of `NeurIPS 2022 Driving SMARTS <https://smarts-project.github.io/archive/2022_nips_driving_smarts/>`_ competition.
+   * - | zoo.policies:discrete-soft-actor-critic-agent-v0
+       | zoo/policies/discrete_soft_actor_critic
+     - driving_smarts==0.0
+     - :attr:`~smarts.core.controllers.ActionSpaceType.TargetPose`
+     - `code <https://github.com/smarts-project/smarts-project.rl/tree/master/discrete_soft_actor_critic>`__
+     - Contributed as part of `NeurIPS 2022 Driving SMARTS <https://smarts-project.github.io/archive/2022_nips_driving_smarts/>`_ competition.

--- a/zoo/policies/__init__.py
+++ b/zoo/policies/__init__.py
@@ -133,3 +133,19 @@ def entry_point_iamp(**kwargs):
 register(
     locator="interaction-aware-motion-prediction-agent-v0", entry_point=entry_point_iamp
 )
+
+def entry_point_dsac(**kwargs):
+    pkg = "discrete_soft_actor_critic"
+    module = ".policy"
+    lib = _verify_installation(pkg=pkg, module=module)
+
+    return AgentSpec(
+        interface=AgentInterface(
+            action=ActionSpaceType.TargetPose,
+        ),
+        agent_builder=lib.Policy,
+    )
+
+register(
+    locator="discrete-soft-actor-critic-agent-v0", entry_point=entry_point_dsac
+)

--- a/zoo/policies/__init__.py
+++ b/zoo/policies/__init__.py
@@ -134,6 +134,7 @@ register(
     locator="interaction-aware-motion-prediction-agent-v0", entry_point=entry_point_iamp
 )
 
+
 def entry_point_dsac(**kwargs):
     pkg = "discrete_soft_actor_critic"
     module = ".policy"
@@ -146,6 +147,5 @@ def entry_point_dsac(**kwargs):
         agent_builder=lib.Policy,
     )
 
-register(
-    locator="discrete-soft-actor-critic-agent-v0", entry_point=entry_point_dsac
-)
+
+register(locator="discrete-soft-actor-critic-agent-v0", entry_point=entry_point_dsac)

--- a/zoo/policies/discrete_soft_actor_critic/setup.cfg
+++ b/zoo/policies/discrete_soft_actor_critic/setup.cfg
@@ -1,0 +1,19 @@
+[metadata]
+name = smarts_agent_dsac_stub
+version = 0.1.0
+url = https://github.com/huawei-noah/SMARTS
+description = SMARTS zoo agent.
+long_description = Trained Discrete Soft Actor Critic agent. See [SMARTS](https://github.com/huawei-noah/SMARTS).
+long_description_content_type=text/markdown
+classifiers=
+    Programming Language :: Python
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.8
+
+[options]
+packages = find:
+include_package_data = True
+zip_safe = True
+python_requires = == 3.8.*
+install_requires = 
+    smarts_agent_dsac==0.1.0

--- a/zoo/policies/discrete_soft_actor_critic/setup.py
+++ b/zoo/policies/discrete_soft_actor_critic/setup.py
@@ -1,0 +1,4 @@
+from setuptools import setup
+
+if __name__ == "__main__":
+    setup()


### PR DESCRIPTION
+ Adds agent contributed as part of NeurIPS 2022 Driving SMARTS competition to the SMARTS agent zoo.
+ Agent added: [Discrete Soft Actor Critic](https://github.com/GrandpaDZB/2022NeurIPS_SMARTS_competition_code)
+ Policy files are hosted at PyPI and [smarts-project](https://github.com/smarts-project/smarts-project.rl/tree/master/discrete_soft_actor_critic).
+ Added documentation in ReadTheDocs.