### PR TITLE
Make heading relative in RelativeTargetPose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - `HiWayEnvV1` derived environments now allow an explicit scenario through `reset(options["scenario"])`.
 - `HiWayEnvV1` derived environments now allow an explicit simulation start time through `reset(options["start_time"])`.
 - Exposed `smarts` as a property on `HiWayEnvV1`.
+- Made the heading input relative to the current heading in `RelativeTargetPose` action space.
 ### Deprecated
 ### Fixed
 ### Removed

--- a/smarts/core/controllers/__init__.py
+++ b/smarts/core/controllers/__init__.py
@@ -138,9 +138,9 @@ class ActionSpaceType(Enum):
     """
     RelativeTargetPose = 11
     """
-    Action=(delta_x, delta_y, heading). Type= ``Sequence[float,
+    Action=(delta_x, delta_y, delta_heading). Type= ``Sequence[float,
     float, float]``. Continuous action space of vehicle's next pose in terms of delta x 
-    coordinate, delta y coordinate, and heading, to be reached in 0.1 seconds.
+    coordinate, delta y coordinate, and delta heading, to be reached in 0.1 seconds.
     """
 
 
@@ -246,7 +246,7 @@ class Controllers:
                 motion_action = [
                     action[0] + position[0],
                     action[1] + position[1],
-                    action[2],
+                    action[2] + heading,
                     0.1,
                 ]
             MotionPlannerController.perform_action(

--- a/smarts/env/gymnasium/driving_smarts_competition_env.py
+++ b/smarts/env/gymnasium/driving_smarts_competition_env.py
@@ -79,7 +79,7 @@ def driving_smarts_competition_v0_env(
            +------------------------------------+-------------+-------+
            | Δy-coordinate                      | [-2.8, 2.8] | m     |
            +------------------------------------+-------------+-------+
-           | Heading with respect to map's axes | [-π, π]     | rad   |
+           | Δheading                           | [-π, π]     | rad   |
            +------------------------------------+-------------+-------+
 
         (ii) :attr:`~smarts.core.controllers.ActionSpaceType.TargetPose`
@@ -89,7 +89,7 @@ def driving_smarts_competition_v0_env(
             +====================================+===============+=======+
             | Next x-coordinate                  | [-1e10, 1e10] | m     |
             +------------------------------------+---------------+-------+
-            |  Next y-coordinate                 | [-1e10, 1e10] | m     |
+            | Next y-coordinate                  | [-1e10, 1e10] | m     |
             +------------------------------------+---------------+-------+
             | Heading with respect to map's axes | [-π, π]       | rad   |
             +------------------------------------+---------------+-------+


### PR DESCRIPTION
Makes the heading input relative to the current heading in `RelativeTargetPose` action space.