### PR TITLE
[Fix] Provider removes social agents at inappropriate time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 ### Deprecated
 ### Fixed
 - Missing neighborhood vehicle ids are now added to the `highway-v1` formatted observations.
+- Stopped agent providers from removing social agents when they have no actor.
 ### Removed
 ### Security
 

--- a/smarts/core/agents_provider.py
+++ b/smarts/core/agents_provider.py
@@ -20,6 +20,7 @@
 
 import logging
 import weakref
+import warnings
 from functools import lru_cache
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
@@ -125,14 +126,10 @@ class AgentsProvider(Provider):
         self._remove_actors_without_actions(agent_actions)
         agents_without_actors = agent_actions.keys() - self._my_agent_actors.keys()
         if agents_without_actors:
-            self._log.error(
-                "actions specified for an agent without an actor: %s. Cleaning up social agents.",
+            warnings.warn(
+                "actions specified for an agent without an actor: %s.",
                 agents_without_actors,
             )
-            orphaned_social_agents = (
-                self._agent_manager.social_agent_ids & agents_without_actors
-            )
-            self._agent_manager.teardown_social_agents(orphaned_social_agents)
 
         agent_manager = self._agent_manager
         vehicle_index = self._vehicle_index

--- a/smarts/core/agents_provider.py
+++ b/smarts/core/agents_provider.py
@@ -127,8 +127,8 @@ class AgentsProvider(Provider):
         agents_without_actors = agent_actions.keys() - self._my_agent_actors.keys()
         if agents_without_actors:
             warnings.warn(
-                "actions specified for an agent without an actor: %s.",
-                agents_without_actors,
+                "actions specified for an agent without an actor: %s."
+                % agents_without_actors,
             )
 
         agent_manager = self._agent_manager


### PR DESCRIPTION
The AgentsProvider was removing agents at a weird time as noted here https://github.com/huawei-noah/SMARTS/issues/1870#issuecomment-1441067349

Removing agents that have no actor at this point complicates managing agents.

See CHANGELOG.md