### PR TITLE
Fix sstudio trip generation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 ### Deprecated
 ### Fixed
 - Missing neighborhood vehicle ids are now added to the `highway-v1` formatted observations.
+- Using `trip` in sstudio traffic generation no longer causes a durouter error.
 ### Removed
 ### Security
 

--- a/smarts/sstudio/generators.py
+++ b/smarts/sstudio/generators.py
@@ -322,7 +322,7 @@ class TrafficGenerator:
                 "vehicle",
                 id="{}".format(trip.vehicle_name),
                 type=actor.id,
-                route=route.id,
+                route=route.id + "trip",
                 depart=trip.depart,
                 departLane=route.begin[1],
                 departPos=route.begin[2],


### PR DESCRIPTION
`duarouter` was unable to find the trip route because the trip was named differently from that provided to the sumo vehicle definition.