### PR TITLE
Remove unique id suffix from agent vehicle name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 ## [Unreleased]
 ### Added
 ### Changed
+- Unique id suffix is removed from vehicle name while building agent vehicle in `VehicleIndex.build_agent_vehicle()` function. 
 ### Deprecated
 ### Fixed
 - Missing neighborhood vehicle ids are now added to the `highway-v1` formatted observations.

--- a/smarts/core/vehicle_index.py
+++ b/smarts/core/vehicle_index.py
@@ -607,17 +607,16 @@ class VehicleIndex:
         boid=False,
     ):
         """Build an entirely new vehicle for an agent."""
-        vehicle_id = f"{agent_id}-{gen_id()}"
         vehicle = Vehicle.build_agent_vehicle(
-            sim,
-            vehicle_id,
-            agent_interface,
-            plan,
-            filepath,
-            tire_filepath,
-            trainable,
-            surface_patches,
-            initial_speed,
+            sim=sim,
+            vehicle_id=agent_id,
+            agent_interface=agent_interface,
+            plan=plan,
+            vehicle_filepath=filepath,
+            tire_filepath=tire_filepath,
+            trainable=trainable,
+            surface_patches=surface_patches,
+            initial_speed=initial_speed,
         )
 
         sensor_state = SensorState(


### PR DESCRIPTION
Unique id suffix is removed from vehicle name while building agent vehicle in `VehicleIndex.build_agent_vehicle()` function. 