### PR TITLE
Return done value and rewards for all agents in HiWayEnvV1 when observation options are set to 'full"

### DIFF
--- a/smarts/env/gymnasium/hiway_env_v1.py
+++ b/smarts/env/gymnasium/hiway_env_v1.py
@@ -293,9 +293,9 @@ class HiWayEnvV1(gym.Env):
         if self._observations_formatter.observation_options == ObservationOptions.full:
             return (
                 self._observations_formatter.format(observations),
-                sum(r for r in rewards.values()),
-                dones["__all__"],
-                dones["__all__"],
+                rewards,
+                dones,
+                dones,
                 info,
             )
         elif self._observations_formatter.observation_options in (


### PR DESCRIPTION
Hi, I wanted to propose a simple change to the `step` method of `HiWayEnvV1`. 

Currently, when `observation_options` are set to `full`, the `step` method returns only a single value for both `done` and `reward`, respectively. I think, however, that this behavior is undesirable for a few reasons:

1. (I think that) this deviates from the PettingZoo parallel API, which makes it less convenient to pass a `HiWayEnvV1` instance to a wrapper intended for PettingZoo environments. 
2. The docs don't specify that the reward and done values will be affected.
3. There could be separate formatting options for `reward` and `done`