### PR TITLE
Fix SMARTS ignores social agent start time.

### DIFF
--- a/scenarios/sumo/zoo_intersection/scenario.py
+++ b/scenarios/sumo/zoo_intersection/scenario.py
@@ -86,17 +86,19 @@ gen_scenario(
         social_agent_missions={
             f"s-agent-{social_agent2.name}": (
                 [social_agent2],
-                [Mission(RandomRoute())],
+                [
+                    Mission(
+                        Route(
+                            begin=("edge-south-SN", 0, 30), end=("edge-east-WE", 0, 10)
+                        ),
+                    ),
+                 ],
             ),
             f"s-agent-{social_agent1.name}": (
                 [social_agent1],
                 [
-                    EndlessMission(begin=("edge-south-SN", 0, 30)),
-                    Mission(
-                        Route(
-                            begin=("edge-west-WE", 0, 10), end=("edge-east-WE", 0, 10)
-                        )
-                    ),
+                    EndlessMission(begin=("edge-south-SN", 0, 10), start_time=0.7),
+
                 ],
             ),
         },

--- a/smarts/core/agent_manager.py
+++ b/smarts/core/agent_manager.py
@@ -61,6 +61,7 @@ class AgentManager:
         # would not be included
         self._initial_interfaces = interfaces
         self._pending_agent_ids = set()
+        self._pending_social_agent_ids = set()
 
         # Agent interfaces are interfaces for _all_ active agents
         self._agent_interfaces = {}
@@ -117,6 +118,11 @@ class AgentManager:
     def pending_agent_ids(self) -> Set[str]:
         """The IDs of agents that are waiting to enter the simulation"""
         return self._pending_agent_ids
+
+    @property
+    def pending_social_agent_ids(self) -> Set[str]:
+        """The IDs of social agents that are waiting to enter the simulation"""
+        return self._pending_social_agent_ids
 
     @property
     def active_agents(self) -> Set[str]:
@@ -460,28 +466,7 @@ class AgentManager:
         sim = self._sim()
         assert sim
         social_agents = sim.scenario.social_agents
-        if social_agents:
-            self._setup_agent_buffer()
-        else:
-            return
-
-        self._remote_social_agents = {
-            agent_id: self._agent_buffer.acquire_agent() for agent_id in social_agents
-        }
-
-        for agent_id, (social_agent, social_agent_model) in social_agents.items():
-            self._add_agent(
-                agent_id,
-                social_agent.interface,
-                social_agent_model,
-                trainable=False,
-                # XXX: Currently boids can only be run from bubbles
-                boid=False,
-            )
-            self._social_agent_ids.add(agent_id)
-
-        for social_agent_id, remote_social_agent in self._remote_social_agents.items():
-            remote_social_agent.start(social_agents[social_agent_id][0])
+        self._pending_social_agent_ids.update(social_agents.keys())
 
     def _start_keep_alive_boid_agents(self):
         """Configures and adds boid agents to the sim."""
@@ -509,6 +494,43 @@ class AgentManager:
                 initial_speed=actor.initial_speed,
             )
             self.start_social_agent(agent_id, social_agent, social_agent_data_model)
+
+    def add_and_emit_social_agent(
+        self, agent_id: str, agent_spec, agent_model: SocialAgent
+    ):
+        """Generates an entirely new social agent and emits a vehicle for it immediately.
+
+        This 
+
+        Args:
+            agent_id (str): The agent id for the new agent.
+            agent_spec (AgentSpec): The agent spec of the new agent
+            agent_model (SocialAgent): The agent configuration of the new vehicle.
+        Returns:
+            bool:
+                If the agent is added. False if the agent id is already reserved
+                by a pending ego agent or current social/ego agent.
+        """
+        if agent_id in self.agent_ids or agent_id in self.pending_agent_ids:
+            return False
+
+        self._setup_agent_buffer()
+        remote_agent = self._agent_buffer.acquire_agent()
+        self._add_agent(
+            agent_id=agent_id,
+            agent_interface=agent_spec.interface,
+            agent_model=agent_model,
+            trainable=False,
+            boid=False,
+        )
+        if agent_id in self._pending_social_agent_ids:
+            self._pending_social_agent_ids.remove(agent_id)
+        remote_agent.start(agent_spec=agent_spec)
+        self._remote_social_agents[agent_id] = remote_agent
+        self._agent_interfaces[agent_id] = agent_spec.interface
+        self._social_agent_ids.add(agent_id)
+        self._social_agent_data_models[agent_id] = agent_model
+        return True
 
     def _add_agent(
         self, agent_id, agent_interface, agent_model, boid=False, trainable=True

--- a/smarts/env/tests/test_social_agent.py
+++ b/smarts/env/tests/test_social_agent.py
@@ -25,28 +25,25 @@ import pytest
 from smarts.core.agent import Agent
 from smarts.core.agent_interface import AgentInterface, AgentType
 from smarts.core.utils.episodes import episodes
-from smarts.zoo.agent_spec import AgentSpec
+from smarts.env.hiway_env import HiWayEnv
 
 AGENT_ID = "Agent-007"
 SOCIAL_AGENT_ID = "Alec Trevelyan"
 
-MAX_EPISODES = 3
+MAX_EPISODES = 1
 
 
 @pytest.fixture
-def agent_spec():
-    return AgentSpec(
-        interface=AgentInterface.from_type(AgentType.Laner, max_episode_steps=100),
-        agent_builder=lambda: Agent.from_function(lambda _: "keep_lane"),
-    )
+def agent_interface():
+    return AgentInterface.from_type(AgentType.Laner, max_episode_steps=100, neighborhood_vehicle_states=True)
 
 
 @pytest.fixture
-def env(agent_spec):
+def env(agent_interface: AgentInterface):
     env = gym.make(
         "smarts.env:hiway-v0",
         scenarios=["scenarios/sumo/zoo_intersection"],
-        agent_specs={AGENT_ID: agent_spec},
+        agent_interfaces={AGENT_ID: agent_interface},
         headless=True,
         visdom=False,
         fixed_timestep_sec=0.01,
@@ -56,29 +53,35 @@ def env(agent_spec):
     env.close()
 
 
-def test_social_agents(env, agent_spec):
-    episode = None
-    for episode in episodes(n=MAX_EPISODES):
-        agent = agent_spec.build_agent()
+def test_social_agents_not_in_env_obs_keys(env: HiWayEnv):
+    for _ in range(MAX_EPISODES):
         observations = env.reset()
-        episode.record_scenario(env.scenario_log)
 
         dones = {"__all__": False}
         while not dones["__all__"]:
-            obs = observations[AGENT_ID]
-            observations, rewards, dones, infos = env.step({AGENT_ID: agent.act(obs)})
-            episode.record_step(observations, rewards, dones, infos)
+            observations, rewards, dones, infos = env.step({AGENT_ID: "keep_lane"})
 
             assert SOCIAL_AGENT_ID not in observations
             assert SOCIAL_AGENT_ID not in dones
 
-            # Reward is currently the delta in distance travelled by this agent.
-            # We want to make sure that this is infact a delta and not total distance
-            # travelled since this bug has appeared a few times.
-            #
-            # The way to verify this is by making sure the reward does not grow without bounds
-            assert -3 < rewards[AGENT_ID] < 3
 
-    assert episode is not None and episode.index == (
-        MAX_EPISODES - 1
-    ), "Simulation must cycle through to the final episode"
+def test_social_agents_in_env_neighborhood_vehicle_obs(env: HiWayEnv, agent_interface: AgentInterface):
+    first_seen_vehicles = {}
+    for _ in range(MAX_EPISODES):
+        observations = env.reset()
+
+        dones = {"__all__": False}
+        while not dones["__all__"]:
+            observations, rewards, dones, infos = env.step({AGENT_ID: "keep_lane"})
+
+            new_nvs_ids = [nvs.id for nvs in observations[AGENT_ID].neighborhood_vehicle_states if nvs.id not in first_seen_vehicles]
+            for v_id in new_nvs_ids:
+                first_seen_vehicles[v_id] = observations[AGENT_ID].step_count + 1
+    print(first_seen_vehicles)
+    print()
+
+    seen_zoo_social_vehicles = [v_id for v_id in first_seen_vehicles if "zoo" in v_id]
+    assert len(seen_zoo_social_vehicles) == 2
+    late_entry = next((v_id for v_id in seen_zoo_social_vehicles if "zoo-car1" in v_id), None)
+    assert late_entry is not None, seen_zoo_social_vehicles
+    assert first_seen_vehicles[late_entry] == 70


### PR DESCRIPTION
This fixes an issue with SMARTS where the social vehicles started instantly regardless of what mission start time they were given.