### PR TITLE
Upgrade minimum Python version to 3.8

### DIFF
--- a/.github/workflows/ci-auto-commit-linux.yml
+++ b/.github/workflows/ci-auto-commit-linux.yml
@@ -26,10 +26,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: master 
+          ref: master
       - name: Install SMARTS
         run: |
-          python3.7 -m venv ${{env.venv_dir}}
+          python3.8 -m venv ${{env.venv_dir}}
           . ${{env.venv_dir}}/bin/activate
           pip install --upgrade pip wheel
           pip install .[camera_obs,rllib,test,torch,train]
@@ -40,10 +40,10 @@ jobs:
       - name: Commit requirement changes
         uses: EndBug/add-and-commit@v7
         with:
-          add: 'requirements.txt'
+          add: "requirements.txt"
           branch: master
-          default_author: user_info 
-          message: 'GitHub Actions: Update requirements.txt'
+          default_author: user_info
+          message: "GitHub Actions: Update requirements.txt"
       - name: isort, Black, and prettier
         run: |
           . ${{env.venv_dir}}/bin/activate
@@ -56,5 +56,5 @@ jobs:
         with:
           add: '["*.py", "*.html", "*.js"]'
           branch: master
-          default_author: user_info 
-          message: 'GitHub Actions: Format'
+          default_author: user_info
+          message: "GitHub Actions: Format"

--- a/.github/workflows/ci-auto-commit-linux.yml
+++ b/.github/workflows/ci-auto-commit-linux.yml
@@ -12,7 +12,7 @@ jobs:
   auto-commit-linux:
     runs-on: ubuntu-20.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    container: huaweinoah/smarts:v0.4.18-minimal
+    container: huaweinoah/smarts:v0.6.1-minimal
     steps:
       - name: Install packages
         run: |

--- a/.github/workflows/ci-base-tests-linux.yml
+++ b/.github/workflows/ci-base-tests-linux.yml
@@ -15,7 +15,7 @@ jobs:
         tests:
           - ./cli
           - ./envision
-          - ./smarts/core --nb-exec-timeout 65536
+          - ./smarts/core --nb-exec-timeout 65536 --ignore=./smarts/core/tests/test_notebook.py
           - ./smarts/env --ignore=./smarts/env/tests/test_rllib_hiway_env.py
           - ./smarts/env/tests/test_rllib_hiway_env.py
           - ./smarts/sstudio

--- a/.github/workflows/ci-base-tests-linux.yml
+++ b/.github/workflows/ci-base-tests-linux.yml
@@ -9,7 +9,7 @@ jobs:
   base-tests-linux:
     runs-on: ubuntu-20.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    container: huaweinoah/smarts:v0.4.18-minimal
+    container: huaweinoah/smarts:v0.6.1-minimal
     strategy:
       matrix:
         tests:

--- a/.github/workflows/ci-base-tests-linux.yml
+++ b/.github/workflows/ci-base-tests-linux.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Install dependencies
         run: |
-          python3.7 -m venv ${{env.venv_dir}}
+          python3.8 -m venv ${{env.venv_dir}}
           . ${{env.venv_dir}}/bin/activate
           pip install --upgrade pip
           pip install --upgrade wheel

--- a/.github/workflows/ci-base-tests-mac.yml
+++ b/.github/workflows/ci-base-tests-mac.yml
@@ -21,7 +21,7 @@ jobs:
           - ./examples/tests --ignore=./examples/tests/test_learning.py
           - ./smarts/sstudio
           - ./smarts/env/tests/test_rllib_hiway_env.py
-          - ./smarts/core --nb-exec-timeout 65536
+          - ./smarts/core --nb-exec-timeout 65536 --ignore=./smarts/core/tests/test_notebook.py
           - ./smarts/env --ignore=./smarts/env/tests/test_rllib_hiway_env.py
     steps:
       - name: Checkout

--- a/.github/workflows/ci-base-tests-mac.yml
+++ b/.github/workflows/ci-base-tests-mac.yml
@@ -31,9 +31,9 @@ jobs:
       - name: Setup Python
         run: |
           brew update
-          brew install python@3.7
+          brew install python@3.8
           brew unlink python@3.9
-          brew link --force --overwrite python@3.7
+          brew link --force --overwrite python@3.8
       - name: Setup SUMO
         run: |
           brew install xquartz
@@ -42,7 +42,7 @@ jobs:
           brew install geos
       - name: Install dependencies
         run: |
-          python3.7 -m venv ${{env.venv_dir}}
+          python3.8 -m venv ${{env.venv_dir}}
           . ${{env.venv_dir}}/bin/activate
           pip install --upgrade pip
           pip install --upgrade wheel

--- a/.github/workflows/ci-format.yml
+++ b/.github/workflows/ci-format.yml
@@ -9,7 +9,7 @@ jobs:
   test-header:
     runs-on: ubuntu-20.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    container: huaweinoah/smarts:v0.4.18-minimal
+    container: huaweinoah/smarts:v0.6.1-minimal
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -21,7 +21,7 @@ jobs:
   test-docstring:
     runs-on: ubuntu-20.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    container: huaweinoah/smarts:v0.4.18-minimal
+    container: huaweinoah/smarts:v0.6.1-minimal
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -41,7 +41,7 @@ jobs:
   test-types:
     runs-on: ubuntu-20.04
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository) && (github.ref != 'refs/heads/master')
-    container: huaweinoah/smarts:v0.4.18-minimal
+    container: huaweinoah/smarts:v0.6.1-minimal
     steps:
       - name: Install packages
         run: |

--- a/.github/workflows/ci-format.yml
+++ b/.github/workflows/ci-format.yml
@@ -56,10 +56,10 @@ jobs:
           fetch-depth: 0
       - name: Install SMARTS
         run: |
-          python3.7 -m venv ${{env.venv_dir}}
+          python3.8 -m venv ${{env.venv_dir}}
           . ${{env.venv_dir}}/bin/activate
           pip install --upgrade pip wheel
-          pip install -e .[dev,camera_obs,train,test] 
+          pip install -e .[dev,camera_obs,train,test]
       - name: Get changed files on branch since branching
         id: changed-files
         shell: bash
@@ -76,4 +76,3 @@ jobs:
         run: |
           . ${{env.venv_dir}}/bin/activate
           pytype -d pyi-error,import-error ${{steps.changed-files.outputs.changed_files}}
-

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup package
         run: |
           cd $GITHUB_WORKSPACE
-          python3.7 -m venv ${{env.venv_dir}}
+          python3.8 -m venv ${{env.venv_dir}}
           . ${{env.venv_dir}}/bin/activate
           pip install --upgrade pip
           pip install --upgrade wheel

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   test-benchmark:
     runs-on: ubuntu-20.04
-    container: huaweinoah/smarts:v0.4.18-minimal
+    container: huaweinoah/smarts:v0.6.1-minimal
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci-test-learning.yml
+++ b/.github/workflows/ci-test-learning.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   test_learning:
     runs-on: ubuntu-20.04
-    container: huaweinoah/smarts:v0.4.18-minimal
+    container: huaweinoah/smarts:v0.6.1-minimal
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci-test-learning.yml
+++ b/.github/workflows/ci-test-learning.yml
@@ -2,7 +2,7 @@ name: SMARTS CI Learning
 
 on:
   schedule:
-    - cron: '0 23 * * 2'
+    - cron: "0 23 * * 2"
       # Time is in UTC
       # Runs at 11.00pm, UTC  , every Tuesday
       # Runs at  7.00pm, UTC-4, every Tuesday
@@ -23,7 +23,7 @@ jobs:
       - name: Setup package
         run: |
           cd $GITHUB_WORKSPACE
-          python3.7 -m venv ${{env.venv_dir}}
+          python3.8 -m venv ${{env.venv_dir}}
           . ${{env.venv_dir}}/bin/activate
           pip install --upgrade pip
           pip install wheel

--- a/.github/workflows/ci-test-long-determinism.yml
+++ b/.github/workflows/ci-test-long-determinism.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   test_long_determinism:
     runs-on: ubuntu-20.04
-    container: huaweinoah/smarts:v0.4.18-minimal
+    container: huaweinoah/smarts:v0.6.1-minimal
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci-test-long-determinism.yml
+++ b/.github/workflows/ci-test-long-determinism.yml
@@ -2,7 +2,7 @@ name: SMARTS CI Long Determinism
 
 on:
   schedule:
-    - cron: '0 23 * * 6'
+    - cron: "0 23 * * 6"
       # Time is in UTC
       # Runs at 11.00pm, UTC  , every Saturday
       # Runs at  7.00pm, UTC-4, every Saturday
@@ -23,7 +23,7 @@ jobs:
       - name: Setup package
         run: |
           cd $GITHUB_WORKSPACE
-          python3.7 -m venv ${{env.venv_dir}}
+          python3.8 -m venv ${{env.venv_dir}}
           . ${{env.venv_dir}}/bin/activate
           pip install --upgrade pip
           pip install .[camera_obs,rllib,test,torch,train]

--- a/.github/workflows/ci-test-memory-growth.yml
+++ b/.github/workflows/ci-test-memory-growth.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   test_memory:
     runs-on: ubuntu-20.04
-    container: huaweinoah/smarts:v0.4.18-minimal
+    container: huaweinoah/smarts:v0.6.1-minimal
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci-test-memory-growth.yml
+++ b/.github/workflows/ci-test-memory-growth.yml
@@ -2,7 +2,7 @@ name: SMARTS CI Memory
 
 on:
   schedule:
-    - cron: '0 23 * * 4'
+    - cron: "0 23 * * 4"
       # Time is in UTC
       # Runs at 11.00pm, UTC  , every Thursday
       # Runs at  7.00pm, UTC-4, every Thursday
@@ -23,7 +23,7 @@ jobs:
       - name: Setup package
         run: |
           cd $GITHUB_WORKSPACE
-          python3.7 -m venv ${{env.venv_dir}}
+          python3.8 -m venv ${{env.venv_dir}}
           . ${{env.venv_dir}}/bin/activate
           pip install --upgrade pip
           pip install wheel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 ## [Unreleased]
 ### Added
 ### Changed
+- Changed the minimum supported Python version from 3.7 to 3.8
 ### Deprecated
 ### Fixed
 ### Removed

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ test: build-all-scenarios
 		./examples/tests ./smarts/env ./envision ./smarts/core ./smarts/sstudio ./tests \
 		--ignore=./smarts/core/tests/test_smarts_memory_growth.py \
 		--ignore=./smarts/core/tests/test_env_frame_rate.py \
+		--ignore=./smarts/core/tests/test_notebook.py \
 		--ignore=./smarts/env/tests/test_benchmark.py \
 		--ignore=./examples/tests/test_learning.py \
 		-k 'not test_long_determinism'

--- a/baselines/marl_benchmark/README.md
+++ b/baselines/marl_benchmark/README.md
@@ -17,8 +17,8 @@ This directory contains the scenarios, training environment, and agents used in 
 # git clone ...
 cd <projec/baseline/marl_benchmark>
 
-# setup virtual environment; presently at least Python 3.7 and higher is officially supported
-python3.7 -m venv .venv
+# setup virtual environment; presently at least Python 3.8 and higher is officially supported
+python3.8 -m venv .venv
 
 # enter virtual environment to install all dependencies
 source .venv/bin/activate
@@ -40,8 +40,8 @@ To run the training procedure,
 
 ```bash
 # from baselines/marl_benchmark/
-$ python3.7 run.py <scenario> -f <config_file>
-# E.x. python3.7 run.py scenarios/sumo/intersections/4lane -f agents/ppo/baseline-lane-control.yaml
+$ python3.8 run.py <scenario> -f <config_file>
+# E.x. python3.8 run.py scenarios/sumo/intersections/4lane -f agents/ppo/baseline-lane-control.yaml
 ```
 
 To run the evaluation procedure for multiple algorithms,
@@ -49,7 +49,7 @@ To run the evaluation procedure for multiple algorithms,
 ```bash
 # from baselines/marl_benchmark/
 $ python evaluate.py <scenario> -f <config_files>
-# E.x. python3.7  evaluate.py scenarios/sumo/intersections/4lane \
+# E.x. python3.8  evaluate.py scenarios/sumo/intersections/4lane \
 #          -f agents/ppo/baseline-lane-control.yaml \
 #          --checkpoint ./log/results/run/4lane-4/PPO_Simple_977c1_00000_0_2020-10-14_00-06-10
 ```

--- a/baselines/marl_benchmark/setup.py
+++ b/baselines/marl_benchmark/setup.py
@@ -40,7 +40,7 @@ setup(
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
     zip_safe=True,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         "smarts[train]==0.4.16",
         "setuptools>=41.0.0,!=50.0",

--- a/docs/resources/containers.rst
+++ b/docs/resources/containers.rst
@@ -50,10 +50,10 @@ Instructions for running SMARTS within a `singularity <https://apptainer.org/>`_
     # 1. Run container in interactive mode.
     $ singularity shell --containall --bind ../SMARTS:/src ./utils/singularity/smarts.sif
     # Inside the container
-    Singularity> python3.7 /src/examples/control/chase_via_points.py /src/scenarios/sumo/loop/ --headless
+    Singularity> python3.8 /src/examples/control/chase_via_points.py /src/scenarios/sumo/loop/ --headless
 
     # 2. Run commands within the container from the host system.
-    $ singularity exec --containall --bind ../SMARTS:/src ./utils/singularity/smarts.sif python3.7 /src/examples/control/chase_via_points.py /src/scenarios/sumo/loop/ --headless
+    $ singularity exec --containall --bind ../SMARTS:/src ./utils/singularity/smarts.sif python3.8 /src/examples/control/chase_via_points.py /src/scenarios/sumo/loop/ --headless
 
     # 3. Run container instance in the background.
     $ singularity instance start --containall --bind ../SMARTS:/src ./utils/singularity/smarts.sif smarts_train /src/examples/control/chase_via_points.py /src/scenarios/sumo/loop/ --headless

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -6,7 +6,7 @@ Setup
 Prerequisites
 -------------
 
-+ python3 (3.7 or 3.8)
++ python3 (3.8 or 3.9)
 + ubuntu (>=16.04)
 
 Installation
@@ -39,9 +39,9 @@ Run the following commands to setup the SMARTS simulator.
     # waiting for user input. 
     $ bash utils/setup/install_deps.sh
 
-    # Setup virtual environment. Presently at least Python 3.7 and higher is
+    # Setup virtual environment. Presently at least Python 3.8 and higher is
     # officially supported.
-    $ python3.7 -m venv .venv
+    $ python3.8 -m venv .venv
 
     # Enter virtual environment to install dependencies.
     $ source .venv/bin/activate

--- a/examples/replay/README.md
+++ b/examples/replay/README.md
@@ -74,14 +74,14 @@ Or for `scenarios/sumo/straight`, you can wrap the `trajectory_boid_agent` and `
 ## Setup and Running:
 ### External dependencies:
 Ubuntu 18.04
-Python 3.7.5 or higher
+Python 3.8 or higher
 Eclipse SUMO 1.8.0 or higher
 
 ```bash
 # 1. construct your virtual environment
 cd <project>
 ./install_deps.sh # skip if you have python installed
-python3.7 -m venv .venv
+python3.8 -m venv .venv
 . .venv/bin/activate
 pip install --upgrade pip
 pip install -e .
@@ -91,9 +91,9 @@ mkdir ./klws_replay
 
 # 3. Run the replay agent using the --write argument and with required agent's parameters (Like the klws_agent which requires you to pass in the speed parameter) to store the actions and inputs of agents to CRASH_DIR directory:
 CRASH_DIR=./klws_replay
-python3.7 examples/replay/replay_klws_agent.py scenarios/sumo/loop --save-dir $CRASH_DIR --speed 20 --write --headless
+python3.8 examples/replay/replay_klws_agent.py scenarios/sumo/loop --save-dir $CRASH_DIR --speed 20 --write --headless
 
 # 4. Now you can replay the agent's previous action by not using the --write to load the observations saved by the wrapper in CRASH_DIR directory:
-python3.7 examples/replay/replay_klws_agent.py scenarios/sumo/loop --save-dir $CRASH_DIR --speed 20 --headless
+python3.8 examples/replay/replay_klws_agent.py scenarios/sumo/loop --save-dir $CRASH_DIR --speed 20 --headless
 
 ```

--- a/examples/rl/intersection/Dockerfile
+++ b/examples/rl/intersection/Dockerfile
@@ -11,18 +11,18 @@ RUN apt-get update --fix-missing && \
     apt-get install -y \
         git \
         libspatialindex-dev \
-        python3.7 \
-        python3.7-venv \
+        python3.8 \
+        python3.8-venv \
         xorg && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
 # Update default python version.
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.7 1
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1
 
 # Setup virtual environment and install pip.
 ENV VIRTUAL_ENV=/opt/.venv
-RUN python3.7 -m venv $VIRTUAL_ENV
+RUN python3.8 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip install --upgrade pip wheel
 

--- a/examples/rl/intersection/README.md
+++ b/examples/rl/intersection/README.md
@@ -31,7 +31,7 @@ action_space = gym.spaces.Box(low=-1.0, high=1.0, shape=(3,), dtype=np.float32)
 ```bash
 $ git clone https://github.com/huawei-noah/SMARTS.git
 $ cd <path>/SMARTS/examples/rl/intersection
-$ python3.7 -m venv ./.venv
+$ python3.8 -m venv ./.venv
 $ source ./.venv/bin/activate
 $ pip install --upgrade pip
 $ pip install -e .
@@ -41,7 +41,7 @@ $ pip install -e .
 1. Train
     ```bash
     $ cd <path>/SMARTS/examples/rl/intersection
-    $ python3.7 run.py 
+    $ python3.8 run.py 
     ```
 1. Trained model is saved into `<path>/SMARTS/examples/rl/intersection/logs/<folder_name>` folder.
 1. Monitor the RL agent during or after the training using tensorboard
@@ -54,17 +54,17 @@ $ pip install -e .
 1. Start
     ```bash
     $ cd <path>/SMARTS/examples/rl/intersection
-    $ scl envision start --scenarios ./.venv/lib/python3.7/site-packages/smarts/scenarios &
+    $ scl envision start --scenarios ./.venv/lib/python3.8/site-packages/smarts/scenarios &
     ```
 1. Run
     + Evaluate your own model 
         ```bash
-        $ python3.7 run.py --mode=evaluate --model="./logs/<folder_name>/<model>" --head
+        $ python3.8 run.py --mode=evaluate --model="./logs/<folder_name>/<model>" --head
         ```
     + Evaluate pre-trained agent
         ```bash
         $ curl -o ./logs/pretrained/intersection.zip --create-dirs -L https://github.com/Adaickalavan/SMARTS-zoo/raw/main/intersection-v0/PPO_5800000_steps.zip        
-        $ python3.7 run.py --mode=evaluate --model="./logs/pretrained/intersection" --head
+        $ python3.8 run.py --mode=evaluate --model="./logs/pretrained/intersection" --head
         ```
 1. Go to `localhost:8081` to view the simulation in Envision.
 
@@ -75,5 +75,5 @@ $ pip install -e .
     $ docker build --file=./examples/rl/intersection/Dockerfile --network=host --tag=intersection .
     $ docker run --rm -it --network=host --gpus=all intersection
     (container) $ cd /src/examples/rl/intersection
-    (container) $ python3.7 run.py
+    (container) $ python3.8 run.py
     ```

--- a/examples/rl/intersection/setup.py
+++ b/examples/rl/intersection/setup.py
@@ -15,7 +15,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=True,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         "setuptools>=41.0.0,!=50.0",
         "protobuf==3.20.1",

--- a/examples/rl/racing/Dockerfile
+++ b/examples/rl/racing/Dockerfile
@@ -11,24 +11,24 @@ RUN apt-get update --fix-missing && \
     apt-get install -y \
         ffmpeg \
         libspatialindex-dev \
-        python3.7 \
-        python3.7-venv \
+        python3.8 \
+        python3.8-venv \
         xorg && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
 # Update default python version.
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.7 1
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1
 
 # Setup virtual environment and install pip.
 ENV VIRTUAL_ENV=/opt/.venv
-RUN python3.7 -m venv $VIRTUAL_ENV
+RUN python3.8 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip install --upgrade pip wheel
 
 # Setup SUMO.
 RUN pip install eclipse-sumo==1.10.0
-ENV SUMO_HOME $VIRTUAL_ENV/lib64/python3.7/site-packages/sumo
+ENV SUMO_HOME $VIRTUAL_ENV/lib64/python3.8/site-packages/sumo
 
 # Install requirements.txt .
 COPY ./examples/rl/racing/requirements.txt /tmp/requirements.txt

--- a/examples/rl/racing/README.md
+++ b/examples/rl/racing/README.md
@@ -28,7 +28,7 @@ action_space = gym.spaces.Box(low=-1.0, high=1.0, shape=(3,), dtype=np.float32)
 ```bash
 $ git clone https://github.com/huawei-noah/SMARTS.git
 $ cd <path>/SMARTS/examples/rl/racing
-$ python3.7 -m venv ./.venv
+$ python3.8 -m venv ./.venv
 $ source ./.venv/bin/activate
 $ pip install --upgrade pip
 $ pip install -e .
@@ -38,7 +38,7 @@ $ pip install -e .
 1. Train
     ```bash
     $ cd <path>/SMARTS/examples/rl/racing
-    $ python3.7 run.py 
+    $ python3.8 run.py 
     ```
 1. The trained model is saved into `<path>/SMARTS/examples/rl/racing/logs/<folder_name>` folder.
 
@@ -47,7 +47,7 @@ $ pip install -e .
     ```bash
     $ cd <path>/SMARTS/examples/rl/racing
     $ scl envision start -s ./scenarios &
-    $ python3.7 run.py --mode=evaluate --logdir="<path>/SMARTS/examples/rl/racing/logs/<folder_name>" --head
+    $ python3.8 run.py --mode=evaluate --logdir="<path>/SMARTS/examples/rl/racing/logs/<folder_name>" --head
     ```
 1. Go to `localhost:8081` to view the simulation in Envision.
 
@@ -58,5 +58,5 @@ $ pip install -e .
     $ docker build --file=<path>/SMARTS/examples/rl/racing/Dockerfile --network=host --tag=racing <path>/SMARTS
     $ docker run --rm -it --network=host --gpus=all racing
     (container) $ cd /src/examples/rl/racing
-    (container) $ python3.7 run.py
+    (container) $ python3.8 run.py
     ```

--- a/examples/rl/racing/setup.py
+++ b/examples/rl/racing/setup.py
@@ -15,7 +15,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=True,
-    python_requires="~=3.7",
+    python_requires="~=3.8",
     install_requires=[
         "setuptools>=41.0.0,!=50.0",
         "smarts[camera_obs]==1.0.0",

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,9 @@ install_requires =
     eclipse-sumo>=1.12.0  # sumo
     gym>=0.17.3,<=0.19.0
     gymnasium==0.27.0
-    numpy>=1.19.5  # required for tf 2.4 below
+    # numpy>=1.19.5 required for tf 2.4
+    # numpy<1.24 required for ray (see https://github.com/ray-project/ray/issues/31258)
+    numpy>=1.19.5,<1.24.0  
     pandas>=1.3.4  # only used by zoo/evaluation
     psutil>=5.4.8
     pybullet==3.0.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -91,7 +91,7 @@ remote_agent =
 rllib = 
     opencv-python==4.1.2.30
     opencv-python-headless==4.1.2.30
-    ray[rllib]==1.0.1.post1
+    ray[rllib]==1.4.0
 ros = 
     catkin_pkg
     rospkg

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,6 @@ classifiers=
     Development Status :: 5 - Production/Stable
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     License :: OSI Approved :: MIT License
@@ -18,7 +17,7 @@ classifiers=
 packages = find:
 include_package_data = True
 zip_safe = True
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires = 
     # setuptools:
     #   tensorboard needs >=41

--- a/smarts/core/tests/test_notebook.ipynb
+++ b/smarts/core/tests/test_notebook.ipynb
@@ -6,20 +6,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from pathlib import Path\n",
+    "import smarts\n",
     "from smarts.core.tests.test_notebook import run_scenario\n",
-    "import os\n",
-    "import sys\n",
     "\n",
-    "\n",
-    "def find(path):\n",
-    "    for dirname in sys.path:\n",
-    "        attempt = os.path.join(dirname, path)\n",
-    "        if os.path.isdir(attempt):\n",
-    "            return attempt\n",
-    "    return None\n",
-    "\n",
-    "\n",
-    "scenario_path = find(\"scenarios/sumo/loop\")"
+    "scenario_path = Path(smarts.__file__).parents[1] / \"scenarios/sumo/loop\""
    ]
   },
   {
@@ -32,8 +23,6 @@
    },
    "outputs": [],
    "source": [
-    "import sys\n",
-    "\n",
     "run_scenario([scenario_path], \"test_notebook\", True, 1, 32, 50)"
    ]
   }

--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -18,24 +18,24 @@ RUN apt-get update --fix-missing && \
     apt-get update && \
     apt-get install -y \
         libspatialindex-dev \
-        python3.7 \
-        python3.7-venv \
+        python3.8 \
+        python3.8-venv \
         xorg && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
 # Update default python version.
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.7 1
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1
 
 # Setup virtual environment and install pip.
 ENV VIRTUAL_ENV=/opt/.venv
-RUN python3.7 -m venv $VIRTUAL_ENV
+RUN python3.8 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip install --upgrade pip wheel
 
 # Setup SUMO.
 RUN pip install eclipse-sumo==1.12.0
-ENV SUMO_HOME $VIRTUAL_ENV/lib64/python3.7/site-packages/sumo
+ENV SUMO_HOME $VIRTUAL_ENV/lib64/python3.8/site-packages/sumo
 
 # Install requirements.txt .
 COPY ./requirements.txt /tmp/requirements.txt

--- a/utils/docker/Dockerfile.minimal
+++ b/utils/docker/Dockerfile.minimal
@@ -20,8 +20,8 @@ RUN apt-get update --fix-missing && \
     apt-get update && \
     apt-get install -y \
         libspatialindex-dev \
-        python3.7 \
-        python3.7-venv \
+        python3.8 \
+        python3.8-venv \
         sumo \
         sumo-doc \
         sumo-tools \
@@ -34,7 +34,7 @@ RUN apt-get update --fix-missing && \
 ENV SUMO_HOME /usr/share/sumo
 
 # Update default python version
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.7 1
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1
 
 # Setup pip
 RUN wget https://bootstrap.pypa.io/get-pip.py -O get-pip.py && \

--- a/utils/setup/README.pypi.md
+++ b/utils/setup/README.pypi.md
@@ -10,8 +10,8 @@ Check out the paper at [SMARTS: Scalable Multi-Agent Reinforcement Learning Trai
 ## Installation of the SMARTS package
 You can install the SMARTS package from [PyPI](https://pypi.org/project/smarts/).
 
-Package installation requires Python >= 3.7.
-If you dont have python 3.7 or higher, make sure to install or update python first.
+Package installation requires Python >= 3.8.
+If you dont have python 3.8 or higher, make sure to install or update python first.
 
 ```bash
 # For windows user 

--- a/utils/setup/install_deps.sh
+++ b/utils/setup/install_deps.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-function check_python_version_gte_3_7 {
+function check_python_version_gte_3_8 {
     echo "Checking for >=python3.8"
     # running through current minor versions
     hash python3.8 2>/dev/null \
@@ -8,7 +8,7 @@ function check_python_version_gte_3_7 {
     || hash python3.9 2>/dev/null;
 }
 
-function install_python_3_7 {
+function install_python_3_8 {
     echo "Installing python3.8"
     sudo apt-get install $1 software-properties-common
     sudo add-apt-repository $1 ppa:deadsnakes/ppa
@@ -23,20 +23,20 @@ function do_install_for_linux {
         build-essential cmake
 
     #only a problem for linux
-    if ! check_python_version_gte_3_7; then
+    if ! check_python_version_gte_3_8; then
         echo "A >=3.8 python version not found"
         if  [[ "$1" = "-y" ]]; then
-            install_python_3_7 "$1"
+            install_python_3_8 "$1"
         else
-            read -p "Install python3.8? [Yn]" should_add_python_3_7
-            if [[ $should_add_python_3_7 =~ ^[yY\w]*$ ]]; then
+            read -p "Install python3.8? [Yn]" should_add_python_3_8
+            if [[ $should_add_python_3_8 =~ ^[yY\w]*$ ]]; then
                 echo ""
                 printf "This will run the following commands:\n$ sudo apt-get update\n$ sudo apt-get install software-properties-common\n$ sudo add-apt-repository ppa:deadsnakes/ppa\n$ sudo apt-get install python3.8 python3.8-tk python3.8-venv"
                 echo ""
-                read -p "WARNING. Is this OK? If you are unsure choose no. [Yn]" should_add_python_3_7
+                read -p "WARNING. Is this OK? If you are unsure choose no. [Yn]" should_add_python_3_8
                 # second check to make sure they really want to
-                if [[ $should_add_python_3_7 =~ ^[yY\w]*$ ]]; then
-                    install_python_3_7
+                if [[ $should_add_python_3_8 =~ ^[yY\w]*$ ]]; then
+                    install_python_3_8
                 fi
             fi
         fi

--- a/utils/setup/install_deps.sh
+++ b/utils/setup/install_deps.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 
 function check_python_version_gte_3_7 {
-    echo "Checking for >=python3.7"
+    echo "Checking for >=python3.8"
     # running through current minor versions
-    hash python3.7 2>/dev/null \
+    hash python3.8 2>/dev/null \
     || hash python3.8 2>/dev/null \
     || hash python3.9 2>/dev/null;
 }
 
 function install_python_3_7 {
-    echo "Installing python3.7"
+    echo "Installing python3.8"
     sudo apt-get install $1 software-properties-common
     sudo add-apt-repository $1 ppa:deadsnakes/ppa
-    sudo apt-get install $1 python3.7 python3.7-tk python3.7-venv
+    sudo apt-get install $1 python3.8 python3.8-tk python3.8-venv
 }
 
 function do_install_for_linux {
@@ -24,14 +24,14 @@ function do_install_for_linux {
 
     #only a problem for linux
     if ! check_python_version_gte_3_7; then
-        echo "A >=3.7 python version not found"
+        echo "A >=3.8 python version not found"
         if  [[ "$1" = "-y" ]]; then
             install_python_3_7 "$1"
         else
-            read -p "Install python3.7? [Yn]" should_add_python_3_7
+            read -p "Install python3.8? [Yn]" should_add_python_3_7
             if [[ $should_add_python_3_7 =~ ^[yY\w]*$ ]]; then
                 echo ""
-                printf "This will run the following commands:\n$ sudo apt-get update\n$ sudo apt-get install software-properties-common\n$ sudo add-apt-repository ppa:deadsnakes/ppa\n$ sudo apt-get install python3.7 python3.7-tk python3.7-venv"
+                printf "This will run the following commands:\n$ sudo apt-get update\n$ sudo apt-get install software-properties-common\n$ sudo add-apt-repository ppa:deadsnakes/ppa\n$ sudo apt-get install python3.8 python3.8-tk python3.8-venv"
                 echo ""
                 read -p "WARNING. Is this OK? If you are unsure choose no. [Yn]" should_add_python_3_7
                 # second check to make sure they really want to

--- a/utils/singularity/smarts.def
+++ b/utils/singularity/smarts.def
@@ -21,8 +21,8 @@ From: ubuntu:bionic
         apt-get update && \
         apt-get install -y \
             libspatialindex-dev \
-            python3.7 \
-            python3.7-venv \
+            python3.8 \
+            python3.8-venv \
             sumo \
             sumo-doc \
             sumo-tools \
@@ -32,11 +32,11 @@ From: ubuntu:bionic
         rm -rf /var/lib/apt/lists/*
 
     # Update default python version
-    update-alternatives --install /usr/bin/python python /usr/bin/python3.7 1
+    update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1
 
     # Setup virtual environment and install pip
     export VIRTUAL_ENV=/opt/.venv
-    python3.7 -m venv $VIRTUAL_ENV
+    python3.8 -m venv $VIRTUAL_ENV
     export PATH="$VIRTUAL_ENV/bin:$PATH"
     wget https://bootstrap.pypa.io/get-pip.py -O get-pip.py
     python get-pip.py
@@ -57,4 +57,4 @@ From: ubuntu:bionic
     . /src/utils/singularity/setup.sh
 
 %startscript
-    python3.7 "$@"    
+    python3.8 "$@"    

--- a/zoo/policies/cross-rl-agent/cross_rl_agent/train/README.md
+++ b/zoo/policies/cross-rl-agent/cross_rl_agent/train/README.md
@@ -17,7 +17,7 @@ and open `localhost:8081` in your local browser.
 To run an example run:
 ```bash
 # cd zoo/policies/cross-rl-agent/cross_rl_agent/train
-$ python3.7 run_test.py scenarios/4lane_left_turn
+$ python3.8 run_test.py scenarios/4lane_left_turn
 ```
 
 
@@ -25,6 +25,6 @@ $ python3.7 run_test.py scenarios/4lane_left_turn
 To train an agent:
 ```bash
 # cd zoo/policies/cross-rl-agent/cross_rl_agent/train
-$ python3.7 run_train.py scenarios/4lane_left_turn #--headless
+$ python3.8 run_train.py scenarios/4lane_left_turn #--headless
 ```
 For fast training, you can stop the envision server and add `--headless`.

--- a/zoo/policies/open-agent/setup.py
+++ b/zoo/policies/open-agent/setup.py
@@ -36,10 +36,10 @@ try:
             "/bin/bash",
             "konstin2/maturin",
             "-c",
-            "cd /io/python_bindings_open_agent_solver && maturin build --release -i python3.7",
+            "cd /io/python_bindings_open_agent_solver && maturin build --release -i python3.8",
         ],
         cwd=str(python_bindings_src.parent),
-        # ["maturin", "build", "--release", "-i", "python3.7"],
+        # ["maturin", "build", "--release", "-i", "python3.8"],
         # cwd=str(python_bindings_src),
     )
 

--- a/zoo/run_tests.sh
+++ b/zoo/run_tests.sh
@@ -5,7 +5,7 @@ do
     if [ -d "${policy}/tests" ]; then
         echo "Testing ${policy}"
         venv_dir=`mktemp -u -d`
-        python3.7 -m venv "${venv_dir}"
+        python3.8 -m venv "${venv_dir}"
         source "${venv_dir}/bin/activate"
         whl="$(find ${policy} | grep .whl | sort -n | tail -n1)"
         echo "Installing SMARTS"


### PR DESCRIPTION
This PR bumps the minimum supported Python version to 3.8. This has been planned for some time, but was made necessary during the Argoverse 2 integration which requires >=3.8.

Some package version changes were needed:
- Upgraded `ray[rllib]` from `1.0.1.post1` to `1.4.0` to get rid of `gym[atari]` dependency which had problems installing in 3.8
- Put a `numpy<1.24.0` upper bound to fix an issue with `ray[rllib]==1.4.0` (see https://github.com/ray-project/ray/issues/31258)

Note also that an issue with notebooks popped up: #1902. We have decided to ignore the test for now to unblock the Argoverse integration, but this should be investigated.