### PR TITLE
Improve Argoverse road grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 ### Deprecated
 ### Fixed
 - Fixed "rl/racing" `numpy` incompatibility.
+- Fixed an issue in Argoverse maps where adjacent lanes would sometimes not be grouped in the same road.
 ### Removed
 ### Security
 


### PR DESCRIPTION
Fixes #1922.

This improves grouping of roads in Argoverse maps. We were previously a bit too conservative in deciding when adjacent lanes are part of the same road.

See below for what the scenario from the issue looks like after the fix. There is no longer a gap in the lane/road lines, and traffic flows smoothly in both lanes.

![argoverse-map-fix](https://user-images.githubusercontent.com/17256344/227625685-4622cdc1-30f3-4461-8d9d-35ebd766bc02.gif)
