### PR TITLE
Fix `tableprint` segfaulting on bytes array.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Fixed an issue where Argoverse scenarios with a `Mission` would not run properly.
 - `Trip.actor` field is now effective. Previously `actor` had no effect.
 - Fixed an issue where building sumo scenarios would sometimes stall.
+- `VehicleIndex` no longer segfaults when attempting to `repr()` it.
 ### Removed
 ### Security
 

--- a/smarts/core/vehicle_index.py
+++ b/smarts/core/vehicle_index.py
@@ -837,9 +837,9 @@ class VehicleIndex:
         )
 
         by["position"] = [", ".join([f"{x:.2f}" for x in p]) for p in by["position"]]
-        by["actor_id"] = [truncate(p, 20) for p in by["actor_id"]]
-        by["vehicle_id"] = [truncate(p, 20) for p in by["vehicle_id"]]
-        by["shadow_actor_id"] = [truncate(p, 20) for p in by["shadow_actor_id"]]
+        by["actor_id"] = [str(truncate(p, 20)) for p in by["actor_id"]]
+        by["vehicle_id"] = [str(truncate(p, 20)) for p in by["vehicle_id"]]
+        by["shadow_actor_id"] = [str(truncate(p, 20)) for p in by["shadow_actor_id"]]
         by["is_boid"] = [str(bool(x)) for x in by["is_boid"]]
         by["is_hijacked"] = [str(bool(x)) for x in by["is_hijacked"]]
         by["actor_role"] = [str(ActorRole(x)).split(".")[-1] for x in by["actor_role"]]


### PR DESCRIPTION
This fixes an issue where `VehicleIndex` would segfault on trying to generate its `repr()`.

Closes #1873.