### PR TITLE
fix outdated url in readthedoc

### DIFF
--- a/docs/benchmarks/driving_smarts_2022.rst
+++ b/docs/benchmarks/driving_smarts_2022.rst
@@ -4,7 +4,7 @@ Driving SMARTS 2022
 ===================
 
 The Driving SMARTS 2022 is a benchmark derived from the
-`NeurIPS 2022 Driving SMARTS <https://smarts-project.github.io/archive/2022_nips_driving_smarts/>`_ competition.
+`NeurIPS 2022 Driving SMARTS <https://smarts-project.github.io/>`_ competition.
 
 Objective
 ---------


### PR DESCRIPTION
The previous url to the 2022 competition in readthedoc has been outdated, update to a valid