### PR TITLE
Warn character truncation once only

### DIFF
--- a/smarts/env/utils/observation_conversion.py
+++ b/smarts/env/utils/observation_conversion.py
@@ -67,10 +67,13 @@ _UNSIGNED_INT64_SPACE = gym.spaces.Box(low=0, high=1e10, shape=(), dtype=np.int6
 _DISCRETE2_SPACE = gym.spaces.Discrete(n=2)
 _LANE_ID_SPACE = gym.spaces.Text(_WAYPOINT_NAME_LIMIT, charset=_WAYPOINT_CHAR_SET)
 
+_WARN_CHARACTER_TRUNCATION = True
 
 def _format_id(lane_id: str, max_length, type_):
+    global _WARN_CHARACTER_TRUNCATION
     lane_name = lane_id
-    if len(lane_name) > max_length:
+    if _WARN_CHARACTER_TRUNCATION and len(lane_name) > max_length:
+        _WARN_CHARACTER_TRUNCATION = False
         warnings.warn(
             f"`{type_}` named `{lane_name}` is more than "
             f"`{max_length}` characters long. It will be truncated "


### PR DESCRIPTION
+ Character truncation warning message from observation space formatter tends to fill up the terminal. Example:
  ```bash
  WARNING:smarts.env.utils.observation_conversion:`vehicle id` named `car-flow-route-E1_2_0-E3_2_max--5782264158901839037--6390006830799584855--3-0.2` is more than `50` characters long. It will be truncated and may cause unintended issues with navigation and lane identification.
  WARNING:smarts.env.utils.observation_conversion:`vehicle id` named `car-flow-route-E1_0_0-E3_0_max-6963017027078397547--6390006830799584855--0-0.2` is more than `50` characters long. It will be truncated and may cause unintended issues with navigation and lane identification.
  WARNING:smarts.env.utils.observation_conversion:`vehicle id` named `car-flow-route-E1_0_0-E3_0_max-6963017027078397547--6390006830799584855--0-0.3` is more than `50` characters long. It will be truncated and may cause unintended issues with navigation and lane identification.
  WARNING:smarts.env.utils.observation_conversion:`vehicle id` named `car-flow-route-E1_2_0-E3_2_max--5782264158901839037--6390006830799584855--3-0.2` is more than `50` characters long. It will be truncated and may cause unintended issues with navigation and lane identification.
  ```
+ Hence, warn only on the first occurence.
+ Is there better a way to warn once only?