### PR TITLE
Modify "feature request" template for more natural user experience

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -4,6 +4,13 @@ title: "[Feature request] Feature request title"
 labels: ["enhancement"]
 body:
   - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: |
+        Is your feature request related to a problem? Please describe. 
+        Give clear and concise description of what the problem is. Ex. I am always frustrated when (...).
+  - type: textarea
     id: proposal
     attributes:
       label: Proposal
@@ -12,13 +19,6 @@ body:
         Give a clear and concise description of what you want to happen.
     validations:
       required: true
-  - type: textarea
-    id: motivation
-    attributes:
-      label: Motivation
-      description: |
-        Is your feature request related to a problem? Please describe. 
-        Give clear and concise description of what the problem is. Ex. I am always frustrated when (...).
   - type: textarea
     id: alternatives
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -10,6 +10,8 @@ body:
       description: |
         Is your feature request related to a problem? Please describe. 
         Give clear and concise description of what the problem is. Ex. I am always frustrated when (...).
+      validations:
+        required: true
   - type: textarea
     id: proposal
     attributes:


### PR DESCRIPTION
The structure of current "feature request" issue template is "Proposal" then "Motivation", which is easier for us to read as devs because when we check it we can always see the solution that user would like first. 

But from user's perspective, it might be more logically natural for general writing if motivation/context goes first, and followed by the possible solution. 

Still not sure if we should do this since either way has its pros/cons, sall comments are welcomed!