### PR TITLE
Unconstrained path change in ChaseViaPoints zoo agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Considering lane-change time ranges between 3s and 6s, assuming a speed of 13.89m/s, the via sensor lane acquisition range was increased from 40m to 80m, for better driving ability.
 - Modified naming of benchmark used in NeurIPS 2022 from driving-smarts-competition-env to driving-smarts-v2022.
 - Sstudio generated scenario vehicle traffic ids are now shortened.
+- ChaseViaPoints zoo agent uses unconstrained path change command, instead of being constrained to [-1, 0, +1] path change commands used previously. 
 ### Deprecated
 ### Fixed
 - Fixed issues related to waypoints in junctions on Argoverse maps. Waypoints will now be generated for all paths leading through the lane(s) the vehicle is on.

--- a/zoo/policies/chase_via_points_agent.py
+++ b/zoo/policies/chase_via_points_agent.py
@@ -41,15 +41,9 @@ class ChaseViaPointsAgent(Agent):
         if via_point_wp_ind[0] in ego_wp_inds:
             return (obs.via_data.near_via_points[via_point_ind].required_speed, 0)
 
-        # Change to left lane since target via point is on the left lane.
-        if ego_wp_inds[0] < via_point_wp_ind[0]:
-            return (obs.via_data.near_via_points[via_point_ind].required_speed, 1)
-
-        # Change to right lane since target via point is on the right lane.
-        if ego_wp_inds[0] > via_point_wp_ind[0]:
-            return (obs.via_data.near_via_points[via_point_ind].required_speed, -1)
-
-        raise Exception("ChaseViaPointsAgent did not catch any preprogrammed actions.")
+        # Turn leftwards if (via_point_wp_ind[0] - ego_wp_inds[0]) > 0 , as target via point is on the left.
+        # Turn rightwards if (via_point_wp_ind[0] - ego_wp_inds[0]) < 0 , as target via point is on the right.
+        return (obs.via_data.near_via_points[via_point_ind].required_speed, via_point_wp_ind[0] - ego_wp_inds[0])
 
 
 def _nearest_waypoint(matrix: np.ndarray, points: np.ndarray, radius: float = 2):


### PR DESCRIPTION
ChaseViaPoints zoo agent uses unconstrained path change command, instead of being constrained to [-1, 0, +1] path change commands used previously. 