### PR TITLE
CI fix: constrain ipython version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,7 @@ camera_obs =
     panda3d-gltf==0.13
 dev = 
     black[jupyter]==22.6.0
+    ipython>=7.8.0,<8.13.0 # from black[jupyter]: ipython 8.13.0 requires Python 3.9
     grpcio-tools==1.32.0
     isort==5.7.0
     pre-commit==2.16.0


### PR DESCRIPTION
The CI started [failing](https://github.com/huawei-noah/SMARTS/actions/runs/4833766458/jobs/8614162804) with the following error:

```
ImportError: 
IPython 8.13+ supports Python 3.9 and above, following NEP 29.
IPython 8.0-8.12 supports Python 3.8 and above, following NEP 29.
...
```

It looks like a new IPython version was released today which requires Python 3.9.