### PR TITLE
Fix model.predict output for use in benchmark 

### DIFF
--- a/examples/rl/drive/inference/contrib_policy/policy.py
+++ b/examples/rl/drive/inference/contrib_policy/policy.py
@@ -45,7 +45,7 @@ class Policy(Agent):
         processed_obs = self._process(obs)
         action, _ = self.model.predict(observation=processed_obs, deterministic=True)
         formatted_action = self._format_action.format(
-            model_action=action, prev_heading=obs["ego_vehicle_state"]["heading"]
+            action=int(action), prev_heading=obs["ego_vehicle_state"]["heading"]
         )
         return formatted_action
 

--- a/examples/rl/platoon/inference/contrib_policy/filter_obs.py
+++ b/examples/rl/platoon/inference/contrib_policy/filter_obs.py
@@ -21,7 +21,6 @@ class FilterObs:
 
         self._no_color = np.zeros((3,))
         self._wps_color = np.array(Colors.GreenTransparent.value[0:3]) * 255
-        self._leader_color = np.array(SceneColors.SocialAgent.value[0:3]) * 255
         self._traffic_color = np.array(SceneColors.SocialVehicle.value[0:3]) * 255
         self._road_color = np.array(SceneColors.Road.value[0:3]) * 255
         self._lane_divider_color = np.array(SceneColors.LaneDivider.value[0:3]) * 255

--- a/examples/rl/platoon/inference/contrib_policy/policy.py
+++ b/examples/rl/platoon/inference/contrib_policy/policy.py
@@ -44,7 +44,7 @@ class Policy(Agent):
         """Mandatory act function to be implemented by user."""
         processed_obs = self._process(obs)
         action, _ = self.model.predict(observation=processed_obs, deterministic=True)
-        formatted_action = self._format_action.format(action)
+        formatted_action = self._format_action.format(action=int(action))
         return formatted_action
 
     def _process(self, obs):

--- a/examples/rl/platoon/train/preprocess.py
+++ b/examples/rl/platoon/train/preprocess.py
@@ -24,7 +24,6 @@ class Preprocess(gym.Wrapper):
 
         self._format_action = FormatAction(agent_interface.action)
         self.action_space = self._format_action.action_space
-        print("Policy initialised.")
 
     def _process(self, obs):
         obs = self._filter_obs.filter(obs)

--- a/examples/rl/platoon/train/reward.py
+++ b/examples/rl/platoon/train/reward.py
@@ -90,7 +90,7 @@ class Reward(gym.Wrapper):
             # if agent_obs["events"]["reached_goal"]:
             #     reward[agent_id] += np.float64(30)
 
-            # Reward for distance travelled by driving
+            # Reward for distance travelled in one step
             reward[agent_id] += np.float64(env_reward[agent_id])
 
             # Check if leader is in front and within the rgb observation

--- a/examples/rl/platoon/train/reward.py
+++ b/examples/rl/platoon/train/reward.py
@@ -90,7 +90,7 @@ class Reward(gym.Wrapper):
             # if agent_obs["events"]["reached_goal"]:
             #     reward[agent_id] += np.float64(30)
 
-            # Reward for distance travelled in one step
+            # Reward for distance travelled by driving
             reward[agent_id] += np.float64(env_reward[agent_id])
 
             # Check if leader is in front and within the rgb observation


### PR DESCRIPTION
+ `model.predict()` outputs a zero dimension array in a non-vectorized single env setup.
+ The above output could not be used as a dictionary index.
+ Hence, I cast the zero dimension array to int.