### PR TITLE
Argoverse and SUMO waypoint improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Fixed implementations of `RoadMap.waypoint_paths()` to ensure that the result is never empty.
 - The routes of `SumoTrafficSimulation` traffic vehicles are now preserved to be passed over to other traffic simulators when the `SumoTrafficSimulation` disconnects.
 - `SumoTrafficSimulation` no longer reports that it manages vehicles when it is disconnected.
+- Fixed waypoints so that they will always be the length of the `lookahead` parameter, even in junctions.
 ### Removed
 - Removed the following dependencies from smarts: `pandas`, `rich`, `twisted`, `sh`.
 ### Security

--- a/smarts/core/sumo_road_network.py
+++ b/smarts/core/sumo_road_network.py
@@ -980,9 +980,7 @@ class SumoRoadNetwork(RoadMap):
             for lanes in junction_paths:
                 road_ids = [lane.road.road_id for lane in lanes]
                 start_lane = lanes[0]
-                new_paths = start_lane._waypoint_paths_at(
-                    pose.point, lookahead, road_ids
-                )
+                new_paths = start_lane._waypoint_paths_at(pose.point, lookahead)
                 for path in new_paths:
 
                     def _angle_between(pose, wp):
@@ -1429,7 +1427,7 @@ class SumoRoadNetwork(RoadMap):
                 self.point = point
                 self.filter_road_ids = filter_road_ids
                 self._starts = {}
-            self._starts[llp.lp.lane.index] = paths
+            self._starts[llp.lp.lane.lane_id] = paths
 
         def query(
             self,
@@ -1440,7 +1438,7 @@ class SumoRoadNetwork(RoadMap):
         ) -> Optional[List[List[Waypoint]]]:
             """Attempt to find previously cached waypoints"""
             if self._match(lookahead, point, filter_road_ids):
-                hit = self._starts.get(llp.lp.lane.index, None)
+                hit = self._starts.get(llp.lp.lane.lane_id, None)
                 if hit:
                     # consider just returning all of them (not slicing)?
                     return [path[: (lookahead + 1)] for path in hit]

--- a/smarts/core/sumo_road_network.py
+++ b/smarts/core/sumo_road_network.py
@@ -1026,6 +1026,8 @@ class SumoRoadNetwork(RoadMap):
         # We take the 10 closest lanepoints then filter down to that which has
         # the closest heading. This way we get the lanepoint on our lane instead of
         # a potentially closer lane that is on a different junction connection.
+        if not closest_lps[0].lane.in_junction:
+            return []
         lps = closest_lps.copy()
         lps.sort(key=lambda lp: abs(pose.heading - lp.pose.heading))
         lane: RoadMap.Lane = lps[0].lane


### PR DESCRIPTION
Fixes #2018 and #2023.

There were a number of issues here. One notable one was that cached lanepoints from incorrect lanes were sometimes returned. We now always generate waypoints for each junction lane (rather than for their roads), and without filtering by `road_id`. This ensures the `lookahead` value will be respected.

Videos below:

https://github.com/huawei-noah/SMARTS/assets/17256344/b7f559ff-c8c8-4c99-963c-8934fb59d1c6

https://github.com/huawei-noah/SMARTS/assets/17256344/210cd356-50f9-49e5-a115-b4a42622e43f



