### PR TITLE
Replace gym with gymnasium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Added `Condition`, `ConditionRequires`, `ConditionState` and various condition implementations to enable logical operations in scenarios.
 - Traffic light signals are now visualized in Envision.
 - Interest vehicles now show up in Envision.
+- Seed of `hiway-v1` env can be retrieved through a new property `seed`.
 ### Changed
 - Changed waypoints in sumo maps to use more incoming lanes into junctions.
 - Increased the cutoff radius for filtering out waypoints that are too far away in junctions in sumo maps.
@@ -27,6 +28,8 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - `TrapEntryTactic.wait_to_hijack_limit_s` field now defaults to `0`.
 - `EntryTactic` derived classes now contain `condition` to provide extra filtering of candidate actors.
 - `EntryTactic` derived classes now contain `start_time`.
+- `info` returned by `hiway-v1` in `reset()` and `step()` methods are unified.
+- Changed instances of `hiway-v0` and `gym` to use `hiway-v1` and `gymnasium`, respectively.
 ### Deprecated
 - `visdom` is set to be removed from the SMARTS object parameters.
 - Deprecated `start_time` on missions.

--- a/docs/minimal.py
+++ b/docs/minimal.py
@@ -1,4 +1,4 @@
-import gym
+import gymnasium as gym
 from smarts.core.agent import Agent
 from smarts.core.agent_interface import AgentInterface, AgentType
 

--- a/examples/control/hiway_env_v1_lane_follower.py
+++ b/examples/control/hiway_env_v1_lane_follower.py
@@ -12,7 +12,7 @@ from smarts.sstudio.scenario_construction import build_scenarios
 
 
 class LaneFollowerAgent(Agent):
-    def act(self, obs: Dict[Any, Union[Any, Dict]]):
+    def act(self, obs):
         return (obs["waypoint_paths"]["speed_limit"][0][0], 0)
 
 
@@ -38,7 +38,7 @@ def main(scenarios, headless, num_episodes, max_episode_steps=None):
             observation, reward, terminated, truncated, info = env.step(
                 {"SingleAgent": agent_action}
             )
-            episode.record_step(observation, reward, terminated, info)
+            episode.record_step(observation, reward, terminated, truncated, info)
 
     env.close()
 

--- a/examples/control/laner.py
+++ b/examples/control/laner.py
@@ -2,13 +2,14 @@ import random
 import sys
 from pathlib import Path
 
-import gym
+import gymnasium as gym
 
 sys.path.insert(0, str(Path(__file__).parents[2].absolute()))
 from examples.tools.argument_parser import default_argument_parser
 from smarts.core.agent import Agent
 from smarts.core.agent_interface import AgentInterface, AgentType
 from smarts.core.utils.episodes import episodes
+from smarts.env.utils.action_conversion import ActionOptions
 from smarts.sstudio.scenario_construction import build_scenarios
 from smarts.zoo.agent_spec import AgentSpec
 
@@ -34,13 +35,13 @@ def main(scenarios, headless, num_episodes, max_episode_steps=None):
     }
 
     env = gym.make(
-        "smarts.env:hiway-v0",
+        "smarts.env:hiway-v1",
         scenarios=scenarios,
         agent_interfaces={
             a_id: a_intrf.interface for a_id, a_intrf in agent_specs.items()
         },
         headless=headless,
-        sumo_headless=True,
+        action_options=ActionOptions.unformatted,
     )
 
     for episode in episodes(n=num_episodes):
@@ -48,17 +49,17 @@ def main(scenarios, headless, num_episodes, max_episode_steps=None):
             agent_id: agent_spec.build_agent()
             for agent_id, agent_spec in agent_specs.items()
         }
-        observations = env.reset()
+        observations, _ = env.reset()
         episode.record_scenario(env.scenario_log)
 
-        dones = {"__all__": False}
-        while not dones["__all__"]:
+        terminateds = {"__all__": False}
+        while not terminateds["__all__"]:
             actions = {
                 agent_id: agents[agent_id].act(agent_obs)
                 for agent_id, agent_obs in observations.items()
             }
-            observations, rewards, dones, infos = env.step(actions)
-            episode.record_step(observations, rewards, dones, infos)
+            observations, rewards, terminateds, truncateds, infos = env.step(actions)
+            episode.record_step(observations, rewards, terminateds, truncateds, infos)
 
     env.close()
 

--- a/examples/egoless.py
+++ b/examples/egoless.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-import gym
+import gymnasium as gym
 from tools.argument_parser import default_argument_parser
 
 from smarts.core.utils.episodes import episodes
@@ -9,11 +9,10 @@ from smarts.sstudio.scenario_construction import build_scenarios
 
 def main(scenarios, headless, num_episodes, max_episode_steps=None):
     env = gym.make(
-        "smarts.env:hiway-v0",
+        "smarts.env:hiway-v1",
         scenarios=scenarios,
-        agent_specs={},
+        agent_interfaces={},
         headless=headless,
-        sumo_headless=True,
     )
 
     if max_episode_steps is None:
@@ -25,7 +24,7 @@ def main(scenarios, headless, num_episodes, max_episode_steps=None):
 
         for _ in range(max_episode_steps):
             env.step({})
-            episode.record_step({}, {}, {}, {})
+            episode.record_step({}, {}, {}, {}, {})
 
     env.close()
 

--- a/examples/env/figure_eight_env.py
+++ b/examples/env/figure_eight_env.py
@@ -1,43 +1,35 @@
 from pathlib import Path
 
-import gym
+import gymnasium as gym
 
 from smarts.core.agent_interface import AgentInterface, AgentType
-from smarts.env.wrappers.single_agent import SingleAgent
-from smarts.zoo.agent_spec import AgentSpec
+from smarts.env.gymnasium.wrappers.single_agent import SingleAgent
 
-agent_spec = AgentSpec(
-    interface=AgentInterface.from_type(
-        AgentType.Laner,
-        max_episode_steps=150,
-        top_down_rgb=True,
-        occupancy_grid_map=True,
-        drivable_area_grid_map=True,
-    ),
-    agent_builder=None,
+agent_interface = AgentInterface.from_type(
+    AgentType.Laner,
+    max_episode_steps=150,
+    top_down_rgb=True,
+    occupancy_grid_map=True,
+    drivable_area_grid_map=True,
 )
 
 
 def entry_point(*args, **kwargs):
-    from smarts.env.hiway_env import HiWayEnv
-
     scenario = str(
         (Path(__file__).parent / "../../scenarios/sumo/figure_eight").resolve()
     )
-    ## Note: can build the scenario here
+    # Note: can build the scenario here
     from smarts.sstudio.scenario_construction import build_scenario
 
     build_scenario(scenario=scenario, clean=True)
-    hiwayenv = HiWayEnv(
-        agent_specs={"agent-007": agent_spec},
+    env = gym.make(
+        "smarts.env:hiway-v1",
+        agent_interfaces={"agent-007": agent_interface},
         scenarios=[scenario],
         headless=True,
-        sumo_headless=True,
     )
-    hiwayenv.metadata["render.modes"] = set(hiwayenv.metadata["render.modes"]) | {
-        "rgb_array"
-    }
-    return SingleAgent(hiwayenv)
+    env.metadata["render.modes"] = set(env.metadata["render.modes"]) | {"rgb_array"}
+    return SingleAgent(env)
 
 
 gym.register("figure_eight-v0", entry_point=entry_point)

--- a/examples/rl/drive/train/env.py
+++ b/examples/rl/drive/train/env.py
@@ -13,7 +13,7 @@ def make_env(env_id, scenario, agent_interface, config, seed):
     from train.reward import Reward
 
     from smarts.env.gymnasium.wrappers.api_reversion import Api021Reversion
-    from smarts.env.wrappers.single_agent import SingleAgent
+    from smarts.env.gymnasium.wrappers.single_agent import SingleAgent
 
     env = gym.make(
         env_id,
@@ -24,8 +24,8 @@ def make_env(env_id, scenario, agent_interface, config, seed):
         headless=not config.head,  # If False, enables Envision display.
     )
     env = Reward(env)
-    env = Api021Reversion(env)
     env = SingleAgent(env)
+    env = Api021Reversion(env)
     env = Preprocess(env, agent_interface)
     env = Monitor(env)
 

--- a/examples/rl/platoon/train/env.py
+++ b/examples/rl/platoon/train/env.py
@@ -13,7 +13,7 @@ def make_env(env_id, scenario, agent_interface, config, seed):
     from train.reward import Reward
 
     from smarts.env.gymnasium.wrappers.api_reversion import Api021Reversion
-    from smarts.env.wrappers.single_agent import SingleAgent
+    from smarts.env.gymnasium.wrappers.single_agent import SingleAgent
 
     env = gym.make(
         env_id,
@@ -24,8 +24,8 @@ def make_env(env_id, scenario, agent_interface, config, seed):
         headless=not config.head,  # If False, enables Envision display.
     )
     env = Reward(env)
-    env = Api021Reversion(env)
     env = SingleAgent(env)
+    env = Api021Reversion(env)
     env = Preprocess(env, agent_interface)
     env = Monitor(env)
 

--- a/examples/tools/regression_rllib.py
+++ b/examples/tools/regression_rllib.py
@@ -5,7 +5,7 @@ import os
 import tempfile
 from pathlib import Path
 
-import gym
+import gymnasium as gym
 import numpy as np
 import pandas as pd
 

--- a/smarts/core/agent.py
+++ b/smarts/core/agent.py
@@ -21,8 +21,6 @@ import logging
 import warnings
 from typing import Any, Callable
 
-from smarts.core.observations import Observation
-
 warnings.simplefilter("once")
 
 logger = logging.getLogger(__name__)
@@ -49,7 +47,7 @@ class Agent:
 
         return FunctionAgent()
 
-    def act(self, obs: Observation, **configs):
+    def act(self, obs, **configs):
         """The agent action. See documentation on observations, `AgentSpec`, and `AgentInterface`.
 
         Expects an adapted observation and returns an unadapted action.

--- a/smarts/core/tests/test_notebook.py
+++ b/smarts/core/tests/test_notebook.py
@@ -23,7 +23,7 @@ import logging
 import os
 import tempfile
 
-import gym
+import gymnasium as gym
 import importlib_resources
 import pytest
 import pytest_notebook.nb_regression as nb
@@ -61,27 +61,28 @@ def run_scenario(
     )
 
     env = gym.make(
-        "smarts.env:hiway-v0",
+        "smarts.env:hiway-v1",
         scenarios=scenarios,
-        agent_specs={AGENT_ID: agent_spec},
+        agent_specs={AGENT_ID: agent_spec.interface},
         sim_name=sim_name,
         headless=headless,
         fixed_timestep_sec=0.1,
-        sumo_headless=True,
         seed=seed,
     )
 
     for episode in episodes(n=num_episodes):
         agent = agent_spec.build_agent()
-        observations = env.reset()
+        observations, _ = env.reset()
         episode.record_scenario(env.scenario_log)
 
-        dones = {"__all__": False}
-        while not dones["__all__"]:
+        terminateds = {"__all__": False}
+        while not terminateds["__all__"]:
             agent_obs = observations[AGENT_ID]
             agent_action = agent.act(agent_obs)
-            observations, rewards, dones, infos = env.step({AGENT_ID: agent_action})
-            episode.record_step(observations, rewards, dones, infos)
+            observations, rewards, terminateds, truncateds, infos = env.step(
+                {AGENT_ID: agent_action}
+            )
+            episode.record_step(observations, rewards, terminateds, truncateds, infos)
 
     env.close()
 

--- a/smarts/core/tests/test_observations.py
+++ b/smarts/core/tests/test_observations.py
@@ -23,7 +23,7 @@ import logging
 import math
 from typing import Dict
 
-import gym
+import gymnasium as gym
 import numpy as np
 import pytest
 from panda3d.core import OrthographicLens, Point2, Point3
@@ -53,6 +53,7 @@ from smarts.core.scenario import Scenario
 from smarts.core.signals import SignalLightState
 from smarts.core.smarts import SMARTS
 from smarts.core.sumo_traffic_simulation import SumoTrafficSimulation
+from smarts.env.utils.observation_conversion import ObservationOptions
 from smarts.zoo.agent_spec import AgentSpec
 
 logging.basicConfig(level=logging.INFO)
@@ -93,19 +94,20 @@ def agent_interface():
 def agent_spec(agent_interface):
     return AgentSpec(
         interface=agent_interface,
-        agent_builder=lambda: Agent.from_function(lambda _: "keep_lane"),
+        agent_builder=lambda: Agent.from_function(lambda _: 0),
     )
 
 
 @pytest.fixture
 def env(agent_spec: AgentSpec):
     _env = gym.make(
-        "smarts.env:hiway-v0",
+        "smarts.env:hiway-v1",
         scenarios=["scenarios/sumo/figure_eight"],
         agent_interfaces={AGENT_ID: agent_spec.interface},
         headless=True,
         fixed_timestep_sec=0.1,
         seed=42,
+        observation_options=ObservationOptions.unformatted,
     )
 
     yield _env
@@ -184,13 +186,13 @@ def sample_vehicle_pos(
 
 def test_observations(env, agent_spec):
     agent = agent_spec.build_agent()
-    observations: Dict[str, Observation] = env.reset()
+    observations: Dict[str, Observation] = env.reset()[0]
 
     # Let the agent step for a while
     for _ in range(NUM_STEPS):
         agent_obs = observations[AGENT_ID]
         agent_action = agent.act(agent_obs)
-        observations, _, _, _ = env.step({AGENT_ID: agent_action})
+        observations, _, _, _, _ = env.step({AGENT_ID: agent_action})
 
     # RGB
     rgb = observations[AGENT_ID].top_down_rgb

--- a/smarts/core/utils/episodes.py
+++ b/smarts/core/utils/episodes.py
@@ -141,25 +141,32 @@ class EpisodeLog:
         )
         self.mission_hash = scenario_log["mission_hash"]
 
-    def record_step(self, observations=None, rewards=None, dones=None, infos=None):
+    def record_step(self, observations, rewards, terminateds, truncateds, infos):
         """Record a step end."""
         self.steps += 1
 
-        if not isinstance(dones, dict):
-            observations, rewards, dones, infos = self._convert_to_dict(
-                observations, rewards, dones, infos
+        if not isinstance(terminateds, dict):
+            (
+                observations,
+                rewards,
+                terminateds,
+                truncateds,
+                infos,
+            ) = self._convert_to_dict(
+                observations, rewards, terminateds, truncateds, infos
             )
 
-        if dones.get("__all__", False) and infos is not None:
+        if terminateds.get("__all__", False) and infos is not None:
             for agent, score in infos.items():
                 self.scores[agent] = score["score"]
 
-    def _convert_to_dict(self, observations, rewards, dones, infos):
+    def _convert_to_dict(self, observations, rewards, terminateds, truncateds, infos):
         observations, rewards, infos = [
             {"SingleAgent": obj} for obj in [observations, rewards, infos]
         ]
-        dones = {"SingleAgent": dones, "__all__": dones}
-        return observations, rewards, dones, infos
+        terminateds = {"SingleAgent": terminateds, "__all__": terminateds}
+        truncateds = {"SingleAgent": truncateds, "__all__": truncateds}
+        return observations, rewards, terminateds, truncateds, infos
 
 
 def episodes(n):

--- a/smarts/diagnostic/run.py
+++ b/smarts/diagnostic/run.py
@@ -28,7 +28,7 @@ from time import time
 from typing import Any, Callable, Dict, Sequence
 
 import cpuinfo
-import gym
+import gymnasium as gym
 import matplotlib.pyplot as plt
 import psutil
 from mdutils.mdutils import MdUtils
@@ -36,6 +36,7 @@ from mdutils.mdutils import MdUtils
 import smarts
 from smarts.core.scenario import Scenario
 from smarts.core.utils.math import welford
+from smarts.env.gymnasium.hiway_env_v1 import ScenarioOrder
 from smarts.sstudio.scenario_construction import build_scenarios
 
 _SEED = 42
@@ -49,13 +50,12 @@ logger.setLevel(logging.INFO)
 def _compute(scenario_dir, ep_per_scenario=10, max_episode_steps=_MAX_EPISODE_STEPS):
     build_scenarios(scenarios=scenario_dir, seed=_SEED)
     env = gym.make(
-        "smarts.env:hiway-v0",
+        "smarts.env:hiway-v1",
         scenarios=scenario_dir,
-        shuffle_scenarios=False,
+        scenarios_order=ScenarioOrder.Sequential,
         sim_name="Diagnostic",
-        agent_specs={},
+        agent_interfaces={},
         headless=True,
-        sumo_headless=True,
         seed=_SEED,
     )
     scenarios = Scenario.get_scenario_list(scenario_dir)

--- a/smarts/env/custom_observations.py
+++ b/smarts/env/custom_observations.py
@@ -20,7 +20,7 @@
 from dataclasses import dataclass
 from typing import Callable, Dict
 
-import gym
+import gymnasium as gym
 import numpy as np
 
 from smarts.core.coordinates import Heading

--- a/smarts/env/gymnasium/wrappers/episode_logger.py
+++ b/smarts/env/gymnasium/wrappers/episode_logger.py
@@ -19,12 +19,11 @@
 # THE SOFTWARE.
 from typing import Any, Dict, Iterator, Tuple
 
-import gym
+import gymnasium as gym
 
 from smarts.core.utils.episodes import EpisodeLog, EpisodeLogs
 
 Action = Any
-Operation = Any
 
 
 class EpisodeLogger(gym.Wrapper):
@@ -36,20 +35,19 @@ class EpisodeLogger(gym.Wrapper):
         self._closed = False
         self._log_iter = self._episode_logs(col_width)
 
-    def step(self, action: Action) -> Tuple[Operation, float, bool, Dict[str, Any]]:
+    def step(self, action: Action):
         """Mark a step for logging."""
-
         step_vals = super().step(action)
         self._current_episode.record_step(*step_vals)
         return step_vals
 
-    def reset(self) -> Any:
+    def reset(self) -> Tuple[Any, Dict[str, Any]]:
         """Mark an episode reset for logging."""
 
-        obs = super().reset()
+        out = super().reset()
         self._current_episode: EpisodeLog = next(self._log_iter)
         self._current_episode.record_scenario(self.scenario_log)
-        return obs
+        return out
 
     def close(self):
         """Cap off the episode logging."""

--- a/smarts/env/gymnasium/wrappers/single_agent.py
+++ b/smarts/env/gymnasium/wrappers/single_agent.py
@@ -22,7 +22,7 @@
 
 from typing import Any, Tuple
 
-import gym
+import gymnasium as gym
 
 
 class SingleAgent(gym.Wrapper):
@@ -48,28 +48,32 @@ class SingleAgent(gym.Wrapper):
         if self.action_space:
             self.action_space = self.action_space[self._agent_id]
 
-    def step(self, action: Any) -> Tuple[Any, float, bool, Any]:
+    def step(self, action: Any) -> Tuple[Any, float, bool, bool, Any]:
         """Steps a single-agent SMARTS environment.
 
         Args:
             action (Any): Agent's action
 
         Returns:
-            Tuple[Any, float, bool, Any]: Agent's observation, reward, done, and info
+            Tuple[Any, float, bool, bool, Any]: Agent's observation, reward,
+                terminated, truncated, and info
         """
-        obs, reward, done, info = self.env.step({self._agent_id: action})
+        obs, reward, terminated, truncated, info = self.env.step(
+            {self._agent_id: action}
+        )
         return (
             obs[self._agent_id],
             reward[self._agent_id],
-            done[self._agent_id],
+            terminated[self._agent_id],
+            truncated[self._agent_id],
             info[self._agent_id],
         )
 
-    def reset(self) -> Any:
+    def reset(self) -> Tuple[Any, Any]:
         """Resets a single-agent SMARTS environment.
 
         Returns:
-            Any: Agent's observation
+            Tuple[Any, Any]: Agent's observation and info
         """
-        obs = self.env.reset()
-        return obs[self._agent_id]
+        obs, info = self.env.reset()
+        return obs[self._agent_id], info[self._agent_id]

--- a/smarts/env/tests/test_benchmark.py
+++ b/smarts/env/tests/test_benchmark.py
@@ -19,12 +19,11 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-import gym
+import gymnasium as gym
 import pytest
 
 from smarts.core.agent_interface import AgentInterface, AgentType
 from smarts.core.controllers import ActionSpaceType
-from smarts.zoo.agent_spec import AgentSpec
 
 
 @pytest.fixture(params=[5, 10])
@@ -43,19 +42,19 @@ def agent_interface(request):
 
 
 @pytest.fixture
-def agent_specs(agent_ids, agent_interface):
-    return {id_: AgentSpec(interface=agent_interface) for id_ in agent_ids}
+def agent_interfaces(agent_ids, agent_interface):
+    return {id_: agent_interface for id_ in agent_ids}
 
 
 @pytest.fixture
 def env(agent_specs):
     env = gym.make(
-        "smarts.env:hiway-v0",
+        "smarts.env:hiway-v1",
         scenarios=["scenarios/sumo/loop"],
-        agent_specs=agent_specs,
+        agent_interfaces=agent_interfaces,
         headless=True,
         seed=2008,
-        fixed_timestep_sec=0.01,
+        fixed_timestep_sec=0.1,
     )
     env.reset()
     yield env

--- a/smarts/env/tests/test_hiway_env.py
+++ b/smarts/env/tests/test_hiway_env.py
@@ -85,7 +85,7 @@ def test_hiway_env(env: HiWayEnv, agent_spec: AgentSpec):
                 [-3 < reward < 3 for reward in rewards.values()]
             ), f"Expected bounded reward per timestep, but got {rewards}."
 
-            episode.record_step(observations, rewards, dones, infos)
+            episode.record_step(observations, rewards, dones, dones, infos)
 
     assert episode is not None and episode.index == (
         MAX_EPISODES - 1

--- a/smarts/env/tests/test_hiway_env_v1.py
+++ b/smarts/env/tests/test_hiway_env_v1.py
@@ -76,9 +76,9 @@ def test_hiway_env_v1_unformatted(env: HiWayEnvV1):
         observations = env.reset()
         episode.record_scenario(env.scenario_log)
 
-        terminated = {"__all__": False}
-        while not terminated["__all__"]:
-            observations, rewards, terminated, truncated, infos = env.step(
+        terminateds = {"__all__": False}
+        while not terminateds["__all__"]:
+            observations, rewards, terminateds, truncateds, infos = env.step(
                 {AGENT_ID: "keep_lane"}
             )
 
@@ -91,7 +91,7 @@ def test_hiway_env_v1_unformatted(env: HiWayEnvV1):
                 [-3 < reward < 3 for reward in rewards.values()]
             ), f"Expected bounded reward per timestep, but got {rewards}."
 
-            episode.record_step(observations, rewards, terminated, infos)
+            episode.record_step(observations, rewards, terminateds, truncateds, infos)
 
     assert episode is not None and episode.index == (
         MAX_EPISODES - 1

--- a/smarts/env/tests/test_rllib_hiway_env.py
+++ b/smarts/env/tests/test_rllib_hiway_env.py
@@ -21,7 +21,7 @@
 # THE SOFTWARE.
 from pathlib import Path
 
-import gym
+import gymnasium as gym
 import numpy as np
 import pytest
 

--- a/smarts/env/utils/record.py
+++ b/smarts/env/utils/record.py
@@ -17,10 +17,9 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-import os
 from typing import Any
 
-import gym
+import gymnasium as gym
 import numpy as np
 
 from smarts.core.sensors import Observation

--- a/smarts/env/wrappers/recorder_wrapper.py
+++ b/smarts/env/wrappers/recorder_wrapper.py
@@ -20,7 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 import os
-import typing
 from pathlib import Path
 
 import gym

--- a/zoo/evaluation/egoless_example.py
+++ b/zoo/evaluation/egoless_example.py
@@ -1,6 +1,6 @@
 import argparse
 
-import gym
+import gymnasium as gym
 
 from smarts.core.utils.episodes import episodes
 
@@ -25,11 +25,10 @@ if __name__ == "__main__":
         f"./{args.replay_data}/{args.scenarios[0].split('/')[-1]}/data_replay"
     )
     env = gym.make(
-        "smarts.env:hiway-v0",
+        "smarts.env:hiway-v1",
         scenarios=args.scenarios,
-        agent_specs={},
+        agent_interfaces={},
         headless=args.headless,
-        visdom=False,
         fixed_timestep_sec=0.1,
         envision_record_data_replay_path=data_replay_path,
     )
@@ -40,6 +39,6 @@ if __name__ == "__main__":
 
         for _ in range(600):
             env.step({})
-            episode.record_step({}, {}, {}, {})
+            episode.record_step({}, {}, {}, {}, {})
 
     env.close()

--- a/zoo/policies/rl-agent/rl_agent/agent.py
+++ b/zoo/policies/rl-agent/rl_agent/agent.py
@@ -2,7 +2,6 @@
 This file contains an RLlib-trained policy evaluation usage (not for training).
 """
 import pickle
-from pathlib import Path
 
 import gym
 import tensorflow.compat.v1 as tf


### PR DESCRIPTION
1. This pull request is a step towards replacing gym with gymnasium. Related issue #1981.
   - `info` returned by `hiway-v1` in `reset()` and `step()` methods are unified.
   - Seed of `hiway-v1` env can be retrieved through a new property `seed`.
   - Replaced instances of `hiway-v0` and `gym` with `hiway-v1` and `gymnasium`, respectively.

1. The following are the remaining components which still use gym. They are to be removed or made optional in subsequent pull requests.
    - SMARTS/smarts/env/hiway_env.py
    - SMARTS/smarts/env/tests/test_hiway_env.py
    - SMARTS/smarts/env/gymnasium/wrappers/api_reversion.py
    - SMARTS/examples/rl/rllib
    - SMARTS/smarts/env/wrappers/gif_recorder.py
    - SMARTS/smarts/env/wrappers/record_video.py
    - SMARTS/smarts/env/wrappers/recorder_wrapper.py
    - SMARTS/zoo/evaluation/npc_ego_example.py
    - SMARTS/zoo/policies/cross-rl-agent
    - SMARTS/zoo/policies/rl-agent