### PR TITLE
Standardize entry tactic capture time range.

### DIFF
--- a/smarts/core/tests/test_observations.py
+++ b/smarts/core/tests/test_observations.py
@@ -319,13 +319,13 @@ def test_signal_observations(smarts, scenario):
                 signals[0].controlled_lanes[0] == ":junction-intersection_9_0"
             ), f"step={step}"
             assert len(signals[0].controlled_lanes) == 1, f"step={step}"
-            if step < 449:
+            if step < 448:
                 assert signals[0].state == SignalLightState.STOP, f"{step}"
                 assert signals[0].last_changed is None, f"{step}"
-            elif step < 799:
+            elif step < 798:
                 assert signals[0].state == SignalLightState.GO, f"{step}"
                 assert np.isclose(signals[0].last_changed, 45.1), f"{step}"
-            elif step < 899:
+            elif step < 898:
                 assert signals[0].state == SignalLightState.CAUTION, f"{step}"
                 assert np.isclose(signals[0].last_changed, 80.1), f"{step}"
             else:

--- a/smarts/core/tests/test_trap_manager.py
+++ b/smarts/core/tests/test_trap_manager.py
@@ -185,7 +185,7 @@ def test_capture_vehicle(smarts: SMARTS, scenarios, traffic_sim):
 @pytest.mark.parametrize("traffic_sim", ["SUMO", "SMARTS"], indirect=True)
 def test_emit_on_default(smarts: SMARTS, empty_scenarios):
     smarts.reset(next(empty_scenarios))
-    assert round(smarts.elapsed_sim_time, 2) == 3.1
+    assert round(smarts.elapsed_sim_time, 2) == 3.2
     assert len(smarts.vehicle_index.agent_vehicle_ids()) == 1
     assert len(smarts.vehicle_index.vehicle_ids_by_owner_id(AGENT_ID)) == 1
 

--- a/smarts/core/trap_manager.py
+++ b/smarts/core/trap_manager.py
@@ -61,7 +61,7 @@ class Trap:
     def patience_expired(self, sim_time: float):
         """If the trap has expired and should no longer capture a vehicle."""
         expiry_time = self.activation_time + self.patience
-        return expiry_time < sim_time or math.isclose(expiry_time, sim_time)
+        return expiry_time < sim_time and not math.isclose(expiry_time, sim_time)
 
     def includes(self, vehicle_id: str):
         """Returns if the given actor should be considered for capture."""
@@ -220,7 +220,10 @@ class TrapManager(ActorCaptureManager):
                 )
                 continue
 
-            if trap.patience_expired(sim.elapsed_sim_time):
+            if (
+                trap.patience_expired(sim.elapsed_sim_time)
+                and sim.elapsed_sim_time > sim.timestep_sec
+            ):
                 capture_by_agent_id[agent_id] = _CaptureState(
                     ConditionState.EXPIRED, trap, updated_mission=trap.mission
                 )


### PR DESCRIPTION
This fixes the range of vehicle capture for entry tactics by making the time range work like python `range()` which means `start` is included and `end` is excluded. There is also a particular case now for times that start before the first step completes.

The issue opened now by excluding the end time is that 0 length wait time will always emit a vehicle without an attempt to capture which could be unexpected. I am unsure if I should put in an automatic value there or set the default to `>0`.