### PR TITLE
Fix `collection` moudule DeprecationWarning

### DIFF
--- a/smarts/sstudio/types/standard_metadata.py
+++ b/smarts/sstudio/types/standard_metadata.py
@@ -21,12 +21,12 @@
 # THE SOFTWARE.
 
 
-import collections
+from collections.abc import Mapping
 from functools import cached_property
 from typing import Any, Dict, Iterator, Optional
 
 
-class StandardMetadata(collections.Mapping):
+class StandardMetadata(Mapping):
     """Metadata that does not have direct influence on the simulation."""
 
     def __init__(


### PR DESCRIPTION
This warning usually appears at the beginning of a simulation as the following:
```
04:49:33 (.venv) kyber@kyber-Z370-X driving-smarts-2.competition-scenarios ±|master ✗|→ scl run ~/SMARTS/examples/control/chase_via_points.py t3/validation/02703945-4c1c-432d-9d6a-13a2d674bb2e_agents_1/
/home/kyber/SMARTS/smarts/sstudio/types/standard_metadata.py:24: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
  from collections import Mapping
/home/kyber/SMARTS/.venv/lib/python3.8/site-packages/gymnasium/spaces/box.py:129: UserWarning: WARN: Box bound precision lowered by casting to float32
  gym.logger.warn(f"Box bound precision lowered by casting to {self.dtype}")
Using configuration from: /home/kyber/SMARTS/smarts/engine.ini
╭────────────────────┬────────────────────┬────────────────────┬────────────────────┬────────────────────┬────────────────────┬────────────────────┬────────────────────╮
│            Episode │     Sim T / Wall T │        Total Steps │        Steps / Sec │       Scenario Map │    Scenario Routes │     Mission (Hash) │             Scores │
├────────────────────┼────────────────────┼────────────────────┼────────────────────┼────────────────────┼──────────────
```