### PR TITLE
Scenario build error message improvements

### DIFF
--- a/.github/workflows/ci-format.yml
+++ b/.github/workflows/ci-format.yml
@@ -118,7 +118,7 @@ jobs:
     steps:
       - name: Install packages
         run: |
-          apt-get update
+          apt-get update --fix-missing
           apt-get install -y python3.8-dev
       - name: Add safe directory
         run: git config --global --add safe.directory $GITHUB_WORKSPACE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - `info` returned by `hiway-v1` in `reset()` and `step()` methods are unified.
 - Changed instances of `hiway-v0` and `gym` to use `hiway-v1` and `gymnasium`, respectively.
 - `RoadMap.Route` now optionally stores the start and end lanes of the route.
-- `DistToDestination` metric is now computed by summing the (i) off-route distance driven by the vehicle from its last on-route position, and (ii) the distance to goal from the vehicle's last on-route position. 
+- `DistToDestination` metric is now computed by summing the (i) off-route distance driven by the vehicle from its last on-route position, and (ii) the distance to goal from the vehicle's last on-route position.
+- Improved error messages for scenario build failures.
 ### Deprecated
 - `visdom` is set to be removed from the SMARTS object parameters.
 - Deprecated `start_time` on missions.

--- a/scenarios/sumo/loop/scenario.py
+++ b/scenarios/sumo/loop/scenario.py
@@ -1,13 +1,9 @@
 import random
-import sys
 from pathlib import Path
 
-from smarts.core import seed
 from smarts.core.colors import Colors
 from smarts.sstudio import gen_scenario
 from smarts.sstudio import types as t
-
-seed(42)
 
 traffic = t.Traffic(
     flows=[

--- a/smarts/sstudio/genscenario.py
+++ b/smarts/sstudio/genscenario.py
@@ -62,7 +62,7 @@ class ActorAndMission:
 def _check_if_called_externally():
     frame_info = inspect.stack()[2]
     module = inspect.getmodule(frame_info[0])
-    if module.__name__ != "smarts.sstudio.genscenario":
+    if not module or module.__name__ != "smarts.sstudio.genscenario":
         logger.warning(
             "",
             exc_info=DeprecationWarning(

--- a/smarts/sstudio/scenario_builder.py
+++ b/smarts/sstudio/scenario_builder.py
@@ -1,0 +1,25 @@
+import argparse
+
+from smarts.core import seed as smarts_seed
+
+
+def _build(scenario_py: str, seed: int):
+    # Make sure all the seed values are consistent before running the scenario script
+    smarts_seed(seed)
+
+    # Execute the scenario script, using the current globals that were set by the seed value
+    with open(scenario_py, "rb") as source_file:
+        code = compile(source_file.read(), scenario_py, "exec")
+        exec(code, {"__file__": scenario_py})
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("scenario_py", help="Path to the scenario.py file.", type=str)
+    parser.add_argument(
+        "seed",
+        help="Seed that will be set before executing the scenario script.",
+        type=int,
+    )
+    args = parser.parse_args()
+    _build(args.scenario_py, args.seed)

--- a/smarts/sstudio/scenario_builder.py
+++ b/smarts/sstudio/scenario_builder.py
@@ -1,3 +1,23 @@
+# Copyright (C) 2023. Huawei Technologies Co., Ltd. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
 import argparse
 
 from smarts.core import seed as smarts_seed


### PR DESCRIPTION
When an error is encountered while building a scenario, the error message can be cryptic because it is actually running a temp file, and the stack trace is noisy:

```sh
Building: scenarios/sumo/loop/
Traceback (most recent call last):
  File "tmpjv0_4z2_.py", line 14, in <module>
    traffic = t.Traffic(
NameError: name 't' is not defined
Traceback (most recent call last):
  File "/home/saul/code/SMARTS/.venv/bin/scl", line 8, in <module>
    sys.exit(scl())
  File "/home/saul/code/SMARTS/.venv/lib/python3.8/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/saul/code/SMARTS/.venv/lib/python3.8/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/saul/code/SMARTS/.venv/lib/python3.8/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/saul/code/SMARTS/.venv/lib/python3.8/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/saul/code/SMARTS/.venv/lib/python3.8/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/saul/code/SMARTS/.venv/lib/python3.8/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/saul/code/SMARTS/cli/studio.py", line 55, in build
    build_scenario(scenario=scenario, clean=clean, seed=seed, log=click.echo)
  File "/home/saul/code/SMARTS/smarts/sstudio/scenario_construction.py", line 62, in build_scenario
    subprocess.check_call(
  File "/usr/lib/python3.8/subprocess.py", line 364, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/home/saul/code/SMARTS/.venv/bin/python3.8', 'tmpjv0_4z2_.py']' returned non-zero exit status 1.
```

I changed it so that no temp file is created, and I trimmed the error message:

```sh
Building: scenarios/sumo/loop/
Traceback (most recent call last):
  File "scenario_builder.py", line 45, in <module>
    _build(args.scenario_py, args.seed)
  File "scenario_builder.py", line 33, in _build
    exec(code, {"__file__": scenario_py})
  File "/home/saul/code/SMARTS/scenarios/sumo/loop/scenario.py", line 9, in <module>
    traffic = t.Traffic(
NameError: name 't' is not defined
Command '['/home/saul/code/SMARTS/.venv/bin/python3.8', 'scenario_builder.py', '/home/saul/code/SMARTS/scenarios/sumo/loop/scenario.py', '42']' returned non-zero exit status 1.
```

We could remove even more of the error message if we want.