### PR TITLE
CI test for Driving SMARTS 2023 benchmark

### DIFF
--- a/.github/workflows/ci-base-tests-linux.yml
+++ b/.github/workflows/ci-base-tests-linux.yml
@@ -51,3 +51,34 @@ jobs:
             --ignore=./smarts/env/tests/test_benchmark.py \
             --ignore=./examples/tests/test_learning.py \
             -k 'not test_long_determinism'
+
+  benchmark:
+    runs-on: ubuntu-20.04
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    container: ghcr.io/smarts-project/smarts:v0.6.1-minimal
+    strategy:
+      matrix:
+        tests:
+          - drive
+          - platoon
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          cd ${GITHUB_WORKSPACE}
+          python3.8 -m venv ${{env.venv_dir}}
+          . ${{env.venv_dir}}/bin/activate
+          pip install --upgrade pip
+          pip install wheel==0.38.4
+          pip install -e .[camera_obs,argoverse,test,ray]
+          scl zoo install examples/rl/${{matrix.tests}}/inference
+      - name: Run smoke tests
+        run: |
+          cd ${GITHUB_WORKSPACE}
+          . ${{env.venv_dir}}/bin/activate
+          PYTHONPATH=$PWD PYTHONHASHSEED=42 pytest -v \
+            --doctest-modules \
+            --forked \
+            --dist=no \
+            ${GITHUB_WORKSPACE}/smarts/benchmark/tests/test_benchmark_runner.py::test_${{matrix.tests}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Interest vehicles now show up in Envision.
 - Seed of `hiway-v1` env can be retrieved through a new property `seed`.
 - Added `TrafficEngineActor` to describe a scenario studio defined actor that is controlled by a traffic engine.
+- Added CI test for Driving SMARTS 2023 benchmark, which tests the benchmark by using it to evaluate (i) `examples.rl.drive.inference:contrib-agent-v0`, and (ii) `examples.rl.platoon.inference:contrib-agent-v0` agents. 
 ### Changed
 - Changed waypoints in sumo maps to use more incoming lanes into junctions.
 - Increased the cutoff radius for filtering out waypoints that are too far away in junctions in sumo maps.

--- a/smarts/benchmark/tests/test_benchmark_runner.py
+++ b/smarts/benchmark/tests/test_benchmark_runner.py
@@ -1,0 +1,81 @@
+# MIT License
+#
+# Copyright (C) 2023. Huawei Technologies Co., Ltd. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from smarts.benchmark.driving_smarts import load_config
+from smarts.benchmark.entrypoints.benchmark_runner_v0 import benchmark
+
+
+@pytest.fixture(scope="module")
+def get_benchmark_args(request):
+    config_path = Path(__file__).resolve().parents[3] / request.param
+    benchmark_args = load_config(config_path)["benchmark"]
+    assert isinstance(benchmark_args, dict), f"Config path not found: {config_path}."
+    benchmark_args.update({"eval_episodes": 2})
+    return benchmark_args
+
+
+def _get_model(action):
+    class MockModel:
+        def predict(*args, **kwargs):
+            return (action, None)
+
+    return lambda _: MockModel()
+
+
+@pytest.mark.parametrize(
+    "get_benchmark_args",
+    [
+        "smarts/benchmark/driving_smarts/v2023/config_1.yaml",
+        "smarts/benchmark/driving_smarts/v2023/config_2.yaml",
+    ],
+    indirect=True,
+)
+def test_drive(get_benchmark_args):
+    """Tests Driving SMARTS 2023.1 and 2023.2 benchmarks using `examples/rl/drive` model."""
+    from contrib_policy.policy import Policy
+
+    agent_locator = "examples.rl.drive.inference:contrib-agent-v0"
+    action = 1
+    with mock.patch.object(Policy, "_get_model", _get_model(action)):
+        benchmark(benchmark_args=get_benchmark_args, agent_locator=agent_locator)
+
+
+@pytest.mark.parametrize(
+    "get_benchmark_args",
+    [
+        "smarts/benchmark/driving_smarts/v2023/config_3.yaml",
+    ],
+    indirect=True,
+)
+def test_platoon(get_benchmark_args):
+    """Tests Driving SMARTS 2023.3 benchmark using `examples/rl/platoon` model."""
+    from contrib_policy.policy import Policy
+
+    agent_locator = "examples.rl.platoon.inference:contrib-agent-v0"
+    action = 2
+    with mock.patch.object(Policy, "_get_model", _get_model(action)):
+        benchmark(benchmark_args=get_benchmark_args, agent_locator=agent_locator)


### PR DESCRIPTION
- Added CI test for Driving SMARTS 2023 benchmark, which tests the benchmark by using it to evaluate (i) `examples.rl.drive.inference:contrib-agent-v0`, and (ii) `examples.rl.platoon.inference:contrib-agent-v0` agents. 
- By using the RL examples to test the benchmark, we simultaneously verify the zoo-agent compatible packaged inference code of `examples.rl.drive.inference:contrib-agent-v0`, and (ii) `examples.rl.platoon.inference:contrib-agent-v0` agents.
- Note: The CI test for this PR will pass after #2061 is merged.