### PR TITLE
Fix annoying `pybullet` `argv[0]=` print

### DIFF
--- a/smarts/core/smarts.py
+++ b/smarts/core/smarts.py
@@ -36,7 +36,7 @@ from smarts.core.id_actor_capture_manager import IdActorCaptureManager
 from smarts.core.plan import Plan
 from smarts.core.renderer_base import RendererBase
 from smarts.core.simulation_local_constants import SimulationLocalConstants
-from smarts.core.utils.logging import suppress_output, timeit
+from smarts.core.utils.logging import timeit
 from smarts.core.utils.type_operations import TypeSuite
 
 from . import config, models
@@ -206,10 +206,9 @@ class SMARTS(ProviderManager):
         # For macOS GUI. See our `BulletClient` docstring for details.
         # from .utils.bullet import BulletClient
         # self._bullet_client = BulletClient(pybullet.GUI)
-        with suppress_output(stderr=False):
-            self._bullet_client = pybullet.SafeBulletClient(
-                pybullet.DIRECT
-            )  # pylint: disable=no-member
+        self._bullet_client = pybullet.SafeBulletClient(
+            pybullet.DIRECT
+        )  # pylint: disable=no-member
 
         # Set up indices
         self._sensor_manager = SensorManager()

--- a/smarts/core/utils/pybullet.py
+++ b/smarts/core/utils/pybullet.py
@@ -25,7 +25,7 @@ from smarts.core.utils.logging import suppress_output
 # XXX: Importing pybullet logs an annoying build version tag. There's no "friendly"
 #      way to fix this since they simply use print(...). Disabling logging at the
 #      time of import is our hack.
-with suppress_output():
+with suppress_output(stderr=False):
     from pybullet import *
     from pybullet_utils import bullet_client
 
@@ -44,11 +44,12 @@ class SafeBulletClient(bullet_client.BulletClient):
             `pybullet.DIRECT` creates a headless simulation,
             `pybullet.SHARED_MEMORY` connects to an existing simulation.
         """
-        super().__init__(connection_mode=connection_mode)
+        with suppress_output(stderr=False):
+            super().__init__(connection_mode=connection_mode)
 
     def __del__(self):
         """Clean up connection if not already done."""
-        super().__init__()
+        super().__del__()
 
     def __getattr__(self, name):
         """Inject the client id into Bullet functions."""


### PR DESCRIPTION
This fixes a bug I accidentally introduced with the `pybullet` wrapper intended to prevent copying.