### PR TITLE
Add gifs for baseline agent in benchmark scenarios

### DIFF
--- a/docs/benchmarks/driving_smarts_2023_1.rst
+++ b/docs/benchmarks/driving_smarts_2023_1.rst
@@ -45,27 +45,54 @@ below.
 Any method such as reinforcement learning, offline reinforcement learning, behavior cloning, generative models,
 predictive models, etc, may be used to develop the policy.
 
-Several scenarios are provided for training. Their names and tasks are as follows. 
-The desired task execution is illustrated in a gif by a trained baseline agent. 
+Training scenarios
+------------------
+
+Several scenarios are provided for training as follows. 
+The corresponding gifs show the task execution by a trained baseline agent. 
 
 **Driving SMARTS 2023.1 scenarios**
 
 + :scenarios:`cruise_2lane_agents_1 <sumo/straight/cruise_2lane_agents_1>`
+
+  .. image:: https://raw.githubusercontent.com/smarts-project/smarts-project.github.io/master/assets/driving_smarts_2023_1/cruise_2lane_agents_1.gif
+
 + :scenarios:`cutin_2lane_agents_1 <sumo/straight/cutin_2lane_agents_1>`
+
+  .. image:: https://raw.githubusercontent.com/smarts-project/smarts-project.github.io/master/assets/driving_smarts_2023_1/cutin_2lane_agents_1.gif
+
 + :scenarios:`merge_exit_sumo_t_agents_1 <sumo/straight/merge_exit_sumo_t_agents_1>`
 + :scenarios:`overtake_2lane_agents_1 <sumo/straight/overtake_2lane_agents_1>`
 + :scenarios:`00a445fb-7293-4be6-adbc-e30c949b6cf7_agents_1 <argoverse/straight/00a445fb-7293-4be6-adbc-e30c949b6cf7_agents_1>`
+  
+  .. image:: https://raw.githubusercontent.com/smarts-project/smarts-project.github.io/master/assets/driving_smarts_2023_1/00a445fb-7293-4be6-adbc-e30c949b6cf7_agents_1.gif
+     :width: 75%
 + :scenarios:`0a53dd99-2946-4b4d-ab66-c4d6fef97be2_agents_1 <argoverse/straight/0a53dd99-2946-4b4d-ab66-c4d6fef97be2_agents_1>`
+  
+  .. image:: https://raw.githubusercontent.com/smarts-project/smarts-project.github.io/master/assets/driving_smarts_2023_1/0a53dd99-2946-4b4d-ab66-c4d6fef97be2_agents_1.gif
+     :width: 75%
 + :scenarios:`0a576bf1-66ae-495a-9c87-236f3fc2aa01_agents_1 <argoverse/straight/0a576bf1-66ae-495a-9c87-236f3fc2aa01_agents_1>`
 
 **Driving SMARTS 2023.2 scenarios**
 
 + :scenarios:`1_to_3lane_left_turn_sumo_c_agents_1 <sumo/intersections/1_to_3lane_left_turn_sumo_c_agents_1>`
+  
+  .. image:: https://raw.githubusercontent.com/smarts-project/smarts-project.github.io/master/assets/driving_smarts_2023_2/1_to_3lane_left_turn_sumo_c_agents_1.gif
+     :width: 75%
 + :scenarios:`1_to_3lane_left_turn_middle_lane_c_agents_1 <sumo/intersections/1_to_3lane_left_turn_middle_lane_c_agents_1>`
 + :scenarios:`00b15e74-04a8-4bd4-9a78-eb24f0c0a980_agents_1 <argoverse/turn/00b15e74-04a8-4bd4-9a78-eb24f0c0a980_agents_1>`
 + :scenarios:`0a60b442-56b0-46c3-be45-cf166a182b67_agents_1 <argoverse/turn/0a60b442-56b0-46c3-be45-cf166a182b67_agents_1>`
+  
+  .. image:: https://raw.githubusercontent.com/smarts-project/smarts-project.github.io/master/assets/driving_smarts_2023_2/0a60b442-56b0-46c3-be45-cf166a182b67_agents_1.gif
+     :width: 75%
 + :scenarios:`0a764a82-b44e-481e-97e7-05e1f1f925f6_agents_1 <argoverse/turn/0a764a82-b44e-481e-97e7-05e1f1f925f6_agents_1>`
+  
+  .. image:: https://raw.githubusercontent.com/smarts-project/smarts-project.github.io/master/assets/driving_smarts_2023_2/0a764a82-b44e-481e-97e7-05e1f1f925f6_agents_1.gif
+     :width: 75%
 + :scenarios:`0bf054e3-7698-4b86-9c98-626df2dee9f4_agents_1 <argoverse/turn/0bf054e3-7698-4b86-9c98-626df2dee9f4_agents_1>`
+  
+  .. image:: https://raw.githubusercontent.com/smarts-project/smarts-project.github.io/master/assets/driving_smarts_2023_2/0bf054e3-7698-4b86-9c98-626df2dee9f4_agents_1.gif
+     :width: 75%
 
 Observation space
 -----------------

--- a/docs/benchmarks/driving_smarts_2023_3.rst
+++ b/docs/benchmarks/driving_smarts_2023_3.rst
@@ -34,27 +34,43 @@ of steps per episode.
 Any method such as reinforcement learning, offline reinforcement learning, behavior cloning, generative models,
 predictive models, etc, may be used to develop the policy.
 
-Several scenarios are provided for training. Their names and tasks are as follows. 
-The desired task execution is illustrated in a gif by a trained baseline agent. 
+Training scenarios
+------------------
 
-+ straight_2lane_agents_1
-    A single ego must follow a specified leader, with no background traffic.
-
-    .. image:: /_static/driving_smarts_2023/platoon_straight_2lane_agents_1.gif
+Several scenarios are provided for training as follows. 
+The corresponding gifs show the task execution by a trained baseline agent. 
 
 + :scenarios:`straight_2lane_sumo_agents_1 <sumo/vehicle_following/straight_2lane_sumo_agents_1>`
 + :scenarios:`straight_2lane_sumo_t_agents_1 <sumo/vehicle_following/straight_2lane_sumo_t_agents_1>`
 + :scenarios:`straight_3lanes_sumo_agents_1 <sumo/vehicle_following/straight_3lanes_sumo_agents_1>`
 + :scenarios:`straight_3lanes_sumo_t_agents_1 <sumo/vehicle_following/straight_3lanes_sumo_t_agents_1>`
+
+  .. image:: https://raw.githubusercontent.com/smarts-project/smarts-project.github.io/master/assets/driving_smarts_2023_3/straight_3lanes_sumo_t_agents_1.gif
+
 + :scenarios:`straight_3lanes_sumo_t_agents_2 <sumo/vehicle_following/straight_3lanes_sumo_t_agents_2>`
 + :scenarios:`merge_exit_sumo_agents_1 <sumo/vehicle_following/merge_exit_sumo_agents_1>`
 + :scenarios:`merge_exit_sumo_t_agents_1 <sumo/vehicle_following/merge_exit_sumo_t_agents_1>`
+
+  .. image:: https://raw.githubusercontent.com/smarts-project/smarts-project.github.io/master/assets/driving_smarts_2023_3/merge_exit_sumo_t_agents_1.gif
+
 + :scenarios:`merge_exit_sumo_t_agents_2 <sumo/vehicle_following/merge_exit_sumo_t_agents_2>`
 + :scenarios:`ff239c9d-e4ff-4acc-bad5-bd55648c212e_0_agents_1 <argoverse/vehicle_following/ff239c9d-e4ff-4acc-bad5-bd55648c212e_0_agents_1>`
+
+  .. image:: https://raw.githubusercontent.com/smarts-project/smarts-project.github.io/master/assets/driving_smarts_2023_3/ff239c9d-e4ff-4acc-bad5-bd55648c212e_0_agents_1.gif
+
 + :scenarios:`ff239c9d-e4ff-4acc-bad5-bd55648c212e_agents_1 <argoverse/vehicle_following/ff239c9d-e4ff-4acc-bad5-bd55648c212e_agents_1>`
 + :scenarios:`ff6dc43b-dd27-4fe4-94b6-5c1b3940daed_agents_1 <argoverse/vehicle_following/ff6dc43b-dd27-4fe4-94b6-5c1b3940daed_agents_1>`
+
+  .. image:: https://raw.githubusercontent.com/smarts-project/smarts-project.github.io/master/assets/driving_smarts_2023_3/ff6dc43b-dd27-4fe4-94b6-5c1b3940daed_agents_1.gif
+     :width: 75%
 + :scenarios:`ff9619b5-b0c0-4942-b5d8-df6a5814f8a2_agents_1 <argoverse/vehicle_following/ff9619b5-b0c0-4942-b5d8-df6a5814f8a2_agents_1>`
+
+  .. image:: https://raw.githubusercontent.com/smarts-project/smarts-project.github.io/master/assets/driving_smarts_2023_3/ff9619b5-b0c0-4942-b5d8-df6a5814f8a2_agents_1.gif
+     :width: 75%
 + :scenarios:`ffd10ec2-715b-48af-a89d-b11f79927f63_agents_1 <argoverse/vehicle_following/ffd10ec2-715b-48af-a89d-b11f79927f63_agents_1>`
+
+  .. image:: https://raw.githubusercontent.com/smarts-project/smarts-project.github.io/master/assets/driving_smarts_2023_3/ffd10ec2-715b-48af-a89d-b11f79927f63_agents_1.gif
+     :width: 75%
 
 Observation space
 -----------------


### PR DESCRIPTION
+ Gifs show a trained baseline agent attempting the Driving SMARTS 2023.1, 2023.2, and 2023.3, benchmark training scenarios.
+ Gifs are hosted at `https://github.com/smarts-project/smarts-project.github.io`
+ See the following for sample of built pages incorporating the new gifs. 
  + https://smarts.readthedocs.io/en/zoo-8/benchmarks/driving_smarts_2023_1.html#training-scenarios
  + https://smarts.readthedocs.io/en/zoo-8/benchmarks/driving_smarts_2023_3.html#training-scenarios