### PR TITLE
Fix traffic history state not being reset

### DIFF
--- a/smarts/core/traffic_history_provider.py
+++ b/smarts/core/traffic_history_provider.py
@@ -109,7 +109,7 @@ class TrafficHistoryProvider(TrafficProvider):
         return self._dbid_to_actor_id(actor_id)
 
     def reset(self):
-        pass
+        self._reset_scenario_state()
 
     def teardown(self):
         self._is_setup = False


### PR DESCRIPTION
This fixes an issue where the traffic history state was not reset between episodes.