### PR TITLE
Prevent user warning configuration from being overwritten.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Fixed issue where `SumoTrafficSimulation` could get locked up on reset if a scenario had only 1 map but multiple scenario variations.
 - Fixed an issue where an out-of-scope method reference caused a pickling error.
 - Fixed an issue where the `EnvisionDataFormatterArgs` default would use a locally defined lambda and cause a serialization failure.
+- Fixed an issue where user configuration was being overridden.
+- Fixed a `pkg_resources` deprecation warning in `python3.10` and up.
 ### Removed
 ### Security
 

--- a/envision/server.py
+++ b/envision/server.py
@@ -50,9 +50,6 @@ import smarts.core.models
 from envision.web import dist as web_dist
 from smarts.core.utils.file import path2hash
 
-logging.basicConfig(level=logging.WARNING)
-
-
 # Mapping of simulation IDs to a set of web client run loops
 WEB_CLIENT_RUN_LOOPS = {}
 

--- a/examples/e2_single_agent.py
+++ b/examples/e2_single_agent.py
@@ -1,10 +1,16 @@
 """This example shows how you might run a SMARTS environment for single-agent work. SMARTS is
 natively multi-agent so a single-agent wrapper is used."""
 import argparse
+import logging
 import random
 import sys
+import warnings
 from pathlib import Path
 from typing import Final
+
+logging.basicConfig(level=logging.ERROR)
+warnings.filterwarnings("ignore")
+
 
 import gymnasium as gym
 

--- a/examples/replay/replay_klws_agent.py
+++ b/examples/replay/replay_klws_agent.py
@@ -14,8 +14,6 @@ from smarts.core.utils.episodes import episodes
 from smarts.env.utils.observation_conversion import ObservationOptions
 from smarts.zoo.registry import make as zoo_make
 
-logging.basicConfig(level=logging.INFO)
-
 AGENT_ID = "Agent-007"
 
 
@@ -116,6 +114,7 @@ def main(scenarios, sim_name, headless, seed, speed, max_steps, save_dir, write)
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     parser = default_argument_parser("klws-agent-example")
     parser.add_argument(
         "--speed",

--- a/smarts/__init__.py
+++ b/smarts/__init__.py
@@ -18,8 +18,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+try:
+    from importlib.metadata import version
 
-import pkg_resources
+    VERSION = version("smarts")
+except:
+    # This is now deprecated `https://setuptools.pypa.io/en/latest/pkg_resources.html`
+    import pkg_resources
 
-# The full version, including alpha/beta/rc tags
-VERSION = pkg_resources.get_distribution("smarts").version
+    # The full version, including alpha/beta/rc tags
+    VERSION = pkg_resources.get_distribution("smarts").version

--- a/smarts/core/agent.py
+++ b/smarts/core/agent.py
@@ -21,8 +21,6 @@ import logging
 import warnings
 from typing import Any, Callable
 
-warnings.simplefilter("once")
-
 logger = logging.getLogger(__name__)
 
 

--- a/smarts/zoo/agent_spec.py
+++ b/smarts/zoo/agent_spec.py
@@ -27,8 +27,6 @@ import cloudpickle
 from smarts.core.agent import Agent
 from smarts.core.agent_interface import AgentInterface
 
-warnings.simplefilter("once")
-
 
 @dataclass
 class AgentSpec(object):


### PR DESCRIPTION
This allows users to squash warnings if they wish.