### PR TITLE
Fix likely cause of `smarts.__del__` call in `ros_driver`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 ### Changed
 ### Deprecated
 ### Fixed
+- Fixed an issue where `SMARTS` might not be explicitly destroyed in the `ros_driver`.
 - Fixed issue where `SumoTrafficSimulation` could get locked up on reset if a scenario had only 1 map but multiple scenario variations.
 - Fixed an issue where an out-of-scope method reference caused a pickling error.
 - Fixed an issue where the `EnvisionDataFormatterArgs` default would use a locally defined lambda and cause a serialization failure.

--- a/smarts/ros/src/smarts_ros/scripts/ros_driver.py
+++ b/smarts/ros/src/smarts_ros/scripts/ros_driver.py
@@ -684,18 +684,17 @@ class ROSDriver:
 
                     self._publish_state()
                     self._publish_agents(observations, dones)
-                except Exception as e:
-                    if isinstance(e, rospy.ROSInterruptException):
-                        raise e
+                except Exception as ex:
+                    if isinstance(ex, rospy.ROSInterruptException):
+                        raise ex
                     batch_mode = rospy.get_param("~batch_mode", False)
                     if not batch_mode:
-                        raise e
+                        raise ex
                     import traceback
 
-                    rospy.logerr(f"SMARTS raised exception:  {e}")
+                    rospy.logerr(f"SMARTS raised exception:  {ex}")
                     rospy.logerr(traceback.format_exc())
                     rospy.logerr("Will wait for next reset...")
-                    self._smarts.destroy()
                     self._smarts = None
                     self._reset_smarts()
                     self.setup_smarts()
@@ -713,8 +712,8 @@ class ROSDriver:
 
         except rospy.ROSInterruptException:
             rospy.loginfo("ROS interrupted.  exiting...")
-
-        self._reset()  # cleans up the SMARTS instance...
+        finally:
+            self._reset()  # cleans up the SMARTS instance...
 
 
 if __name__ == "__main__":

--- a/smarts/ros/src/smarts_ros/scripts/ros_driver.py
+++ b/smarts/ros/src/smarts_ros/scripts/ros_driver.py
@@ -695,6 +695,7 @@ class ROSDriver:
                     rospy.logerr(f"SMARTS raised exception:  {e}")
                     rospy.logerr(traceback.format_exc())
                     rospy.logerr("Will wait for next reset...")
+                    self._smarts.destroy()
                     self._smarts = None
                     self._reset_smarts()
                     self.setup_smarts()


### PR DESCRIPTION
This should cause `SMARTS` to be explicitly deleted on the ROS node.