### PR TITLE
Exclude lxml 5.0.0 due to python-dev requirement.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -85,6 +85,7 @@ gif_recorder =
 gymnasium =
     gymnasium>=0.26.3
 opendrive = 
+    lxml!=5.0.0
     opendrive2lanelet>=1.2.1
     Rtree>=0.9.7
 rllib = 


### PR DESCRIPTION
Fixes the CI. It appears that `lxml==5.0.0` has introduced a `python-dev` dependency.

```python
Collecting lxml>=4.3.4 (from opendrive2lanelet>=1.2.1->smarts==1.4.0)
  Downloading lxml-5.0.0.tar.gz (3.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.8/3.8 MB 247.2 MB/s eta 0:00:00
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [3 lines of output]
      Building lxml version 5.0.0.
      Building without Cython.
      Error: Please make sure the libxml2 and libxslt development packages are installed.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
Error: Process completed with exit code 1.
```