### PR TITLE
Improve sumo map query performance.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Deprecated a few things related to vehicles in the `Scenario` class, including the `vehicle_filepath`, `tire_parameters_filepath`, and `controller_parameters_filepath`. The functionality is now handled through the vehicle definitions.
 - `AgentInterface.vehicle_type` is now deprecated with potential to be restored.
 ### Fixed
+- The performance of SUMO roadmap queries using `SumoRoadNetwork.{nearest_lanes|nearest_lane}()` has been roughly doubled.
 - `SumoTrafficSimulation` gives clearer reasons as to why it failed to connect to the TraCI server.
 - Suppressed an issue where `pybullet_utils.pybullet.BulletClient` would cause an error because it was catching a non `BaseException` type.
 - Fixed a bug where `smarts.core.vehicle_index.VehicleIndex.attach_sensors_to_vehicle()` would pass a method instead of a `PlanFrame` to the generated vehicle `SensorState`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Deprecated a few things related to vehicles in the `Scenario` class, including the `vehicle_filepath`, `tire_parameters_filepath`, and `controller_parameters_filepath`. The functionality is now handled through the vehicle definitions.
 - `AgentInterface.vehicle_type` is now deprecated with potential to be restored.
 ### Fixed
-- The performance of SUMO roadmap queries using `SumoRoadNetwork.{nearest_lanes|nearest_lane|offset_along_lane}()` have been roughly doubled.
+- The performance of SUMO roadmap queries using `SumoRoadNetwork.{nearest_lanes|nearest_lane|offset_along_lane}()` have been greatly improved for long lanes.
 - `SumoTrafficSimulation` gives clearer reasons as to why it failed to connect to the TraCI server.
 - Suppressed an issue where `pybullet_utils.pybullet.BulletClient` would cause an error because it was catching a non `BaseException` type.
 - Fixed a bug where `smarts.core.vehicle_index.VehicleIndex.attach_sensors_to_vehicle()` would pass a method instead of a `PlanFrame` to the generated vehicle `SensorState`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Copy and pasting the git commit messages is __NOT__ enough.
 - Deprecated a few things related to vehicles in the `Scenario` class, including the `vehicle_filepath`, `tire_parameters_filepath`, and `controller_parameters_filepath`. The functionality is now handled through the vehicle definitions.
 - `AgentInterface.vehicle_type` is now deprecated with potential to be restored.
 ### Fixed
-- The performance of SUMO roadmap queries using `SumoRoadNetwork.{nearest_lanes|nearest_lane}()` has been roughly doubled.
+- The performance of SUMO roadmap queries using `SumoRoadNetwork.{nearest_lanes|nearest_lane|offset_along_lane}()` have been roughly doubled.
 - `SumoTrafficSimulation` gives clearer reasons as to why it failed to connect to the TraCI server.
 - Suppressed an issue where `pybullet_utils.pybullet.BulletClient` would cause an error because it was catching a non `BaseException` type.
 - Fixed a bug where `smarts.core.vehicle_index.VehicleIndex.attach_sensors_to_vehicle()` would pass a method instead of a `PlanFrame` to the generated vehicle `SensorState`.

--- a/smarts/core/local_traffic_provider.py
+++ b/smarts/core/local_traffic_provider.py
@@ -81,7 +81,6 @@ class LocalTrafficProvider(TrafficProvider):
 
     def __init__(self):
         self._logger = logging.getLogger(self.__class__.__name__)
-        self._logger.setLevel(logging.DEBUG)
         self._sim = None
         self._scenario = None
         self.road_map: RoadMap = None

--- a/smarts/core/local_traffic_provider.py
+++ b/smarts/core/local_traffic_provider.py
@@ -246,25 +246,20 @@ class LocalTrafficProvider(TrafficProvider):
             hhx, hhy = radians_to_vec(ovs.pose.heading) * (0.5 * length)
             back = Point(center.x - hhx, center.y - hhy)
             front = Point(center.x + hhx, center.y + hhy)
-            with timeit("backlane", self._logger.debug):
-                back_lane = self.road_map.nearest_lane(back, radius=length * 0.5)
-            with timeit("frontlane", self._logger.debug):
-                front_lane = self.road_map.nearest_lane(front, radius=length * 0.5)
-            with timeit("the rest", self._logger.debug):
-                if back_lane:
-                    back_offset = back_lane.offset_along_lane(back)
-                    lbc = self._lane_bumpers_cache.setdefault(back_lane, [])
-                    lbc.append((back_offset, ovs, 1))
-                if front_lane:
-                    front_offset = front_lane.offset_along_lane(front)
-                    lbc = self._lane_bumpers_cache.setdefault(front_lane, [])
-                    lbc.append((front_offset, ovs, 2))
-                if front_lane and back_lane != front_lane:
-                    # it's changing lanes, don't misjudge the target lane...
-                    fake_back_offset = front_lane.offset_along_lane(back)
-                    self._lane_bumpers_cache[front_lane].append(
-                        (fake_back_offset, ovs, 0)
-                    )
+            back_lane = self.road_map.nearest_lane(back, radius=length * 0.5)
+            front_lane = self.road_map.nearest_lane(front, radius=length * 0.5)
+            if back_lane:
+                back_offset = back_lane.offset_along_lane(back)
+                lbc = self._lane_bumpers_cache.setdefault(back_lane, [])
+                lbc.append((back_offset, ovs, 1))
+            if front_lane:
+                front_offset = front_lane.offset_along_lane(front)
+                lbc = self._lane_bumpers_cache.setdefault(front_lane, [])
+                lbc.append((front_offset, ovs, 2))
+            if front_lane and back_lane != front_lane:
+                # it's changing lanes, don't misjudge the target lane...
+                fake_back_offset = front_lane.offset_along_lane(back)
+                self._lane_bumpers_cache[front_lane].append((fake_back_offset, ovs, 0))
         for cache in self._lane_bumpers_cache.values():
             cache.sort()
 

--- a/smarts/core/local_traffic_provider.py
+++ b/smarts/core/local_traffic_provider.py
@@ -67,6 +67,7 @@ if TYPE_CHECKING:
 
 MAX_IMPATIENCE = 3.0
 
+
 def _safe_division(n: float, d: float, default=math.inf):
     """This method uses a short circuit form where `and` converts right side to true|false (as 1|0) in which cases are:
     True and # == #
@@ -254,7 +255,6 @@ class LocalTrafficProvider(TrafficProvider):
                     back_offset = back_lane.offset_along_lane(back)
                     lbc = self._lane_bumpers_cache.setdefault(back_lane, [])
                     lbc.append((back_offset, ovs, 1))
-                    # insort(lbc, (back_offset, ovs, 1))
                 if front_lane:
                     front_offset = front_lane.offset_along_lane(front)
                     lbc = self._lane_bumpers_cache.setdefault(front_lane, [])

--- a/smarts/core/sumo_road_network.py
+++ b/smarts/core/sumo_road_network.py
@@ -132,7 +132,9 @@ class SumoRoadNetwork(RoadMap):
         x = point[0]
         y = point[1]
         r = radius
-        edges: List[sumolib.net.edge.Edge] = self._graph.getEdges()
+        edges: List[sumolib.net.edge.Edge] = sorted(
+            self._graph.getEdges(), key=lambda e: e.getID()
+        )
         if self._rtree_roads is None:
             self._rtree_roads = self._init_rtree(edges)
         near_roads: List[RoadMap.Road] = []

--- a/smarts/core/sumo_road_network.py
+++ b/smarts/core/sumo_road_network.py
@@ -17,7 +17,11 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
+from __future__ import annotations
+
+import itertools
 import logging
+import math
 import os
 import random
 from functools import cached_property, lru_cache
@@ -30,6 +34,7 @@ from shapely.geometry import Point as shPoint
 from shapely.geometry import Polygon
 from shapely.ops import nearest_points, snap
 
+from smarts.core.utils.core_logging import timeit
 from smarts.sstudio.sstypes import MapSpec
 
 from .coordinates import BoundingBox, Heading, Point, Pose, RefLinePoint
@@ -41,7 +46,16 @@ from .utils.geometry import buffered_shape
 from .utils.glb import make_map_glb, make_road_line_glb
 
 from smarts.core.utils.sumo import sumolib  # isort:skip
-from sumolib.net.edge import Edge  # isort:skip
+
+
+def pairwise(iterable):
+    """Generates pairs of neighboring elements.
+    >>> list(pairwise('ABCDEFG'))
+    [(AB), (BC), (CD), (DE), (EF), (FG)]
+    """
+    a, b = itertools.tee(iterable)
+    next(b, None)
+    return zip(a, b)
 
 
 class SumoRoadNetwork(RoadMap):
@@ -53,18 +67,75 @@ class SumoRoadNetwork(RoadMap):
     This corresponds on a 1:1 scale to lanes 3.2m wide, which is typical
      in North America (although US highway lanes are wider at ~3.7m)."""
 
-    def __init__(self, graph, net_file: str, map_spec: MapSpec):
+    def __init__(self, graph: sumolib.net.Net, net_file: str, map_spec: MapSpec):
         self._log = logging.getLogger(self.__class__.__name__)
         self._graph = graph
         self._net_file = net_file
         self._map_spec = map_spec
         self._default_lane_width = SumoRoadNetwork._spec_lane_width(map_spec)
         self._surfaces = dict()
-        self._lanes = dict()
-        self._roads = dict()
+        self._lanes: Dict[str, SumoRoadNetwork.Lane] = dict()
+        self._roads: Dict[str, SumoRoadNetwork.Road] = dict()
         self._features = dict()
         self._waypoints_cache = SumoRoadNetwork._WaypointsCache()
         self._load_traffic_lights()
+        self._rtree_roads = None
+
+    def _init_rtree(self, shapeList: List[sumolib.net.edge.Edge], includeJunctions=True):
+        import rtree
+
+        result = rtree.index.Index()
+        result.interleaved = True
+        MAX_VAL = 1e100
+        for ri, shape in enumerate(shapeList):
+            sumo_lanes: List[sumolib.net.lane.Lane] = shape.getLanes()
+            lane_bbs = list(
+                lane.getBoundingBox(includeJunctions) for lane in sumo_lanes
+            )
+            cxmin, cymin, cxmax, cymax = MAX_VAL, MAX_VAL, -MAX_VAL, -MAX_VAL
+            for xmin, ymin, xmax, ymax in lane_bbs:
+                cxmin = min(cxmin, xmin)
+                cxmax = max(cxmax, xmax)
+                cymin = min(cymin, ymin)
+                cymax = max(cymax, ymax)
+
+            bb = (cxmin, cymin, cxmax, cymax)
+            result.add(ri, bb)
+        return result
+
+    def _update_rtree(
+        self, rtree_, shapeList: List[sumolib.net.edge.Edge], includeJunctions=True
+    ):
+        import rtree
+
+        rtree_: rtree.index.Index
+
+        for ri, shape in enumerate(shapeList):
+            sumo_lanes: List[sumolib.net.lane.Lane] = shape.getLanes()
+            lane_bbs = list(
+                lane.getBoundingBox(includeJunctions) for lane in sumo_lanes
+            )
+            cxmin, cymin, cxmax, cymax = 1e400, 1e400, -1e400, -1e400
+            for xmin, ymin, xmax, ymax in lane_bbs:
+                cxmin = min(cxmin, xmin)
+                cxmax = max(cxmax, xmax)
+                cymin = min(cymin, ymin)
+                cymax = max(cymax, ymax)
+
+            bb = (cxmin, cymin, cxmax, cymax)
+            rtree_.add(ri, bb)
+
+    def near_roads(self, point: Point, radius: float):
+        x = point[0]
+        y = point[1]
+        r = radius
+        edges: List[sumolib.net.edge.Edge] = self._graph.getEdges()
+        if self._rtree_roads is None:
+            self._rtree_roads = self._init_rtree(edges)
+        near_roads: List[SumoRoadNetwork.Road] = []
+        for i in self._rtree_roads.intersection((x - r, y - r, x + r, y + r)):
+            near_roads.append(self.road_by_id(edges[i].getID()))
+        return near_roads
 
     @staticmethod
     def _check_net_origin(bbox):
@@ -81,7 +152,7 @@ class SumoRoadNetwork(RoadMap):
 
     @classmethod
     @lru_cache(maxsize=1)
-    def _shift_coordinates(cls, net_file_path, shifted_path):
+    def _shift_coordinates(cls, net_file_path: str, shifted_path: str):
         assert shifted_path != net_file_path
         logger = logging.getLogger(cls.__name__)
         logger.info(f"normalizing net coordinates into {shifted_path}...")
@@ -310,19 +381,73 @@ class SumoRoadNetwork(RoadMap):
     class Lane(RoadMap.Lane, Surface):
         """Describes a Sumo lane surface."""
 
-        def __init__(self, lane_id: str, sumo_lane, road_map):
+        def __init__(self, lane_id: str, sumo_lane: sumolib.net.lane.Lane, road_map: SumoRoadNetwork):
             super().__init__(lane_id, road_map)
             self._lane_id = lane_id
             self._sumo_lane = sumo_lane
             self._road = road_map.road_by_id(sumo_lane.getEdge().getID())
             assert self._road
 
+            self._rtree_lane_fragments = None
+            self._lane_fragments: Optional[List[
+                Tuple[Tuple[float, float], Tuple[float, float]]
+            ]] = None
+
         def __hash__(self) -> int:
             return hash(self.lane_id) ^ hash(self._map)
 
-        @property
+        def _init_rtree(self, lines):
+            import rtree
+
+            rtree.index.Property()
+            result = rtree.index.Index()
+            result.interleaved = True
+            for ri, (s, e) in enumerate(lines):
+                result.add(
+                    ri,
+                    (
+                        min(e[0], s[0]),
+                        min(e[1], s[1]),
+                        max(e[0], s[0]),
+                        max(e[1], s[1]),
+                    ),
+                )
+            return result
+
+        def get_distance(self, point: Point, radius: float) -> float:
+            x = point[0]
+            y = point[1]
+            r = radius
+            if self._rtree_lane_fragments is None:
+                self._lane_fragments = list(pairwise(self._sumo_lane.getShape(False)))
+                self._rtree_lane_fragments = self._init_rtree(self._lane_fragments)
+
+            dist = math.inf
+            INVALID_DISTANCE = -1
+            for i in self._rtree_lane_fragments.intersection(
+                (x - r, y - r, x + r, y + r)
+            ):
+                d = sumolib.geomhelper.distancePointToLine(
+                    point,
+                    self._lane_fragments[i][0],
+                    self._lane_fragments[i][1],
+                    perpendicular=False,
+                )
+                if d == INVALID_DISTANCE and i != 0:
+                    # distance to inner corner
+                    dist = min(
+                        sumolib.geomhelper.distance(point, self._lane_fragments[i][0]),
+                        sumolib.geomhelper.distance(point, self._lane_fragments[i][1]),
+                    )
+                if d != INVALID_DISTANCE:
+                    if dist is None or d < dist:
+                        dist = d
+            return dist
+
+        @cached_property
         def bounding_box(self):
-            raise NotImplementedError()
+            xmin, ymin, xmax, ymax = self._sumo_lane.getBoundingBox(False)
+            return BoundingBox(Point(xmin, ymin), Point(xmax, ymax))
 
         @property
         def lane_id(self) -> str:
@@ -645,7 +770,12 @@ class SumoRoadNetwork(RoadMap):
         """This is akin to a 'road segment' in real life.
         Many of these might correspond to a single named road in reality."""
 
-        def __init__(self, road_id: str, sumo_edge: Edge, road_map):
+        def __init__(
+            self,
+            road_id: str,
+            sumo_edge: sumolib.net.edge.Edge,
+            road_map: SumoRoadNetwork,
+        ):
             super().__init__(road_id, road_map)
             self._road_id = road_id
             self._sumo_edge = sumo_edge
@@ -781,6 +911,8 @@ class SumoRoadNetwork(RoadMap):
         ), f"SumoRoadNetwork got request for unknown road_id: '{road_id}'"
         road = SumoRoadNetwork.Road(road_id, sumo_edge, self)
         self._roads[road_id] = road
+        if self._rtree_roads is not None:
+            self._update_rtree(self._rtree_roads, [road._sumo_edge], False)
         assert road_id not in self._surfaces
         self._surfaces[road_id] = road
         return road
@@ -797,22 +929,30 @@ class SumoRoadNetwork(RoadMap):
     ) -> List[Tuple[RoadMap.Lane, float]]:
         if radius is None:
             radius = self._default_lane_width
-        # XXX: note that this getNeighboringLanes() call is fairly heavy/expensive (as revealed by profiling)
-        # The includeJunctions parameter is the opposite of include_junctions because
-        # what it does in the Sumo query is attach the "node" that is the junction (node)
-        # shape to the shape of the non-special lanes that connect to it.  So if
-        # includeJunctions is True, we are more likely to hit "normal" lanes
-        # even when in an intersection where we want to hit "special"
-        # lanes when we specify include_junctions=True.  Note that "special"
-        # lanes are always candidates to be returned, no matter what.
-        # See:  https://github.com/eclipse/sumo/issues/5854
-        candidate_lanes = self._graph.getNeighboringLanes(
-            point[0],
-            point[1],
-            r=radius,
-            includeJunctions=not include_junctions,
-            allowFallback=False,  # makes this call fail if rtree is not installed
-        )
+        # # XXX: note that this getNeighboringLanes() call is fairly heavy/expensive (as revealed by profiling)
+        # # The includeJunctions parameter is the opposite of include_junctions because
+        # # what it does in the Sumo query is attach the "node" that is the junction (node)
+        # # shape to the shape of the non-special lanes that connect to it.  So if
+        # # includeJunctions is True, we are more likely to hit "normal" lanes
+        # # even when in an intersection where we want to hit "special"
+        # # lanes when we specify include_junctions=True.  Note that "special"
+        # # lanes are always candidates to be returned, no matter what.
+        # # See:  https://github.com/eclipse/sumo/issues/5854
+        # with timeit("Old sumo lane distance check", print):
+        #     candidate_lanes = self._graph.getNeighboringLanes(
+        #         point[0],
+        #         point[1],
+        #         r=radius,
+        #         includeJunctions=not include_junctions,
+        #         allowFallback=False,  # makes this call fail if rtree is not installed
+        #     )
+        candidate_lanes = []
+        for r in self.near_roads(point, radius):
+            for l in r.lanes:
+                l: SumoRoadNetwork.Lane
+                if (distance := l.get_distance(point, radius)) < math.inf:
+                    candidate_lanes.append((l._sumo_lane, distance))
+
         if not include_junctions:
             candidate_lanes = [
                 lane for lane in candidate_lanes if not lane[0].getEdge().isSpecial()
@@ -910,8 +1050,8 @@ class SumoRoadNetwork(RoadMap):
         ]
 
     def _internal_routes_between(
-        self, start_edge: Edge, end_edge: Edge
-    ) -> List[List[Edge]]:
+        self, start_edge: sumolib.net.edge.Edge, end_edge: sumolib.net.edge.Edge
+    ) -> List[List[sumolib.net.edge.Edge]]:
         if start_edge.isSpecial() or end_edge.isSpecial():
             return [[start_edge, end_edge]]
         routes = []

--- a/smarts/core/sumo_road_network.py
+++ b/smarts/core/sumo_road_network.py
@@ -111,13 +111,13 @@ class SumoRoadNetwork(RoadMap):
         import rtree
 
         rtree_: rtree.index.Index
-
+        MAX_VAL = 1e100
         for ri, shape in enumerate(shapeList):
             sumo_lanes: List[sumolib.net.lane.Lane] = shape.getLanes()
             lane_bbs = list(
                 lane.getBoundingBox(includeJunctions) for lane in sumo_lanes
             )
-            cxmin, cymin, cxmax, cymax = 1e400, 1e400, -1e400, -1e400
+            cxmin, cymin, cxmax, cymax = MAX_VAL, MAX_VAL, -MAX_VAL, -MAX_VAL
             for xmin, ymin, xmax, ymax in lane_bbs:
                 cxmin = min(cxmin, xmin)
                 cxmax = max(cxmax, xmax)

--- a/smarts/core/sumo_road_network.py
+++ b/smarts/core/sumo_road_network.py
@@ -78,8 +78,8 @@ class SumoRoadNetwork(RoadMap):
         self._roads: Dict[str, SumoRoadNetwork.Road] = dict()
         self._features = dict()
         self._waypoints_cache = SumoRoadNetwork._WaypointsCache()
-        self._load_traffic_lights()
         self._rtree_roads = None
+        self._load_traffic_lights()
 
     def _init_rtree(
         self, shapeList: List[sumolib.net.edge.Edge], includeJunctions=True

--- a/smarts/core/sumo_road_network.py
+++ b/smarts/core/sumo_road_network.py
@@ -51,7 +51,7 @@ from smarts.core.utils.sumo import sumolib  # isort:skip
 def pairwise(iterable):
     """Generates pairs of neighboring elements.
     >>> list(pairwise('ABCDEFG'))
-    [(AB), (BC), (CD), (DE), (EF), (FG)]
+    [('A','B'), ('B','C'), ('C','D'), ('D','E'), ('E','F'), ('F','G')]
     """
     a, b = itertools.tee(iterable)
     next(b, None)
@@ -135,7 +135,7 @@ class SumoRoadNetwork(RoadMap):
         edges: List[sumolib.net.edge.Edge] = self._graph.getEdges()
         if self._rtree_roads is None:
             self._rtree_roads = self._init_rtree(edges)
-        near_roads: List[SumoRoadNetwork.Road] = []
+        near_roads: List[RoadMap.Road] = []
         for i in self._rtree_roads.intersection((x - r, y - r, x + r, y + r)):
             near_roads.append(self.road_by_id(edges[i].getID()))
         return near_roads
@@ -458,12 +458,12 @@ class SumoRoadNetwork(RoadMap):
         @overload
         def get_distance(
             self, point: Point, radius: float, get_offset: bool
-        ) -> Tuple[float, float]:
+        ) -> Tuple[float, Optional[float]]:
             ...
 
         def get_distance(
             self, point: Point, radius: float, get_offset=...
-        ) -> Union[float, Tuple[float, float]]:
+        ) -> Union[float, Tuple[float, Optional[float]]]:
             """Get the distance on the lane from the given point within the given radius.
             Specifying to get the offset returns the offset value.
             """
@@ -969,7 +969,7 @@ class SumoRoadNetwork(RoadMap):
             bline = buffered_shape(line, 0.0)
             return line if bline.is_empty else bline
 
-    def road_by_id(self, road_id: str) -> RoadMap.Road:
+    def road_by_id(self, road_id: str) -> SumoRoadNetwork.Road:
         road = self._roads.get(road_id)
         if road:
             return road

--- a/smarts/core/sumo_road_network.py
+++ b/smarts/core/sumo_road_network.py
@@ -453,7 +453,7 @@ class SumoRoadNetwork(RoadMap):
         @overload
         def get_distance(
             self, point: Point, radius: float, *, perpendicular: bool
-        ) -> Tuple[float, Optional[float]]:
+        ) -> float:
             ...
 
         @overload
@@ -518,6 +518,7 @@ class SumoRoadNetwork(RoadMap):
                         self._lane_shape_for_rtree[found_index + 1],
                         False,
                     )
+                    assert isinstance(offset, float)
                 return dist, offset
             return dist
 

--- a/smarts/env/tests/test_determinism.py
+++ b/smarts/env/tests/test_determinism.py
@@ -139,8 +139,8 @@ def test_short_determinism():
 
 def test_long_determinism():
     max_steps_per_episode = 55000
-    episode_count = 1
-    capture_step = 3750
+    episode_count = 10
+    capture_step = 100
     scenarios = "scenarios/sumo/intersections/2lane"
     determinism(
         agent_spec(max_steps_per_episode), scenarios, episode_count, capture_step

--- a/smarts/env/tests/test_determinism.py
+++ b/smarts/env/tests/test_determinism.py
@@ -140,7 +140,7 @@ def test_short_determinism():
 def test_long_determinism():
     max_steps_per_episode = 55000
     episode_count = 1
-    capture_step = 13750
+    capture_step = 3750
     scenarios = "scenarios/sumo/intersections/2lane"
     determinism(
         agent_spec(max_steps_per_episode), scenarios, episode_count, capture_step


### PR DESCRIPTION
This improves the performance of SUMO roadmap calls (at the cost of some additional memory). Lane distance related calls are taking a high toll on simulation.

- [x] Improve performance of `{nearest_lanes|nearest_lane}()`
- [x] Improve performance of `offset_along_lane()`
- [x] Plan generalized query caching.