### PR TITLE
Stop scheduled execution of CI tests

### DIFF
--- a/.github/workflows/ci-base-tests-mac.yml
+++ b/.github/workflows/ci-base-tests-mac.yml
@@ -1,10 +1,10 @@
 name: SMARTS CI Base Tests Mac
 
 on:
-  workflow_run:
-    workflows: ["SMARTS CI Auto Commit Mac"]
-    types:
-      - completed
+  # workflow_run:
+  #   workflows: ["SMARTS CI Auto Commit Mac"]
+  #   types:
+  #     - completed
   workflow_dispatch:
 
 env:

--- a/.github/workflows/ci-test-learning.yml
+++ b/.github/workflows/ci-test-learning.yml
@@ -1,8 +1,8 @@
 name: SMARTS CI Learning
 
 on:
-  schedule:
-    - cron: "0 23 * * 2"
+  # schedule:
+  #   - cron: "0 23 * * 2"
       # Time is in UTC
       # Runs at 11.00pm, UTC  , every Tuesday
       # Runs at  7.00pm, UTC-4, every Tuesday

--- a/.github/workflows/ci-test-long-determinism.yml
+++ b/.github/workflows/ci-test-long-determinism.yml
@@ -1,8 +1,8 @@
 name: SMARTS CI Long Determinism
 
 on:
-  schedule:
-    - cron: "0 23 * * 6"
+  # schedule:
+  #   - cron: "0 23 * * 6"
       # Time is in UTC
       # Runs at 11.00pm, UTC  , every Saturday
       # Runs at  7.00pm, UTC-4, every Saturday

--- a/.github/workflows/ci-test-memory-growth.yml
+++ b/.github/workflows/ci-test-memory-growth.yml
@@ -1,8 +1,8 @@
 name: SMARTS CI Memory
 
 on:
-  schedule:
-    - cron: "0 23 * * 4"
+  # schedule:
+  #   - cron: "0 23 * * 4"
       # Time is in UTC
       # Runs at 11.00pm, UTC  , every Thursday
       # Runs at  7.00pm, UTC-4, every Thursday


### PR DESCRIPTION
Stop scheduled execution of the following CI tests which were failing
- ci-base-tests-mac
- ci-test-learning
- ci-test-long-determinism
- ci-test-memory-growth