### PR TITLE
Fix numpy.core deprecation for NumPy 2.x compatibility

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,8 +22,8 @@ python_requires = >=3.8
 install_requires = 
     setuptools>=41.0.0,!=50.0
     click>=7.1.2  # used in scl
-    # numpy>=1.19.5 required for tf 2.4
-    numpy>=1.19.5
+    # numpy>=1.19.5 required for tf 2.4, <2.0.0 for numpy.core compatibility
+    numpy>=1.19.5,<2.0.0
     psutil>=5.4.8
     shapely>=2.0.0
     tableprint>=0.9.1


### PR DESCRIPTION
## Summary
- Cap `numpy` version to `<2.0.0` in `setup.cfg` to prevent `ImportError` on newer NumPy versions
- NumPy 2.0 renamed `numpy.core` to `numpy._core`, breaking dependencies like `pybullet` that reference `numpy.core.multiarray`
- Without this cap, `pip install` can resolve to NumPy 2.x, causing runtime failures

## Test plan
- Install SMARTS with the updated dependency constraint
- Verify `numpy.core.multiarray` imports succeed (NumPy 1.x is installed)
- Verify sanity test passes on Python 3.10+

Fixes #2162