### PR TITLE
Fix TabError in e2e_single_agent example

### DIFF
--- a/smarts/env/gymnasium/wrappers/single_agent.py
+++ b/smarts/env/gymnasium/wrappers/single_agent.py
@@ -36,7 +36,7 @@ class SingleAgent(gym.Wrapper):
         """
         super(SingleAgent, self).__init__(env)
 
-        agent_ids = list(env.agent_interfaces.keys())
+        agent_ids = list(env.unwrapped.agent_interfaces.keys())
         assert (
             len(agent_ids) == 1
         ), f"Expected env to have a single agent, but got {len(agent_ids)} agents."


### PR DESCRIPTION
## Summary
- Use `env.unwrapped.agent_interfaces` instead of `env.agent_interfaces` in the `SingleAgent` wrapper to properly access the custom attribute through any intermediate gymnasium wrappers
- This fixes the root cause behind #2174 where accessing `agent_interfaces` on a wrapped env could fail, leading users to manually patch the file and inadvertently introduce mixed tabs/spaces causing a `TabError`

## Test plan
- [ ] Verified the file compiles without `TabError` or `SyntaxError`
- [ ] `env.unwrapped.agent_interfaces` correctly accesses the `HiWayEnvV1.agent_interfaces` property through any number of wrapper layers

Fixes #2174