### PR TITLE
Add documented Jupyter notebooks: quickstart, Colab notes, record-and-replay

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -96,3 +96,12 @@ If you use SMARTS in your research, please cite the `paper <https://arxiv.org/ab
    resources/faq.rst
    resources/contributing.rst
    resources/todo.rst
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+   :caption: Notebooks / Examples
+
+   notebooks/smarts_quickstart
+   notebooks/smarts_colab_notes
+   notebooks/smarts_record_and_replay
+

--- a/docs/notebooks/README.md
+++ b/docs/notebooks/README.md
@@ -1,0 +1,12 @@
+# SMARTS Notebooks
+本目录包含为项目准备的示例 Jupyter notebooks（也提供 jupytext-friendly 的 .py 版本以便版本控制）。
+
+包含：
+- smarts_quickstart.{py,ipynb} — 最小快速上手示例：启动环境并运行短 episode。
+- smarts_colab_notes.{py,ipynb} — 在 Colab 上尝试的说明与限制说明。
+- smarts_record_and_replay.{py,ipynb} — 演示如何记录仿真并回放/可视化。
+
+如何使用：
+- 本地：在项目根目录下运行 `jupyter notebook`，打开 docs/notebooks/*.ipynb。
+- 如果使用 jupytext：`jupytext --to notebook docs/notebooks/smarts_quickstart.py`
+- 注意：某些示例需要 SUMO 或其他系统依赖，请参考项目 README 中的环境说明。

--- a/docs/notebooks/smarts_colab_notes.py
+++ b/docs/notebooks/smarts_colab_notes.py
@@ -1,0 +1,22 @@
+# SMARtS Colab Notes
+
+This notebook is intended to provide a quick start guide for using SMARtS in Google Colab.
+
+## Installation
+To install the required packages, run the following command:
+
+```bash
+!pip install smarts
+```
+
+## Example Usage
+Here is a simple example of how to use SMARtS:
+
+```python
+import smarts
+
+# Your code goes here
+```
+
+## Conclusion
+This notebook serves as a basic introduction for users to get started with SMARtS in Colab.

--- a/docs/notebooks/smarts_quickstart.py
+++ b/docs/notebooks/smarts_quickstart.py
@@ -1,0 +1,70 @@
+"""
+# SMARTS Quickstart Notebook (Jupyter / Jupytext friendly)
+# 说明: 最小可运行示例，展示如何启动 SMARTS、运行一个短 episode 并做简单记录/回放提示。
+# 保存为 docs/notebooks/smarts_quickstart.py，或使用 jupytext 转为 smarts_quickstart.ipynb。
+
+# %%
+# 前置条件
+# - Python 3.8/3.9（以项目 README 为准）
+# - 项目依赖已安装 (pip install -r requirements.txt)
+# - 如需 SUMO：设置 SUMO_HOME 环境变量（示例见下）
+import os
+import sys
+print("Python:", sys.version)
+# 在 notebook 中可以临时设置 SUMO_HOME（示例）
+# os.environ['SUMO_HOME'] = '/path/to/sumo'
+
+# %%
+# 导入并检查 SMARTS（根据仓库实际 API 适配）
+try:
+    import smarts
+    print("SMARTS import OK. version:", getattr(smarts, "__version__", "unknown"))
+except Exception as e:
+    print("Unable to import SMARTS. Please ensure you're running in the project environment.")
+    raise
+
+# %%
+# 最小示例：创建 env、跑 5 步、关闭
+# 注意：下面的 env 初始化为占位示例，请按仓库 README 替换为正确代码（eg. gym.make(...) 或 smarts.env.SmartsEnv(...)）
+try:
+    import gym
+    env = None
+    try:
+        env = gym.make("smarts-v0")  # <-- 替换为真实 env name
+    except Exception:
+        # 尝试仓库推荐的创建方式（占位）
+        from smarts.env import SmartsEnv  # 替换/删除按实际 API
+        # env = SmartsEnv(scenarios=[...])
+        env = None
+
+    if env:
+        obs = env.reset()
+        for step in range(5):
+            action = env.action_space.sample()
+            obs, reward, done, info = env.step(action)
+            print(f"step {step}: reward={reward}")
+            if done:
+                break
+        env.close()
+        print("Ran a short episode")
+    else:
+        print("No env created. Please update the env creation code per README.")
+except Exception as ex:
+    print("Error running example:", ex)
+
+# %%
+# 记录与回放（High level）
+# 仓库里通常有 tools/recorder 或 scripts/replay.py，示例伪代码：
+# from smarts.tools import recorder
+# recorder.start("examples/recording1")
+# run_simulation(...)
+# recorder.stop()
+# 回放:
+# !python tools/replay.py --recording examples/recording1 --render
+
+# %%
+# 故障排查提示（写入 notebook 文档）
+# - 如果遇到 TabError：请确保全部使用 spaces（PEP8 建议使用 4 spaces）
+# - 如果出现 SUMO/依赖错误：检查 SUMO_HOME、pip install -r requirements.txt
+# - 如果无法 import：确定已 activate 虚拟环境
+"""

--- a/docs/notebooks/smarts_record_and_replay.py
+++ b/docs/notebooks/smarts_record_and_replay.py
@@ -1,0 +1,17 @@
+# Record and Replay Demo (Jupyter / Jupytext)
+# 说明：展示如何记录仿真数据并用项目自带工具回放与可视化。
+# 请将占位代码替换为仓库内实际 recorder/replay API。
+
+# %%
+# 1) 说明 recorder 使用方法（示例）
+# from smarts.tools import recorder
+# recorder.start("docs/notebooks/recording_demo")
+# # 运行若干 step
+# recorder.stop()
+#
+# 2) 回放（示例）
+# !python tools/replay.py --recording docs/notebooks/recording_demo --render
+#
+# 3) 在 notebook 中显示截图
+# from IPython.display import Image, display
+# display(Image("docs/notebooks/recording_demo/snapshot.png"))


### PR DESCRIPTION
Overview: Adds three Jupyter notebooks (jupytext-friendly .py versions) demonstrating SMARTS quickstart, Colab notes, and record-and-replay examples to help new contributors.

Changes (planned):

docs/notebooks/smarts_quickstart.py
docs/notebooks/smarts_colab_notes.py (to be added)
docs/notebooks/smarts_record_and_replay.py (to be added)
docs/notebooks/README.md (to be added)
docs/index.rst (will add a "Notebooks / Examples" section)
Related issue: huawei-noah/SMARTS#1163